### PR TITLE
Add Cloudflare Email as a config-selected provider

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,13 +1,19 @@
 # Copy this file to .dev.vars and fill in real values.
 # .dev.vars is gitignored — never commit it.
 #
-# In production these live as Worker secrets instead:
-#   wrangler secret put RESEND_API_KEY
-#   wrangler secret put RESEND_WEBHOOK_SECRET
+# In production these live as Worker secrets / vars instead.
 
+# resend (default) or cloudflare
+EMAIL_PROVIDER=resend
+
+# --- Resend (EMAIL_PROVIDER=resend) ---
 # From https://resend.com/api-keys — needs full access (send + domains + receiving).
 RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # Shown once when you create the webhook at https://resend.com/webhooks
-# (see step 4 of the README). Starts with whsec_.
+# (see the README). Starts with whsec_.
 RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# --- Cloudflare Email (EMAIL_PROVIDER=cloudflare) ---
+# Comma-separated domains already onboarded in Email Service / Email Routing.
+# CLOUDFLARE_MAIL_DOMAINS=example.com,mail.example.com

--- a/README.md
+++ b/README.md
@@ -1,69 +1,55 @@
 # QuickMail
 
-Your own web mail client, running on your own domain, on Cloudflare's edge.
-Send and receive real email from `you@yourdomain.com` — inbox, threads,
-attachments, rich-text composer, multiple domains, multiple users.
+A web mail client for your own domain, on Cloudflare's edge. Inbox, threads,
+attachments, a rich-text composer, multiple domains, and multiple users —
+`you@yourdomain.com`, no third-party mailbox.
 
-Deploys to Cloudflare Workers. Costs pennies to run.
+Deploys to Cloudflare Workers.
 
 > **MIT licensed.** Use it, modify it, ship it — commercially or not. See
 > [LICENSE.md](LICENSE.md).
 
-## What's in it
+## What you get
 
-- **Real inbound mail** — MX records point at Resend, which forwards to your
-  Worker. Nothing is polled.
-- **Threaded conversations** — replies group into conversations, quoted history
-  collapses.
-- **Attachments** — inbound files stream into R2; outbound files upload from the
-  composer.
-- **Safe HTML rendering** — received HTML renders in a sandboxed iframe, so a
-  hostile email can't touch your session.
-- **Multiple domains** — connect every domain your Resend key can reach and filter
-  between them, or view them combined.
-- **Multiple users** — each has their own addresses across domains and a default
-  sending identity. Admins get a catch-all and an unrouted-mail view.
-- **Delivery status** — sent mail shows delivered / bounced / complained, live from
-  webhooks.
+- **Real mail in and out** — nothing is polled. The provider delivers into the Worker.
+- **Threads** — replies group into conversations; quoted history collapses.
+- **Attachments** — inbound files land in R2; outbound files upload from the composer.
+- **Safe HTML** — received HTML renders in a sandboxed iframe.
+- **Multiple domains and users** — each user has addresses and a default sending identity. Admins get a catch-all and an unrouted-mail view.
+- **Delivery status** — Resend reports delivered / bounced / complained over webhooks. Cloudflare marks a send `sent` once the binding accepts it.
 - **Light and dark themes.**
 
-## Stack
+---
 
-| Layer | Choice |
-|---|---|
-| Framework | SvelteKit 2 + Svelte 5 (runes) |
-| Styling | Tailwind CSS 4 |
-| Runtime | Cloudflare Workers (`fetch` handler only) |
-| Database | D1 |
-| File storage | R2 |
-| Email in/out | Resend |
-| Auth | Session cookies, PBKDF2 password hashing, no third-party auth service |
+# Choose a mail provider
 
-No paid dependencies beyond Resend and Cloudflare, both of which have usable free
-tiers.
+One provider is active per deploy. Set `EMAIL_PROVIDER` to `resend` (default) or
+`cloudflare`. Do not point the same domain's apex MX at both.
 
-## How it works
+| | [Resend](https://resend.com) | [Cloudflare Email Service](https://developers.cloudflare.com/email-service/) |
+|---|---|---|
+| Outbound | `POST https://api.resend.com/emails` | Workers `env.EMAIL.send()` |
+| Inbound | Webhook → `/api/webhooks/resend` | Worker `email()` handler |
+| DNS | Records Resend gives you (any DNS host) | **Cloudflare DNS required** |
+| Cost | Resend free tier + Cloudflare | Email Sending needs a **Workers paid** plan. Routing is free. |
+| Delivery events | Webhooks (`delivered`, `bounced`, …) | Accepted send is stored as `sent` |
+| Best if | You already use Resend, or the domain is not on Cloudflare DNS | The zone is already on Cloudflare and you want mail on the same account |
 
-| Concern | How |
-|---|---|
-| Outbound | `POST https://api.resend.com/emails` with an `Idempotency-Key` |
-| Inbound | Resend webhook → `POST /api/webhooks/resend` (`email.received`) |
-| Delivery status | Same webhook (`email.delivered`, `email.bounced`, …) updates the Sent list |
-| Webhook auth | Standard Webhooks / Svix HMAC-SHA256 over the raw body |
-| Storage | D1 (users, addresses, domains, mail) + R2 (attachments) |
-
-Webhook payloads carry **metadata only**, so on `email.received` the app fetches
-`GET /emails/receiving/{id}` for the body and
-`GET /emails/receiving/{id}/attachments` for the files, then streams each
-`download_url` into R2.
+Resend webhooks carry **metadata only**. On `email.received` the app fetches the
+body and attachments from Resend. Cloudflare delivers the full MIME on
+`message.raw` — no second HTTP fetch.
 
 ---
 
 # Setup
 
-You need: a domain you control, a [Cloudflare](https://dash.cloudflare.com) account,
-and a [Resend](https://resend.com) account. Budget about 30 minutes, most of it
-waiting for DNS.
+Budget about 30 minutes. Most of it is DNS.
+
+**You need**
+
+1. A domain you control.
+2. A [Cloudflare](https://dash.cloudflare.com) account.
+3. Either a [Resend](https://resend.com) account, **or** the domain on Cloudflare DNS plus a Workers paid plan (Cloudflare Email Sending).
 
 ## 1. Install
 
@@ -72,67 +58,75 @@ bun install          # or: npm install
 bunx wrangler login
 ```
 
-## 2. Verify your domain in Resend
+Use **Wrangler 4.123 or newer** for Cloudflare Email Sending. `4.96` calls an
+old `/email/sending/enable` path and gets a 404. Check with
+`bunx wrangler --version`. Upgrade with `bun add -d wrangler@latest`.
 
-In the Resend dashboard, **Domains → Add Domain**. Resend gives you a set of DNS
-records — add them at your DNS provider and wait for verification.
-
-You need all of these:
-
-| Record | Purpose |
-|---|---|
-| `TXT` on `resend._domainkey` | DKIM signing |
-| `TXT` + `MX` on `send` | SPF and bounce handling |
-| **`MX` on the apex** | **Receiving — without this, no mail ever arrives** |
-
-Add a DMARC policy too, on `_dmarc`:
-
-```txt
-v=DMARC1; p=none; rua=mailto:you@yourdomain.com; pct=100; adkim=s; aspf=s
-```
-
-Start at `p=none` while testing, then tighten to `p=quarantine`.
-
-Enable **both sending and receiving** for the domain in Resend. Then create an API
-key (**API Keys → Create**) with full access.
-
-## 3. Create the Cloudflare resources
+## 2. Create D1 and R2
 
 ```bash
 bunx wrangler d1 create quickmail
 bunx wrangler r2 bucket create quickmail-attachments
 ```
 
-The `d1 create` command prints a `database_id`. Open `wrangler.jsonc` and replace
+`d1 create` prints a `database_id`. Open `wrangler.jsonc` and replace
 `REPLACE_WITH_YOUR_D1_DATABASE_ID` with it.
 
-While you're in `wrangler.jsonc`, set `"name"` to whatever you want your Worker
-called. To serve from your own domain, uncomment the `routes` block and set the
-pattern — the zone must be on the same Cloudflare account.
-
-Then run the migrations and set the API key:
+Set `"name"` to whatever you want the Worker called. To serve from your own
+hostname, uncomment the `routes` block — that zone must be on the same account.
 
 ```bash
 bun run db:migrate:remote
-bunx wrangler secret put RESEND_API_KEY     # paste your re_... key
 ```
 
-## 4. Deploy, then wire the webhook
+Then follow **exactly one** provider track.
 
-The webhook endpoint has to be publicly reachable, so deploy first:
+---
+
+## Track A — Resend
+
+`EMAIL_PROVIDER` can be omitted or set to `resend`.
+
+### A1. Verify the domain
+
+In Resend: **Domains → Add Domain**. Add every record they show, including the
+apex `MX`. Without that MX, mail never arrives.
+
+| Record | Purpose |
+|---|---|
+| `TXT` on `resend._domainkey` | DKIM |
+| `TXT` + `MX` on `send` | SPF and bounces |
+| **`MX` on the apex** | **Receiving** |
+
+Add DMARC on `_dmarc` while you test:
+
+```txt
+v=DMARC1; p=none; rua=mailto:you@yourdomain.com; pct=100; adkim=s; aspf=s
+```
+
+Start at `p=none`, then tighten to `p=quarantine`. Enable **sending and
+receiving** on the domain. Create an API key with full access (send + domains +
+receiving).
+
+```bash
+bunx wrangler secret put RESEND_API_KEY     # paste the re_... key
+```
+
+### A2. Deploy, then create the webhook
+
+The webhook URL has to be public, so deploy first:
 
 ```bash
 bun run deploy
 ```
 
-Note the URL it prints. Now create the webhook — Resend dashboard →
-[resend.com/webhooks](https://resend.com/webhooks) → **Add Webhook**:
+Resend dashboard → [Webhooks](https://resend.com/webhooks) → **Add Webhook**:
 
 - **URL** — `https://<your-worker-url>/api/webhooks/resend`
 - **Events** — `email.received`, `email.sent`, `email.delivered`, `email.bounced`,
   `email.complained`, `email.delivery_delayed`, `email.failed`
 
-Or from the terminal:
+Or:
 
 ```bash
 curl -X POST https://api.resend.com/webhooks \
@@ -142,51 +136,142 @@ curl -X POST https://api.resend.com/webhooks \
        "events":["email.received","email.sent","email.delivered","email.bounced","email.complained","email.delivery_delayed","email.failed"]}'
 ```
 
-The response contains `signing_secret` — **shown once**. Save it:
+The response contains `signing_secret` — **shown once**. Save it and redeploy:
 
 ```bash
 bunx wrangler secret put RESEND_WEBHOOK_SECRET   # the whsec_... value
-bun run deploy                                   # redeploy so it picks up both secrets
+bun run deploy
 ```
 
-## 5. First run
+Jump to [First run](#first-run).
 
-1. Open your deployed URL. `/setup` asks you to create the admin account — name,
-   login email, password.
-2. `/onboarding` lists every domain your Resend key can reach, with verification
-   status. Pick the ones you want.
-3. Claim your address (`you@yourdomain.com`).
+---
 
-Send yourself an email from another account. It should land in the inbox within a
-few seconds.
+## Track B — Cloudflare Email Service
+
+Uses the [Email Service](https://developers.cloudflare.com/email-service/)
+Workers binding (`env.EMAIL.send()`) plus Email Routing. The zone must use
+**Cloudflare DNS**.
+
+### B1. Enable sending and routing
+
+Dashboard (reliable):
+
+1. [Email Sending](https://dash.cloudflare.com/?to=/:account/email-service/sending) → **Onboard Domain** → your zone. Cloudflare adds `cf-bounce` MX/SPF/DKIM and `_dmarc`.
+2. [Email Routing](https://dash.cloudflare.com/?to=/:account/email-service/routing) → **Onboard Domain** on the same zone. Apex MX must point at Cloudflare (`route1.mx.cloudflare.net`, …).
+
+CLI (Wrangler **≥ 4.123**):
+
+```bash
+bunx wrangler email sending enable yourdomain.com
+bunx wrangler email routing enable yourdomain.com
+```
+
+Confirm:
+
+```bash
+bunx wrangler email sending list
+bunx wrangler email routing settings yourdomain.com
+bunx wrangler email sending dns get yourdomain.com
+bunx wrangler email routing dns get yourdomain.com
+```
+
+Sending should show `enabled: yes`. Routing should show `Enabled: true` and
+`Status: ready`.
+
+### B2. Send all inbound mail to this Worker
+
+QuickMail lets users create arbitrary mailboxes (`you@`, `billing@`). Email
+Routing only has 200 named rules and does not know about D1, so you need a
+**catch-all → Worker**.
+
+The Wrangler catch-all update only accepts `forward` or `drop`. Set the Worker
+action in the dashboard:
+
+1. Open [Email Routing](https://dash.cloudflare.com/?to=/:account/email-service/routing) for the domain.
+2. Enable **Catch-all**.
+3. Action: **Send to a Worker**.
+4. Worker: this app (`quickmail`, or whatever `"name"` is in `wrangler.jsonc`).
+5. Save.
+
+The dashboard may require one verified personal destination before rules can be
+saved. Verify it if asked — do **not** forward production mail there.
+
+A named rule (local-part `you` → Worker) also works for a single address, but
+catch-all is what makes “add an address in Settings” work.
+
+### B3. Point the Worker at Cloudflare Email
+
+In `wrangler.jsonc`:
+
+```jsonc
+"vars": {
+  "EMAIL_PROVIDER": "cloudflare",
+  "CLOUDFLARE_MAIL_DOMAINS": "yourdomain.com"
+}
+```
+
+Comma-separate more domains if you onboard several:
+`yourdomain.com,mail.example.com`.
+
+Locally, put the same keys in `.dev.vars` (copy `.dev.vars.example`). `.dev.vars`
+overrides `wrangler.jsonc` vars in `vite dev`.
+
+```bash
+bun run deploy
+```
+
+No Resend key or webhook is used on this track. `vite dev` never runs the
+`email()` handler — inbound only works on a **deployed** Worker or
+`bun run preview`.
+
+---
+
+## First run
+
+1. Open the deployed URL (or `http://localhost:5173` after `bun run dev`).
+2. `/setup` — pick a domain the provider can see, then create the admin (name,
+   local-part, password). That address is both the inbox and the login.
+3. Later users go through `/onboarding` to claim an address on a connected domain.
+
+Send yourself a message from another account. It should land within a few
+seconds (Resend webhook or Cloudflare Routing → Worker).
 
 ---
 
 # Development
 
 ```bash
-cp .dev.vars.example .dev.vars    # then fill in the two values
+cp .dev.vars.example .dev.vars    # fill in the provider you are using
 bun install
 bun run db:migrate:local
 bun run dev                       # D1 and R2 via platformProxy, secrets from .dev.vars
 ```
 
-Other commands:
-
 ```bash
-bun run preview   # production build, served by wrangler dev
+bun run preview   # production build + wrangler dev (needed for Cloudflare inbound)
 bun run check     # svelte-check
-bun run deploy    # build and ship
+bun run deploy    # build, wrap the Worker with email(), ship
 ```
 
-Webhooks can't reach `localhost`. To test inbound mail locally, tunnel it:
+`bun run build` runs SvelteKit, then
+`scripts/wrap-cloudflare-worker.mjs`. The adapter writes a fetch-only Worker;
+the wrap adds the `email()` handler from `src/worker.ts` without overwriting
+that file.
+
+### Testing inbound mail
+
+**Resend.** Webhooks cannot reach `localhost`. Tunnel it:
 
 ```bash
 cloudflared tunnel --url http://localhost:5173
 ```
 
-then point a **second, throwaway** Resend webhook at the tunnel URL. Don't repoint
-your production webhook — you'll stop receiving mail when the tunnel dies.
+Point a **second, throwaway** webhook at the tunnel. Do not repoint production
+or mail stops when the tunnel dies.
+
+**Cloudflare Email.** Use `bun run preview` or a deploy. The catch-all must
+target this Worker.
 
 Forgot the admin password:
 
@@ -194,46 +279,65 @@ Forgot the admin password:
 bun scripts/reset-admin-password.mjs you@example.com newpassword --local
 ```
 
-Drop `--local` to reset it in production.
+Drop `--local` to reset production.
+
+## How QuickMail routes inbound mail
+
+Both providers accept every local-part on a connected domain. The app then:
+
+1. Exact match in `addresses` → that user.
+2. Else the domain's **catch-all owner** (Admin) → that user.
+3. Else the row is stored in `unrouted_emails` and listed in Admin.
+
+That in-app catch-all is separate from Cloudflare Email Routing's catch-all.
+Routing's catch-all gets the message **into** the Worker. QuickMail's catch-all
+decides **which user** sees it.
 
 ## Layout
 
 ```
 src/
+  worker.ts          SvelteKit fetch + Cloudflare email() inbound
   routes/            inbox, compose, drafts, settings, admin, setup
   lib/
-    components/      Svelte UI — sidebar, mailbox, composer, thread view
-    server/          Resend client, webhook verification, D1 queries, auth, crypto
-    utils/           HTML sanitising, quoting, dates, attachments
+    components/      sidebar, mailbox, composer, thread view
+    server/          providers, inbound, D1, auth
+    utils/           HTML, quoting, dates, attachments
+scripts/
+  wrap-cloudflare-worker.mjs   attach email() after the SvelteKit build
 migrations/          D1 schema, applied in order
 ```
 
-## Inbound routing
-
-Resend delivers mail for *every* address on a connected domain, so QuickMail routes
-it in three steps:
-
-1. Exact match in the `addresses` table → that user.
-2. Otherwise, the domain's **catch-all** owner, set in Admin → that user.
-3. Otherwise it's held in `unrouted_emails` and listed in Admin, so nothing is lost.
-
 ## Troubleshooting
 
-**Mail sends but never arrives.** Check the apex `MX` record — it's the one people
-miss. `dig MX yourdomain.com` should point at Resend. Confirm receiving is enabled
-for the domain in the Resend dashboard.
+**`wrangler email sending enable` → 404.** Wrangler is too old. Use 4.123+ or
+onboard under **Compute → Email Service → Email Sending** in the dashboard.
 
-**Webhook returns 401.** `RESEND_WEBHOOK_SECRET` doesn't match the webhook that's
-calling you. Secrets are shown once at creation — if you lost it, delete the webhook
-and make a new one.
+**Catch-all cannot be set to a Worker from the CLI.** Expected.
+`wrangler email routing rules update … catch-all` only allows `forward` or
+`drop`. Use the dashboard (step B2).
 
-**Webhook returns 500.** `bunx wrangler tail` shows live logs.
+**Mail sends but never arrives (Resend).** `dig MX yourdomain.com` should point
+at Resend. Receiving must be enabled on the domain.
 
-**Attachments don't appear.** Confirm the R2 bucket exists and the `bucket_name` in
-`wrangler.jsonc` matches it.
+**Mail sends but never arrives (Cloudflare).** Apex MX must be Cloudflare
+Routing. Catch-all must send to this Worker. `EMAIL_PROVIDER` must be
+`cloudflare`. The Worker must be deployed (`vite dev` will not receive).
 
-**`database_id` errors on deploy.** You didn't replace the placeholder in
-`wrangler.jsonc` with the id from `wrangler d1 create`.
+**Webhook 401.** `RESEND_WEBHOOK_SECRET` does not match. Secrets are shown once
+— delete the webhook and create a new one.
+
+**Webhook 500.** `bunx wrangler tail`.
+
+**Attachments missing.** Confirm the R2 bucket exists and `bucket_name` in
+`wrangler.jsonc` matches.
+
+**`database_id` errors on deploy.** Paste the id from `wrangler d1 create` into
+`wrangler.jsonc`.
+
+**Setup shows no Cloudflare domains.** Set `CLOUDFLARE_MAIL_DOMAINS` (and
+`EMAIL_PROVIDER=cloudflare`) in `.dev.vars` or `wrangler.jsonc` vars, then
+restart the dev server.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "mail",
       "dependencies": {
+        "postal-mime": "^3.0.0",
         "remixicon": "^4.9.1",
       },
       "devDependencies": {
@@ -348,6 +349,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postal-mime": ["postal-mime@3.0.0", "", {}, "sha512-Z4a9ar2Bv3YpK3IXag+Yda30k7bMZfpRuUGyqtHnZ2pjHG8Bl62EhZIk4n1dzv00gfzP9g+94e9kd8+XmjVWLA=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
-		"preview": "vite build && wrangler dev",
-		"deploy": "vite build && wrangler deploy",
+		"build": "vite build && bun scripts/wrap-cloudflare-worker.mjs",
+		"preview": "bun run build && wrangler dev",
+		"deploy": "bun run build && wrangler deploy",
 		"db:migrate:local": "wrangler d1 migrations apply quickmail --local",
 		"db:migrate:remote": "wrangler d1 migrations apply quickmail --remote",
 		"prepare": "svelte-kit sync || echo ''",
@@ -33,6 +33,7 @@
 		"wrangler": "^4.96.0"
 	},
 	"dependencies": {
+		"postal-mime": "^3.0.0",
 		"remixicon": "^4.9.1"
 	}
 }

--- a/scripts/wrap-cloudflare-worker.mjs
+++ b/scripts/wrap-cloudflare-worker.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * adapter-cloudflare writes the SvelteKit fetch worker to wrangler `main`
+ * (`.svelte-kit/cloudflare/_worker.js`). We keep that path so the adapter
+ * does not overwrite `src/worker.ts`, then wrap the generated file with
+ * Cloudflare Email Service's `email()` handler.
+ */
+import { existsSync } from 'node:fs';
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const MARKER = '__QUICKMAIL_EMAIL_WRAPPER__';
+const generated = path.resolve('.svelte-kit/cloudflare/_worker.js');
+const sveltekit = path.resolve('.svelte-kit/cloudflare/_sveltekit.js');
+
+if (!existsSync(generated)) {
+	throw new Error('Expected .svelte-kit/cloudflare/_worker.js after `vite build`.');
+}
+
+const current = await readFile(generated, 'utf8');
+if (current.includes(MARKER)) {
+	process.exit(0);
+}
+
+await rename(generated, sveltekit);
+
+await writeFile(
+	generated,
+	`/* ${MARKER} */
+export { default } from '../../src/worker.ts';
+`
+);

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { CloudflareSendEmailBinding } from '$lib/server/providers/cloudflare-provider';
 import type { Domain, MailAddress, User } from '$lib/types';
 
 declare global {
@@ -8,6 +9,11 @@ declare global {
 				DB: D1Database;
 				ATTACHMENTS: R2Bucket;
 				ASSETS: Fetcher;
+				EMAIL: CloudflareSendEmailBinding;
+				/** `resend` (default) or `cloudflare`. */
+				EMAIL_PROVIDER?: string;
+				/** Comma-separated domains when EMAIL_PROVIDER=cloudflare. */
+				CLOUDFLARE_MAIL_DOMAINS?: string;
 				/** Resend API key — `wrangler secret put RESEND_API_KEY`. */
 				RESEND_API_KEY: string;
 				/** Signing secret from the Resend webhook (whsec_…). */

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,10 +1,14 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { CloudflareSendEmailBinding } from '$lib/server/providers/cloudflare-provider';
 
 declare global {
 	interface Env {
 		DB: D1Database;
 		ATTACHMENTS: R2Bucket;
 		ASSETS: Fetcher;
+		EMAIL: CloudflareSendEmailBinding;
+		EMAIL_PROVIDER?: string;
+		CLOUDFLARE_MAIL_DOMAINS?: string;
 		RESEND_API_KEY: string;
 		RESEND_WEBHOOK_SECRET: string;
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -87,7 +87,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		throw redirect(303, '/login');
 	}
 
-	// Nothing works until a Resend domain is connected and the user owns an
+	// Nothing works until a provider domain is connected and the user owns an
 	// address on it, so send them through onboarding first.
 	const needsOnboarding =
 		event.locals.domains.length === 0 || event.locals.addresses.length === 0;

--- a/src/lib/components/DomainPicker.svelte
+++ b/src/lib/components/DomainPicker.svelte
@@ -64,8 +64,8 @@
 {#if selected.some((id) => domains.find((d) => d.id === id && !d.can_receive))}
 	<p class="hint">
 		<Icon name="information-line" size={14} />
-		Receiving is off for a selected domain. Enable Inbound on it in Resend to get mail — sending
-		still works.
+		Receiving is off for a selected domain. Enable inbound on it at the mail provider to get
+		mail — sending still works.
 	</p>
 {/if}
 

--- a/src/lib/components/DomainSwitcher.svelte
+++ b/src/lib/components/DomainSwitcher.svelte
@@ -91,7 +91,7 @@
 							{#if activeDomainId === domain.id}
 								<Icon name="check-line" size={14} />
 							{:else if !domain.receiving_enabled}
-								<span class="item-flag" title="Receiving not enabled in Resend">send only</span>
+								<span class="item-flag" title="Receiving not enabled for this domain">send only</span>
 							{/if}
 						</button>
 					</li>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,11 +1,11 @@
 export const APP_NAME = 'Mail';
 /**
- * Mail domains are no longer hardcoded — they are discovered from the Resend
- * account during onboarding and stored in the `domains` table.
+ * Mail domains are discovered from the configured provider during onboarding
+ * and stored in the `domains` table.
  */
 export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
 export const MAX_ATTACHMENTS_PER_EMAIL = 5;
-/** Resend caps a single message (including attachments) at 40MB. */
+/** Providers cap a single message (including attachments) well above this. */
 export const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 /** Rows per page in the mailbox list. */
 export const MAILBOX_PAGE_SIZE = 25;

--- a/src/lib/provider-copy.ts
+++ b/src/lib/provider-copy.ts
@@ -1,0 +1,105 @@
+import type { EmailProviderKind } from '$lib/types';
+
+export function providerName(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'Resend';
+		case 'cloudflare':
+			return 'Cloudflare Email';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function missingProviderTitle(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'Resend API key missing';
+		case 'cloudflare':
+			return 'Cloudflare Email is not configured';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function missingProviderHint(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'wrangler secret put RESEND_API_KEY';
+		case 'cloudflare':
+			return 'EMAIL_PROVIDER=cloudflare\nCLOUDFLARE_MAIL_DOMAINS=yourdomain.com';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function noDomainsTitle(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'No domains in this Resend account';
+		case 'cloudflare':
+			return 'No domains in CLOUDFLARE_MAIL_DOMAINS';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function noDomainsBody(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'Add and verify a domain at resend.com/domains, then reload this page.';
+		case 'cloudflare':
+			return 'Onboard the domain in Cloudflare Email Service, then set CLOUDFLARE_MAIL_DOMAINS and reload.';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function domainPickerSubtitle(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'These are the domains your Resend account can send and receive on. Pick the one you want to use — you can add more later.';
+		case 'cloudflare':
+			return 'These are the domains listed in CLOUDFLARE_MAIL_DOMAINS. Pick the one you want to use — you can add more later.';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function onboardingSubtitle(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'Pick the domains from your Resend account that you want in this dashboard.';
+		case 'cloudflare':
+			return 'Pick the domains from CLOUDFLARE_MAIL_DOMAINS that you want in this dashboard.';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function receivingHint(kind: EmailProviderKind, domainName: string): string {
+	switch (kind) {
+		case 'resend':
+			return `Receiving isn't enabled on ${domainName} yet — you can send, but inbound mail won't arrive until you add the MX record in Resend.`;
+		case 'cloudflare':
+			return `Receiving isn't enabled on ${domainName} yet — point Email Routing's catch-all at this Worker.`;
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}

--- a/src/lib/server/cloudflare-inbound.ts
+++ b/src/lib/server/cloudflare-inbound.ts
@@ -1,0 +1,155 @@
+import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import PostalMime, { type Address, type Attachment } from 'postal-mime';
+import { insertAttachmentBytes } from './attachments';
+import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENTS_PER_EMAIL } from './constants';
+import { recordUnroutedEmail, resolveInboundRoute } from './domains';
+import { collectInboundRecipients, parseEmailAddress } from './email-address';
+import { emailExistsByProviderId, insertEmail } from './mail-store';
+import { normalizeMessageId } from './send-mail';
+
+export type CloudflareInboundMessage = {
+	readonly from: string;
+	readonly to: string;
+	readonly headers: Headers;
+	readonly raw: ReadableStream<Uint8Array>;
+	setReject(reason: string): void;
+};
+
+export type CloudflareInboundEnv = {
+	DB: D1Database;
+	ATTACHMENTS: R2Bucket;
+};
+
+/**
+ * Email Routing delivers the full MIME on `message.raw`. Parse once, then reuse
+ * the same mailbox routing and D1/R2 store as the Resend webhook path.
+ */
+export async function handleCloudflareInbound(
+	message: CloudflareInboundMessage,
+	env: CloudflareInboundEnv
+): Promise<void> {
+	const raw = await new Response(message.raw).arrayBuffer();
+	const parsed = await PostalMime.parse(raw, { attachmentEncoding: 'arraybuffer' });
+
+	const envelopeTo = parseEmailAddress(message.to);
+	const recipients = collectInboundRecipients({
+		received_for: envelopeTo.includes('@') ? [envelopeTo] : [],
+		to: mailboxAddresses(parsed.to),
+		cc: mailboxAddresses(parsed.cc),
+		bcc: mailboxAddresses(parsed.bcc)
+	});
+
+	const from = parseEmailAddress(message.from || mailboxAddresses(parsed.from)[0] || '');
+	const subject = parsed.subject?.trim() || message.headers.get('subject')?.trim() || '(no subject)';
+	const messageId =
+		normalizeMessageId(parsed.messageId ?? message.headers.get('message-id')) ?? null;
+	const inReplyTo =
+		normalizeMessageId(parsed.inReplyTo ?? message.headers.get('in-reply-to')) ?? null;
+	const references = parsed.references ?? message.headers.get('references') ?? null;
+	const providerId = await inboundProviderId({
+		messageId,
+		from,
+		to: envelopeTo || recipients.join(','),
+		date: parsed.date ?? message.headers.get('date')
+	});
+
+	if (await emailExistsByProviderId(env.DB, providerId)) {
+		return;
+	}
+
+	const route = await resolveInboundRoute(env.DB, recipients);
+
+	if (!route) {
+		await recordUnroutedEmail(env.DB, {
+			providerId,
+			from,
+			to: recipients.join(', ') || envelopeTo || '(unknown)',
+			subject,
+			reason: 'No matching address and no catch-all for this domain'
+		});
+		return;
+	}
+
+	const emailId = await insertEmail(env.DB, {
+		userId: route.userId,
+		direction: 'inbound',
+		from,
+		to: route.address,
+		cc: mailboxAddresses(parsed.cc).join(', ') || null,
+		subject,
+		bodyText: parsed.text ?? null,
+		bodyHtml: parsed.html ?? null,
+		messageId,
+		inReplyTo,
+		references,
+		domainId: route.domainId,
+		providerId
+	});
+
+	await storeInboundAttachments(env, emailId, parsed.attachments);
+}
+
+async function storeInboundAttachments(
+	env: CloudflareInboundEnv,
+	emailId: string,
+	attachments: Attachment[]
+): Promise<void> {
+	for (const attachment of attachments.slice(0, MAX_ATTACHMENTS_PER_EMAIL)) {
+		const bytes = attachmentBytes(attachment.content);
+		if (!bytes || bytes.byteLength === 0 || bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+			continue;
+		}
+
+		try {
+			await insertAttachmentBytes(env.DB, env.ATTACHMENTS, emailId, {
+				filename: attachment.filename || 'attachment',
+				type: attachment.mimeType || 'application/octet-stream',
+				bytes
+			});
+		} catch (error) {
+			console.error('Failed to store inbound Cloudflare attachment', attachment.filename, error);
+		}
+	}
+}
+
+function mailboxAddresses(value: Address | Address[] | undefined): string[] {
+	if (!value) return [];
+	const list = Array.isArray(value) ? value : [value];
+	const addresses: string[] = [];
+
+	for (const item of list) {
+		if (item.address) addresses.push(item.address);
+		if (item.group) {
+			for (const member of item.group) {
+				if (member.address) addresses.push(member.address);
+			}
+		}
+	}
+
+	return addresses;
+}
+
+function attachmentBytes(content: Attachment['content']): Uint8Array | null {
+	if (content instanceof ArrayBuffer) return new Uint8Array(content);
+	if (ArrayBuffer.isView(content)) {
+		return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
+	}
+	if (typeof content === 'string' && content.length > 0) {
+		return new TextEncoder().encode(content);
+	}
+	return null;
+}
+
+async function inboundProviderId(input: {
+	messageId: string | null;
+	from: string;
+	to: string;
+	date: string | null | undefined;
+}): Promise<string> {
+	if (input.messageId) return input.messageId;
+
+	const material = `${input.from}\n${input.to}\n${input.date ?? ''}`;
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(material));
+	const hex = [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+	return `cf-${hex.slice(0, 32)}`;
+}

--- a/src/lib/server/context.ts
+++ b/src/lib/server/context.ts
@@ -1,15 +1,93 @@
-import { createResendClient, type ResendClient } from './resend';
+import type { AvailableDomain } from '$lib/types';
+import {
+	parseMailDomains,
+	ProviderError,
+	toAvailableDomain,
+	type EmailProvider,
+	type EmailProviderKind
+} from './email-provider';
+import { ConfigError } from './errors';
+import { createCloudflareProvider } from './providers/cloudflare-provider';
+import { createResendProvider, getResendReceivingClient } from './providers/resend-provider';
+import type { ResendClient } from './resend';
+
+export { ConfigError } from './errors';
+export { ProviderError } from './email-provider';
 
 type PlatformLike = App.Platform | undefined | null;
 
-export class ConfigError extends Error {
-	constructor(message: string) {
-		super(message);
-		this.name = 'ConfigError';
+export function getEmailProviderKind(platform: PlatformLike): EmailProviderKind {
+	const raw = platform?.env.EMAIL_PROVIDER?.trim().toLowerCase();
+	if (!raw || raw === 'resend') return 'resend';
+	if (raw === 'cloudflare') return 'cloudflare';
+	throw new ConfigError(`Unknown EMAIL_PROVIDER "${platform?.env.EMAIL_PROVIDER}". Use "resend" or "cloudflare".`);
+}
+
+export function safeEmailProviderKind(platform: PlatformLike): EmailProviderKind {
+	try {
+		return getEmailProviderKind(platform);
+	} catch {
+		return 'resend';
 	}
 }
 
-/** Resend client for the configured API key, or a clear error if unset. */
+export function getEmailProvider(platform: PlatformLike): EmailProvider {
+	const kind = getEmailProviderKind(platform);
+
+	switch (kind) {
+		case 'resend': {
+			const apiKey = platform?.env.RESEND_API_KEY;
+			if (!apiKey) {
+				throw new ConfigError(
+					'RESEND_API_KEY is not set. Add it with `wrangler secret put RESEND_API_KEY` (or to .dev.vars locally).'
+				);
+			}
+			return createResendProvider(apiKey);
+		}
+		case 'cloudflare': {
+			const email = platform?.env.EMAIL;
+			if (!email) {
+				throw new ConfigError(
+					'Cloudflare Email binding EMAIL is missing. Add a send_email binding named EMAIL in wrangler.jsonc.'
+				);
+			}
+			return createCloudflareProvider(email, platform?.env.CLOUDFLARE_MAIL_DOMAINS ?? '');
+		}
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function hasProviderConfigured(platform: PlatformLike): boolean {
+	try {
+		const kind = getEmailProviderKind(platform);
+		switch (kind) {
+			case 'resend':
+				return Boolean(platform?.env.RESEND_API_KEY);
+			case 'cloudflare':
+				return Boolean(platform?.env.EMAIL) && parseMailDomains(platform?.env.CLOUDFLARE_MAIL_DOMAINS).length > 0;
+			default: {
+				const _never: never = kind;
+				return _never;
+			}
+		}
+	} catch {
+		return false;
+	}
+}
+
+export async function listAvailableDomains(
+	platform: PlatformLike,
+	connectedIds: Iterable<string> = []
+): Promise<AvailableDomain[]> {
+	const connected = new Set(connectedIds);
+	const remote = await getEmailProvider(platform).listDomains();
+	return remote.map((domain) => toAvailableDomain(domain, connected.has(domain.id)));
+}
+
+/** Resend receiving API — used only by the Resend webhook handler. */
 export function getResendClient(platform: PlatformLike): ResendClient {
 	const apiKey = platform?.env.RESEND_API_KEY;
 	if (!apiKey) {
@@ -17,13 +95,34 @@ export function getResendClient(platform: PlatformLike): ResendClient {
 			'RESEND_API_KEY is not set. Add it with `wrangler secret put RESEND_API_KEY` (or to .dev.vars locally).'
 		);
 	}
-	return createResendClient(apiKey);
+	return getResendReceivingClient(apiKey);
 }
 
 export function getWebhookSecret(platform: PlatformLike): string | null {
 	return platform?.env.RESEND_WEBHOOK_SECRET ?? null;
 }
 
-export function hasResendKey(platform: PlatformLike): boolean {
-	return Boolean(platform?.env.RESEND_API_KEY);
+export function providerLoadError(kind: EmailProviderKind, error: unknown): string {
+	if (error instanceof ConfigError || error instanceof ProviderError) return error.message;
+	switch (kind) {
+		case 'resend':
+			return 'Could not reach Resend. Check the API key and try again.';
+		case 'cloudflare':
+			return 'Could not load Cloudflare Email domains. Check EMAIL_PROVIDER and CLOUDFLARE_MAIL_DOMAINS.';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function describeProviderError(error: unknown, fallback = 'Failed to send email'): string {
+	if (error instanceof ConfigError || error instanceof ProviderError) return error.message;
+	return error instanceof Error ? error.message : fallback;
+}
+
+export function statusForProviderError(error: unknown): number {
+	if (error instanceof ConfigError) return 503;
+	if (error instanceof ProviderError) return error.status >= 500 ? 502 : 400;
+	return 400;
 }

--- a/src/lib/server/domains.ts
+++ b/src/lib/server/domains.ts
@@ -1,7 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import type { Domain, MailAddress } from '$lib/types';
-import type { ResendClient, ResendDomain } from './resend';
-import { isDomainReceivable, isDomainSendable } from './resend';
+import type { EmailProvider, ProviderDomain } from './email-provider';
 
 type DomainRow = {
 	id: string;
@@ -83,10 +82,10 @@ export async function getDomainByName(db: D1Database, name: string): Promise<Dom
 }
 
 /**
- * Connect (or refresh) a Resend domain. Keyed on the Resend domain id so
+ * Connect (or refresh) a provider domain. Keyed on the provider domain id so
  * re-running is safe and picks up newly verified DNS.
  */
-export async function upsertDomain(db: D1Database, domain: ResendDomain): Promise<Domain> {
+export async function upsertDomain(db: D1Database, domain: ProviderDomain): Promise<Domain> {
 	await db
 		.prepare(
 			`INSERT INTO domains (id, name, status, region, sending_enabled, receiving_enabled, synced_at)
@@ -104,8 +103,8 @@ export async function upsertDomain(db: D1Database, domain: ResendDomain): Promis
 			domain.name.toLowerCase(),
 			domain.status,
 			domain.region ?? null,
-			isDomainSendable(domain) ? 1 : 0,
-			isDomainReceivable(domain) ? 1 : 0
+			domain.sendingEnabled ? 1 : 0,
+			domain.receivingEnabled ? 1 : 0
 		)
 		.run();
 
@@ -129,12 +128,12 @@ export async function setCatchallUser(
 		.run();
 }
 
-/** Re-read every connected domain from Resend so status/capabilities stay fresh. */
-export async function syncDomains(db: D1Database, client: ResendClient): Promise<Domain[]> {
+/** Re-read every connected domain from the active provider so status stays fresh. */
+export async function syncDomains(db: D1Database, provider: EmailProvider): Promise<Domain[]> {
 	const connected = await listDomains(db);
 	if (connected.length === 0) return [];
 
-	const remote = await client.listDomains();
+	const remote = await provider.listDomains();
 	const byId = new Map(remote.map((domain) => [domain.id, domain]));
 
 	for (const domain of connected) {
@@ -142,7 +141,7 @@ export async function syncDomains(db: D1Database, client: ResendClient): Promise
 		if (match) {
 			await upsertDomain(db, match);
 		} else {
-			// Removed in Resend — mark it so the UI can explain why sending fails.
+			// Removed from the provider — mark it so the UI can explain why sending fails.
 			await db
 				.prepare(
 					`UPDATE domains SET status = 'missing', sending_enabled = 0, receiving_enabled = 0,
@@ -281,8 +280,8 @@ export type InboundRoute = {
 /**
  * Resolve who an inbound message belongs to.
  *
- * Resend accepts mail for every address on a connected domain, so we try an
- * exact address match first and fall back to the domain's catch-all owner.
+ * The provider accepts mail for every address on a connected domain, so we try
+ * an exact address match first and fall back to the domain's catch-all owner.
  */
 export async function resolveInboundRoute(
 	db: D1Database,

--- a/src/lib/server/email-provider.ts
+++ b/src/lib/server/email-provider.ts
@@ -1,0 +1,86 @@
+import type { AvailableDomain, EmailProviderKind, MailStatus } from '$lib/types';
+import type { OutboundMailInput, OutboundMailResult } from './send-mail';
+
+export type { EmailProviderKind };
+
+export type ProviderDomain = {
+	id: string;
+	name: string;
+	status: string;
+	region?: string | null;
+	sendingEnabled: boolean;
+	receivingEnabled: boolean;
+};
+
+export type EmailProvider = {
+	kind: EmailProviderKind;
+	send(input: OutboundMailInput): Promise<OutboundMailResult>;
+	listDomains(): Promise<ProviderDomain[]>;
+	getDomain(id: string): Promise<ProviderDomain>;
+};
+
+export class ProviderError extends Error {
+	readonly status: number;
+	readonly code: string;
+
+	constructor(status: number, code: string, message: string) {
+		super(message);
+		this.name = 'ProviderError';
+		this.status = status;
+		this.code = code;
+	}
+}
+
+export function toAvailableDomain(domain: ProviderDomain, connected: boolean): AvailableDomain {
+	return {
+		id: domain.id,
+		name: domain.name,
+		status: domain.status,
+		region: domain.region ?? null,
+		can_send: domain.sendingEnabled,
+		can_receive: domain.receivingEnabled,
+		connected
+	};
+}
+
+/** Outbound rows stay queued until Resend webhooks land; Cloudflare send() is already accepted. */
+export function initialOutboundStatus(kind: EmailProviderKind): MailStatus {
+	switch (kind) {
+		case 'resend':
+			return 'queued';
+		case 'cloudflare':
+			return 'sent';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function providerLabel(kind: EmailProviderKind): string {
+	switch (kind) {
+		case 'resend':
+			return 'Resend';
+		case 'cloudflare':
+			return 'Cloudflare Email';
+		default: {
+			const _never: never = kind;
+			return _never;
+		}
+	}
+}
+
+export function parseMailDomains(value: string | undefined | null): string[] {
+	if (!value?.trim()) return [];
+	const seen = new Set<string>();
+	const domains: string[] = [];
+
+	for (const part of value.split(',')) {
+		const name = part.trim().toLowerCase().replace(/^@/, '');
+		if (!name || seen.has(name)) continue;
+		seen.add(name);
+		domains.push(name);
+	}
+
+	return domains;
+}

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -1,0 +1,6 @@
+export class ConfigError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'ConfigError';
+	}
+}

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -5,7 +5,7 @@ import { MAX_TOTAL_ATTACHMENT_BYTES } from './constants';
 import { getAddressForUser, getDefaultAddress } from './domains';
 import { stripHtml } from './html';
 import { insertEmail } from './mail-store';
-import type { ResendClient } from './resend';
+import { initialOutboundStatus, type EmailProvider } from './email-provider';
 import { parseRecipients, sendOutboundEmail } from './send-mail';
 
 export type ComposeInput = {
@@ -42,10 +42,10 @@ export async function resolveFromAddress(
 	return address;
 }
 
-/** Send through Resend, then record it in the Sent folder with its provider id. */
+/** Send through the configured provider, then record it in the Sent folder. */
 export async function sendAndStore(
 	env: { DB: D1Database; ATTACHMENTS: R2Bucket },
-	client: ResendClient,
+	provider: EmailProvider,
 	user: User,
 	input: ComposeInput
 ): Promise<{ emailId: string; providerId: string; from: MailAddress }> {
@@ -68,7 +68,7 @@ export async function sendAndStore(
 		throw new Error('Attachments exceed the total size limit');
 	}
 
-	const { providerId } = await sendOutboundEmail(client, {
+	const { providerId } = await sendOutboundEmail(provider, {
 		from,
 		senderName: user.name,
 		to: input.to,
@@ -97,7 +97,7 @@ export async function sendAndStore(
 		replyToEmailId: input.replyToEmailId ?? null,
 		domainId: from.domain_id,
 		providerId,
-		status: 'queued',
+		status: initialOutboundStatus(provider.kind),
 		isRead: true
 	});
 

--- a/src/lib/server/providers/cloudflare-provider.ts
+++ b/src/lib/server/providers/cloudflare-provider.ts
@@ -1,0 +1,121 @@
+import { base64ToBytes } from '../attachments';
+import { parseMailDomains, ProviderError, type EmailProvider, type ProviderDomain } from '../email-provider';
+import type { OutboundMailInput, OutboundMailResult } from '../send-mail';
+
+/**
+ * Structured Email Service binding. `@cloudflare/workers-types` does not yet
+ * ship `SendEmail`, so the shape is declared here against the Workers API.
+ * https://developers.cloudflare.com/email-service/api/send-emails/workers-api/
+ */
+export type CloudflareSendEmailBinding = {
+	send(payload: CloudflareSendPayload): Promise<{ messageId: string }>;
+};
+
+export type CloudflareSendPayload = {
+	to: string | string[];
+	from: string | { email: string; name?: string };
+	subject: string;
+	html?: string;
+	text?: string;
+	cc?: string | string[];
+	bcc?: string | string[];
+	replyTo?: string | { email: string; name?: string };
+	headers?: Record<string, string>;
+	attachments?: Array<{
+		content: string | ArrayBuffer | ArrayBufferView;
+		filename: string;
+		type?: string;
+		disposition?: 'attachment' | 'inline';
+		contentId?: string;
+	}>;
+};
+
+export function createCloudflareProvider(
+	email: CloudflareSendEmailBinding,
+	configuredDomains: string
+): EmailProvider {
+	return {
+		kind: 'cloudflare',
+		async send(input: OutboundMailInput): Promise<OutboundMailResult> {
+			try {
+				const response = await email.send({
+					to: input.to,
+					from: { email: input.from.address, name: input.senderName },
+					replyTo: input.from.address,
+					subject: input.subject,
+					text: input.text,
+					html: input.html,
+					...(input.cc?.length ? { cc: input.cc } : {}),
+					...(input.bcc?.length ? { bcc: input.bcc } : {}),
+					...(input.headers && Object.keys(input.headers).length
+						? { headers: input.headers }
+						: {}),
+					...(input.attachments?.length
+						? {
+								attachments: input.attachments.map((file) => ({
+									filename: file.filename,
+									type: file.type,
+									content: base64ToArrayBuffer(file.content),
+									disposition: 'attachment' as const
+								}))
+							}
+						: {})
+				});
+
+				if (!response?.messageId) {
+					throw new ProviderError(502, 'missing_message_id', 'Cloudflare Email did not return a message id');
+				}
+
+				return { providerId: response.messageId };
+			} catch (error) {
+				throw wrapCloudflareError(error);
+			}
+		},
+		async listDomains(): Promise<ProviderDomain[]> {
+			return parseMailDomains(configuredDomains).map(cloudflareDomain);
+		},
+		async getDomain(id: string): Promise<ProviderDomain> {
+			const domains = parseMailDomains(configuredDomains);
+			const match = domains.find((name) => name === id.toLowerCase());
+			if (!match) {
+				throw new ProviderError(
+					404,
+					'domain_not_configured',
+					`${id} is not in CLOUDFLARE_MAIL_DOMAINS`
+				);
+			}
+			return cloudflareDomain(match);
+		}
+	};
+}
+
+function cloudflareDomain(name: string): ProviderDomain {
+	return {
+		id: name,
+		name,
+		status: 'verified',
+		region: null,
+		sendingEnabled: true,
+		receivingEnabled: true
+	};
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+	const bytes = base64ToBytes(base64);
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy.buffer;
+}
+
+function wrapCloudflareError(error: unknown): ProviderError {
+	if (error instanceof ProviderError) return error;
+
+	const code =
+		error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+			? error.code
+			: 'send_failed';
+	const message = error instanceof Error ? error.message : 'Cloudflare Email rejected the message';
+	const status = code === 'E_RATE_LIMIT_EXCEEDED' || code === 'E_INTERNAL_SERVER_ERROR' ? 502 : 400;
+
+	return new ProviderError(status, code, message);
+}

--- a/src/lib/server/providers/resend-provider.ts
+++ b/src/lib/server/providers/resend-provider.ts
@@ -1,0 +1,95 @@
+import {
+	createResendClient,
+	isDomainReceivable,
+	isDomainSendable,
+	ResendError,
+	type ResendClient,
+	type ResendDomain
+} from '../resend';
+import type { EmailProvider, ProviderDomain } from '../email-provider';
+import { ProviderError } from '../email-provider';
+import type { OutboundMailInput, OutboundMailResult } from '../send-mail';
+
+export function createResendProvider(apiKey: string): EmailProvider {
+	const client = createResendClient(apiKey);
+
+	return {
+		kind: 'resend',
+		async send(input: OutboundMailInput): Promise<OutboundMailResult> {
+			try {
+				const result = await client.send(
+					{
+						from: `${input.senderName} <${input.from.address}>`,
+						to: input.to,
+						...(input.cc?.length ? { cc: input.cc } : {}),
+						...(input.bcc?.length ? { bcc: input.bcc } : {}),
+						reply_to: input.from.address,
+						subject: input.subject,
+						text: input.text,
+						html: input.html,
+						...(input.headers && Object.keys(input.headers).length
+							? { headers: input.headers }
+							: {}),
+						...(input.attachments?.length
+							? {
+									attachments: input.attachments.map((file) => ({
+										filename: file.filename,
+										content: file.content,
+										content_type: file.type
+									}))
+								}
+							: {})
+					},
+					input.idempotencyKey
+				);
+
+				return { providerId: result.id };
+			} catch (error) {
+				throw wrapResendError(error);
+			}
+		},
+		async listDomains(): Promise<ProviderDomain[]> {
+			try {
+				const remote = await client.listDomains();
+				return remote.map(toProviderDomain);
+			} catch (error) {
+				throw wrapResendError(error);
+			}
+		},
+		async getDomain(id: string): Promise<ProviderDomain> {
+			try {
+				return toProviderDomain(await client.getDomain(id));
+			} catch (error) {
+				throw wrapResendError(error);
+			}
+		}
+	};
+}
+
+/** Webhook ingest still needs the receiving endpoints on the raw client. */
+export function getResendReceivingClient(apiKey: string): ResendClient {
+	return createResendClient(apiKey);
+}
+
+function toProviderDomain(domain: ResendDomain): ProviderDomain {
+	return {
+		id: domain.id,
+		name: domain.name,
+		status: domain.status,
+		region: domain.region ?? null,
+		sendingEnabled: isDomainSendable(domain),
+		receivingEnabled: isDomainReceivable(domain)
+	};
+}
+
+function wrapResendError(error: unknown): ProviderError {
+	if (error instanceof ProviderError) return error;
+	if (error instanceof ResendError) {
+		return new ProviderError(error.status, error.code, error.message);
+	}
+	return new ProviderError(
+		502,
+		'resend_error',
+		error instanceof Error ? error.message : 'Resend request failed'
+	);
+}

--- a/src/lib/server/send-mail.ts
+++ b/src/lib/server/send-mail.ts
@@ -1,5 +1,5 @@
 import type { MailAddress, OutboundAttachmentInput } from '$lib/types';
-import type { ResendClient } from './resend';
+import type { EmailProvider } from './email-provider';
 
 export type OutboundMailInput = {
 	from: MailAddress;
@@ -12,6 +12,7 @@ export type OutboundMailInput = {
 	html?: string;
 	inReplyTo?: string | null;
 	references?: string | null;
+	headers?: Record<string, string>;
 	attachments?: OutboundAttachmentInput[];
 	idempotencyKey?: string;
 };
@@ -59,7 +60,7 @@ export function validateSubject(subject: string): string | null {
 	return null;
 }
 
-/** Split a comma-separated recipient field into addresses Resend will accept. */
+/** Split a comma-separated recipient field into addresses the provider will accept. */
 export function parseRecipients(value: string | string[] | undefined | null): string[] {
 	if (!value) return [];
 	const parts = Array.isArray(value) ? value : value.split(',');
@@ -82,7 +83,7 @@ ${bodyHtml}
 }
 
 export async function sendOutboundEmail(
-	client: ResendClient,
+	provider: EmailProvider,
 	input: OutboundMailInput
 ): Promise<OutboundMailResult> {
 	const subjectError = validateSubject(input.subject);
@@ -100,7 +101,7 @@ export async function sendOutboundEmail(
 	const safeText = input.text.trim();
 	const bodyHtml = input.html?.trim() || escapeHtml(safeText).replaceAll('\n', '<br>\n');
 
-	const headers: Record<string, string> = {};
+	const headers: Record<string, string> = { ...input.headers };
 	const inReplyTo = formatMessageId(input.inReplyTo);
 	// References is a chain, In-Reply-To a single id. Both matter: mail clients
 	// on the other side thread on them, and so do we when the reply comes back.
@@ -110,29 +111,19 @@ export async function sendOutboundEmail(
 		if (references) headers['References'] = references;
 	}
 
-	const result = await client.send(
-		{
-			from: `${input.senderName} <${input.from.address}>`,
-			to,
-			...(cc.length ? { cc } : {}),
-			...(bcc.length ? { bcc } : {}),
-			reply_to: input.from.address,
-			subject: input.subject.trim(),
-			text: safeText,
-			html: buildHtmlEmail(bodyHtml),
-			...(Object.keys(headers).length ? { headers } : {}),
-			...(input.attachments?.length
-				? {
-						attachments: input.attachments.map((file) => ({
-							filename: file.filename,
-							content: file.content,
-							content_type: file.type
-						}))
-					}
-				: {})
-		},
-		input.idempotencyKey ?? crypto.randomUUID()
-	);
-
-	return { providerId: result.id };
+	return provider.send({
+		from: input.from,
+		senderName: input.senderName,
+		to,
+		...(cc.length ? { cc } : {}),
+		...(bcc.length ? { bcc } : {}),
+		subject: input.subject.trim(),
+		text: safeText,
+		html: buildHtmlEmail(bodyHtml),
+		inReplyTo,
+		references,
+		...(Object.keys(headers).length ? { headers } : {}),
+		attachments: input.attachments,
+		idempotencyKey: input.idempotencyKey ?? crypto.randomUUID()
+	});
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,10 @@ export type Domain = {
 	synced_at: string | null;
 };
 
-/** A domain as reported by the Resend API, flagged with local connection state. */
+/** Which mail backend this deploy is configured to use. */
+export type EmailProviderKind = 'resend' | 'cloudflare';
+
+/** A domain as reported by the active provider, flagged with local connection state. */
 export type AvailableDomain = {
 	id: string;
 	name: string;

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,15 +1,19 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { listUsers } from '$lib/server/auth';
-import { ConfigError, getResendClient } from '$lib/server/context';
+import {
+	safeEmailProviderKind,
+	listAvailableDomains,
+	providerLoadError
+} from '$lib/server/context';
 import { listAllAddresses, listUnroutedEmails } from '$lib/server/domains';
-import { isDomainReceivable, isDomainSendable, ResendError } from '$lib/server/resend';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
 	if (!locals.user?.is_admin) {
 		throw error(403, 'Forbidden');
 	}
 
+	const providerKind = safeEmailProviderKind(platform);
 	const db = platform?.env.DB;
 	if (!db) {
 		return {
@@ -18,6 +22,7 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 			domains: locals.domains,
 			available: [],
 			unrouted: [],
+			providerKind,
 			loadError: 'Database unavailable'
 		};
 	}
@@ -28,26 +33,19 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 		listUnroutedEmails(db, 25)
 	]);
 
-	const connectedIds = new Set(locals.domains.map((domain) => domain.id));
-
 	try {
-		const client = getResendClient(platform);
-		const remote = await client.listDomains();
+		const available = await listAvailableDomains(
+			platform,
+			locals.domains.map((domain) => domain.id)
+		);
 
 		return {
 			users,
 			addresses,
 			unrouted,
 			domains: locals.domains,
-			available: remote.map((domain) => ({
-				id: domain.id,
-				name: domain.name,
-				status: domain.status,
-				region: domain.region ?? null,
-				can_send: isDomainSendable(domain),
-				can_receive: isDomainReceivable(domain),
-				connected: connectedIds.has(domain.id)
-			})),
+			available,
+			providerKind,
 			loadError: null
 		};
 	} catch (err) {
@@ -57,10 +55,8 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 			unrouted,
 			domains: locals.domains,
 			available: [],
-			loadError:
-				err instanceof ConfigError || err instanceof ResendError
-					? err.message
-					: 'Could not reach Resend'
+			providerKind,
+			loadError: providerLoadError(providerKind, err)
 		};
 	}
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -122,8 +122,10 @@
 	<section class="surface-lg admin-card">
 		<h2><Icon name="global-line" size={18} /> Domains</h2>
 		<p class="card-hint">
-			Connected domains send and receive through Resend. Catch-all decides who gets mail addressed
-			to an unknown mailbox on that domain.
+			Connected domains send and receive through {data.providerKind === 'cloudflare'
+				? 'Cloudflare Email'
+				: 'Resend'}. Catch-all decides who gets mail addressed to an unknown mailbox on that
+			domain.
 		</p>
 
 		<ul class="domain-list">
@@ -184,8 +186,11 @@
 					{#if !domain.receiving_enabled}
 						<p class="hint">
 							<Icon name="information-line" size={13} />
-							Inbound is off for this domain in Resend — add the MX record and enable receiving to
-							get mail.
+							Inbound is off for this domain — enable receiving
+							{data.providerKind === 'cloudflare'
+								? "and point Email Routing's catch-all at this Worker"
+								: 'and add the MX record at the provider'}
+							to get mail.
 						</p>
 					{/if}
 					{#if domain.catchall_user_id}
@@ -200,7 +205,9 @@
 
 		{#if connectable.length > 0}
 			<div class="connect-block">
-				<p class="connect-title">Available in Resend</p>
+				<p class="connect-title">
+					Available in {data.providerKind === 'cloudflare' ? 'Cloudflare Email' : 'Resend'}
+				</p>
 				<ul class="connect-list">
 					{#each connectable as domain (domain.id)}
 						<li class="connect-row">

--- a/src/routes/api/domains/+server.ts
+++ b/src/routes/api/domains/+server.ts
@@ -1,10 +1,17 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { ConfigError, getResendClient } from '$lib/server/context';
+import {
+	ConfigError,
+	getEmailProvider,
+	safeEmailProviderKind,
+	hasProviderConfigured,
+	listAvailableDomains,
+	ProviderError,
+	providerLoadError
+} from '$lib/server/context';
 import { listDomains, syncDomains, upsertDomain } from '$lib/server/domains';
-import { isDomainReceivable, isDomainSendable, ResendError } from '$lib/server/resend';
 
 /**
- * GET  — every domain the configured Resend key can reach, flagged with
+ * GET  — every domain the configured provider can reach, flagged with
  *        whether it is already connected to this dashboard.
  * POST — connect one (or several) of them.
  */
@@ -15,47 +22,57 @@ export const GET: RequestHandler = async ({ locals, platform, url }) => {
 	}
 
 	const connected = await listDomains(db);
+	const providerKind = safeEmailProviderKind(platform);
 
 	// Non-admins only need what is already wired up.
 	if (!locals.user.is_admin) {
-		return json({ connected, available: [], resendConfigured: true });
+		return json({
+			connected,
+			available: [],
+			providerConfigured: true,
+			providerKind
+		});
 	}
 
 	try {
-		const client = getResendClient(platform);
+		const provider = getEmailProvider(platform);
 
 		if (url.searchParams.get('sync') === '1') {
-			return json({ connected: await syncDomains(db, client), available: [] });
+			return json({
+				connected: await syncDomains(db, provider),
+				available: [],
+				providerKind
+			});
 		}
-
-		const remote = await client.listDomains();
-		const connectedIds = new Set(connected.map((domain) => domain.id));
 
 		return json({
 			connected,
-			resendConfigured: true,
-			available: remote.map((domain) => ({
-				id: domain.id,
-				name: domain.name,
-				status: domain.status,
-				region: domain.region,
-				can_send: isDomainSendable(domain),
-				can_receive: isDomainReceivable(domain),
-				connected: connectedIds.has(domain.id)
-			}))
+			providerConfigured: true,
+			providerKind,
+			available: await listAvailableDomains(
+				platform,
+				connected.map((domain) => domain.id)
+			)
 		});
 	} catch (error) {
 		if (error instanceof ConfigError) {
-			return json({ connected, available: [], resendConfigured: false, error: error.message });
+			return json({
+				connected,
+				available: [],
+				providerConfigured: false,
+				providerKind,
+				error: error.message
+			});
 		}
 		return json(
 			{
 				connected,
 				available: [],
-				resendConfigured: true,
-				error: error instanceof ResendError ? error.message : 'Failed to reach Resend'
+				providerConfigured: hasProviderConfigured(platform),
+				providerKind,
+				error: providerLoadError(providerKind, error)
 			},
-			{ status: error instanceof ResendError ? error.status : 502 }
+			{ status: error instanceof ProviderError ? (error.status >= 500 ? 502 : 400) : 502 }
 		);
 	}
 };
@@ -74,19 +91,17 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	}
 
 	try {
-		const client = getResendClient(platform);
+		const provider = getEmailProvider(platform);
 		const connected = [];
 
 		for (const id of ids) {
-			// Read it back from Resend so status/capabilities are authoritative.
-			const domain = await client.getDomain(id);
-			connected.push(await upsertDomain(db, domain));
+			connected.push(await upsertDomain(db, await provider.getDomain(id)));
 		}
 
 		return json({ connected, domains: await listDomains(db) }, { status: 201 });
 	} catch (error) {
 		const message =
-			error instanceof ConfigError || error instanceof ResendError
+			error instanceof ConfigError || error instanceof ProviderError
 				? error.message
 				: 'Failed to connect domain';
 		return json({ error: message }, { status: 400 });

--- a/src/routes/api/domains/[id]/+server.ts
+++ b/src/routes/api/domains/[id]/+server.ts
@@ -1,9 +1,8 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { getResendClient } from '$lib/server/context';
+import { getEmailProvider, ProviderError } from '$lib/server/context';
 import { disconnectDomain, getDomain, setCatchallUser, upsertDomain } from '$lib/server/domains';
-import { ResendError } from '$lib/server/resend';
 
-/** PATCH — set the catch-all owner or re-sync DNS status from Resend. */
+/** PATCH — set the catch-all owner or re-sync status from the active provider. */
 export const PATCH: RequestHandler = async ({ params, request, locals, platform }) => {
 	const db = platform?.env.DB;
 	if (!db || !locals.user?.is_admin) {
@@ -22,12 +21,12 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 
 	if (body.refresh) {
 		try {
-			const client = getResendClient(platform);
-			const remote = await client.getDomain(domain.id);
+			const provider = getEmailProvider(platform);
+			const remote = await provider.getDomain(domain.id);
 			return json({ domain: await upsertDomain(db, remote) });
 		} catch (error) {
 			return json(
-				{ error: error instanceof ResendError ? error.message : 'Failed to refresh domain' },
+				{ error: error instanceof ProviderError ? error.message : 'Failed to refresh domain' },
 				{ status: 502 }
 			);
 		}
@@ -40,7 +39,7 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 	return json({ domain: await getDomain(db, domain.id) });
 };
 
-/** DELETE — stop using the domain here. The domain stays in Resend. */
+/** DELETE — stop using the domain here. The domain stays with the provider. */
 export const DELETE: RequestHandler = async ({ params, locals, platform }) => {
 	const db = platform?.env.DB;
 	if (!db || !locals.user?.is_admin) {

--- a/src/routes/api/mail/+server.ts
+++ b/src/routes/api/mail/+server.ts
@@ -1,8 +1,11 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { ConfigError, getResendClient } from '$lib/server/context';
+import {
+	describeProviderError,
+	getEmailProvider,
+	statusForProviderError
+} from '$lib/server/context';
 import { deleteDraft, listEmails } from '$lib/server/mail-store';
 import { sendAndStore } from '$lib/server/outbox';
-import { ResendError } from '$lib/server/resend';
 import type { OutboundAttachmentInput } from '$lib/types';
 
 type SendMailBody = {
@@ -47,10 +50,10 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	}
 
 	try {
-		const client = getResendClient(platform);
+		const provider = getEmailProvider(platform);
 		const { emailId } = await sendAndStore(
 			{ DB: db, ATTACHMENTS: bucket },
-			client,
+			provider,
 			locals.user,
 			{
 				fromAddressId: body.fromAddressId,
@@ -70,18 +73,6 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 
 		return json({ ok: true, id: emailId });
 	} catch (error) {
-		return json({ error: describeError(error) }, { status: statusFor(error) });
+		return json({ error: describeProviderError(error) }, { status: statusForProviderError(error) });
 	}
 };
-
-function describeError(error: unknown): string {
-	if (error instanceof ConfigError) return error.message;
-	if (error instanceof ResendError) return `Resend rejected the message: ${error.message}`;
-	return error instanceof Error ? error.message : 'Failed to send email';
-}
-
-function statusFor(error: unknown): number {
-	if (error instanceof ConfigError) return 503;
-	if (error instanceof ResendError) return error.status >= 500 ? 502 : 400;
-	return 400;
-}

--- a/src/routes/api/mail/[id]/+server.ts
+++ b/src/routes/api/mail/[id]/+server.ts
@@ -1,5 +1,9 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { ConfigError, getResendClient } from '$lib/server/context';
+import {
+	describeProviderError,
+	getEmailProvider,
+	statusForProviderError
+} from '$lib/server/context';
 import {
 	deleteEmailsPermanently,
 	expandToThreads,
@@ -9,7 +13,6 @@ import {
 	setEmailFlags
 } from '$lib/server/mail-store';
 import { sendAndStore } from '$lib/server/outbox';
-import { ResendError } from '$lib/server/resend';
 import { buildReferences, displaySubject } from '$lib/server/threads';
 import type { OutboundAttachmentInput } from '$lib/types';
 
@@ -121,10 +124,10 @@ export const POST: RequestHandler = async ({ params, request, locals, platform }
 				);
 
 	try {
-		const client = getResendClient(platform);
+		const provider = getEmailProvider(platform);
 		const { emailId } = await sendAndStore(
 			{ DB: db, ATTACHMENTS: bucket },
-			client,
+			provider,
 			locals.user,
 			{
 				fromAddressId: body.fromAddressId ?? preferredAddress?.id,
@@ -143,23 +146,9 @@ export const POST: RequestHandler = async ({ params, request, locals, platform }
 
 		return json({ ok: true, id: emailId });
 	} catch (error) {
-		const status =
-			error instanceof ConfigError
-				? 503
-				: error instanceof ResendError && error.status >= 500
-					? 502
-					: 400;
-
 		return json(
-			{
-				error:
-					error instanceof ResendError
-						? `Resend rejected the reply: ${error.message}`
-						: error instanceof Error
-							? error.message
-							: 'Failed to send reply'
-			},
-			{ status }
+			{ error: describeProviderError(error, 'Failed to send reply') },
+			{ status: statusForProviderError(error) }
 		);
 	}
 };

--- a/src/routes/api/setup/+server.ts
+++ b/src/routes/api/setup/+server.ts
@@ -7,24 +7,32 @@ import {
 	SESSION_COOKIE
 } from '$lib/server/auth';
 import { SESSION_DAYS } from '$lib/server/constants';
-import { ConfigError, getResendClient, hasResendKey } from '$lib/server/context';
+import {
+	ConfigError,
+	getEmailProvider,
+	safeEmailProviderKind,
+	hasProviderConfigured,
+	ProviderError
+} from '$lib/server/context';
 import { createAddress, setCatchallUser, upsertDomain } from '$lib/server/domains';
-import { ResendError } from '$lib/server/resend';
 
 export const GET: RequestHandler = async ({ platform }) => {
 	const db = platform?.env.DB;
-	if (!db) return json({ ready: false, needsSetup: true, resendConfigured: false });
+	if (!db) {
+		return json({ ready: false, needsSetup: true, providerConfigured: false, providerKind: 'resend' });
+	}
 
 	const users = await countUsers(db);
 	return json({
 		ready: true,
 		needsSetup: users === 0,
-		resendConfigured: hasResendKey(platform)
+		providerConfigured: hasProviderConfigured(platform),
+		providerKind: safeEmailProviderKind(platform)
 	});
 };
 
 /**
- * First-run bootstrap, done in one shot: connect the chosen Resend domain,
+ * First-run bootstrap, done in one shot: connect the chosen provider domain,
  * create the admin, claim their address, make them the catch-all, sign them in.
  */
 export const POST: RequestHandler = async ({ request, cookies, platform }) => {
@@ -57,9 +65,8 @@ export const POST: RequestHandler = async ({ request, cookies, platform }) => {
 	}
 
 	try {
-		// Read the domain back from Resend so status/capabilities are authoritative.
-		const client = getResendClient(platform);
-		const domain = await upsertDomain(db, await client.getDomain(body.domainId));
+		const provider = getEmailProvider(platform);
+		const domain = await upsertDomain(db, await provider.getDomain(body.domainId));
 
 		const localPart = body.localPart.trim().toLowerCase().replace(/@.*$/, '');
 		const address = `${localPart}@${domain.name}`;
@@ -73,8 +80,8 @@ export const POST: RequestHandler = async ({ request, cookies, platform }) => {
 
 		await createAddress(db, { userId: user.id, domainId: domain.id, localPart });
 
-		// Resend accepts mail for every mailbox on the domain; without a catch-all
-		// anything sent to an unknown address would just pile up unrouted.
+		// The provider accepts mail for every mailbox on the domain; without a
+		// catch-all anything sent to an unknown address would just pile up unrouted.
 		await setCatchallUser(db, domain.id, user.id);
 
 		const session = await login(db, address, body.password);
@@ -89,7 +96,7 @@ export const POST: RequestHandler = async ({ request, cookies, platform }) => {
 		return json({ ok: true, email: address, signedIn: Boolean(session) });
 	} catch (error) {
 		const message =
-			error instanceof ConfigError || error instanceof ResendError
+			error instanceof ConfigError || error instanceof ProviderError
 				? error.message
 				: error instanceof Error
 					? error.message

--- a/src/routes/api/webhooks/resend/+server.ts
+++ b/src/routes/api/webhooks/resend/+server.ts
@@ -4,8 +4,7 @@ import { claimWebhookEvent, handleResendWebhook, type ResendWebhookEvent } from 
 import { verifyWebhookSignature } from '$lib/server/webhook';
 
 /**
- * Resend webhook receiver — this is how mail arrives now that the Cloudflare
- * Email Routing worker handler is gone.
+ * Resend webhook receiver — used when EMAIL_PROVIDER=resend.
  *
  * Point a webhook at https://<your-app>/api/webhooks/resend in the Resend
  * dashboard and subscribe to `email.received` plus the delivery events.

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -1,55 +1,40 @@
 import type { PageServerLoad } from './$types';
-import { ConfigError, getResendClient } from '$lib/server/context';
-import { isDomainReceivable, isDomainSendable, ResendError } from '$lib/server/resend';
-
-export type AvailableDomain = {
-	id: string;
-	name: string;
-	status: string;
-	region: string | null;
-	can_send: boolean;
-	can_receive: boolean;
-	connected: boolean;
-};
+import {
+	ConfigError,
+	safeEmailProviderKind,
+	hasProviderConfigured,
+	listAvailableDomains,
+	providerLoadError
+} from '$lib/server/context';
+import type { AvailableDomain } from '$lib/types';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
+	const providerKind = safeEmailProviderKind(platform);
 	const base = {
 		domains: locals.domains,
 		addresses: locals.addresses,
-		isAdmin: locals.user?.is_admin ?? false
+		isAdmin: locals.user?.is_admin ?? false,
+		providerKind
 	};
 
-	// Only the admin talks to Resend; everyone else just claims an address on an
-	// already-connected domain.
+	// Only the admin talks to the provider; everyone else just claims an address
+	// on an already-connected domain.
 	if (!locals.user?.is_admin) {
-		return { ...base, available: [] as AvailableDomain[], resendConfigured: true, loadError: null };
+		return { ...base, available: [] as AvailableDomain[], providerConfigured: true, loadError: null };
 	}
 
 	try {
-		const client = getResendClient(platform);
-		const remote = await client.listDomains();
-		const connectedIds = new Set(locals.domains.map((domain) => domain.id));
-
-		const available: AvailableDomain[] = remote.map((domain) => ({
-			id: domain.id,
-			name: domain.name,
-			status: domain.status,
-			region: domain.region ?? null,
-			can_send: isDomainSendable(domain),
-			can_receive: isDomainReceivable(domain),
-			connected: connectedIds.has(domain.id)
-		}));
-
-		return { ...base, available, resendConfigured: true, loadError: null };
+		const available = await listAvailableDomains(
+			platform,
+			locals.domains.map((domain) => domain.id)
+		);
+		return { ...base, available, providerConfigured: true, loadError: null };
 	} catch (error) {
 		return {
 			...base,
 			available: [] as AvailableDomain[],
-			resendConfigured: !(error instanceof ConfigError),
-			loadError:
-				error instanceof ConfigError || error instanceof ResendError
-					? error.message
-					: 'Could not reach Resend. Check the API key and try again.'
+			providerConfigured: !(error instanceof ConfigError) && hasProviderConfigured(platform),
+			loadError: providerLoadError(providerKind, error)
 		};
 	}
 };

--- a/src/routes/onboarding/+page.svelte
+++ b/src/routes/onboarding/+page.svelte
@@ -3,6 +3,12 @@
 	import WizardShell from '$lib/components/WizardShell.svelte';
 	import DomainPicker from '$lib/components/DomainPicker.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
+	import {
+		missingProviderTitle,
+		noDomainsBody,
+		noDomainsTitle,
+		onboardingSubtitle
+	} from '$lib/provider-copy';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -88,7 +94,7 @@
 <WizardShell
 	title={needsDomain ? 'Connect a domain' : 'Claim your address'}
 	subtitle={needsDomain
-		? 'Pick the domains from your Resend account that you want in this dashboard.'
+		? onboardingSubtitle(data.providerKind)
 		: "Choose the address you'll send and receive mail from."}
 >
 	{#if needsDomain}
@@ -100,12 +106,12 @@
 					<p class="notice-body">No domain has been connected yet. Ask an admin to finish setup.</p>
 				</div>
 			</div>
-		{:else if !data.resendConfigured || data.loadError}
+		{:else if !data.providerConfigured || data.loadError}
 			<div class="surface-lg notice notice-warn">
-				<Icon name={data.resendConfigured ? 'error-warning-line' : 'key-2-line'} size={18} />
+				<Icon name={data.providerConfigured ? 'error-warning-line' : 'key-2-line'} size={18} />
 				<div>
 					<p class="notice-title">
-						{data.resendConfigured ? "Couldn't load your domains" : 'Resend API key missing'}
+						{data.providerConfigured ? "Couldn't load your domains" : missingProviderTitle(data.providerKind)}
 					</p>
 					<p class="notice-body">{data.loadError}</p>
 				</div>
@@ -114,9 +120,9 @@
 			<div class="surface-lg notice">
 				<Icon name="global-line" size={18} />
 				<div>
-					<p class="notice-title">No domains in this Resend account</p>
+					<p class="notice-title">{noDomainsTitle(data.providerKind)}</p>
 					<p class="notice-body">
-						Add and verify a domain at resend.com/domains, then reload this page.
+						{noDomainsBody(data.providerKind)}
 					</p>
 				</div>
 			</div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -179,7 +179,7 @@
 		{#if selectedDomain && !selectedDomain.receiving_enabled}
 			<p class="hint">
 				<Icon name="information-line" size={14} />
-				Receiving isn't enabled on {selectedDomain.name} in Resend — this address can send but won't
+				Receiving isn't enabled on {selectedDomain.name} — this address can send but won't
 				receive.
 			</p>
 		{/if}

--- a/src/routes/setup/+page.server.ts
+++ b/src/routes/setup/+page.server.ts
@@ -1,37 +1,35 @@
 import type { PageServerLoad } from './$types';
-import { ConfigError, getResendClient } from '$lib/server/context';
-import { isDomainReceivable, isDomainSendable, ResendError } from '$lib/server/resend';
+import {
+	ConfigError,
+	safeEmailProviderKind,
+	hasProviderConfigured,
+	listAvailableDomains,
+	providerLoadError
+} from '$lib/server/context';
 import type { AvailableDomain } from '$lib/types';
 
 /**
- * Loads the domains this Resend key can reach so the first screen is a domain
- * choice rather than a form. Only reachable while the app has no users — the
- * hook redirects away once setup is done.
+ * Loads the domains the configured provider can reach so the first screen is a
+ * domain choice rather than a form. Only reachable while the app has no users
+ * — the hook redirects away once setup is done.
  */
 export const load: PageServerLoad = async ({ platform }) => {
+	const providerKind = safeEmailProviderKind(platform);
+
 	try {
-		const client = getResendClient(platform);
-		const remote = await client.listDomains();
-
-		const available: AvailableDomain[] = remote.map((domain) => ({
-			id: domain.id,
-			name: domain.name,
-			status: domain.status,
-			region: domain.region ?? null,
-			can_send: isDomainSendable(domain),
-			can_receive: isDomainReceivable(domain),
-			connected: false
-		}));
-
-		return { available, resendConfigured: true, loadError: null };
+		const available = await listAvailableDomains(platform);
+		return {
+			available,
+			providerKind,
+			providerConfigured: true,
+			loadError: null
+		};
 	} catch (error) {
 		return {
 			available: [] as AvailableDomain[],
-			resendConfigured: !(error instanceof ConfigError),
-			loadError:
-				error instanceof ConfigError || error instanceof ResendError
-					? error.message
-					: 'Could not reach Resend. Check the API key and try again.'
+			providerKind,
+			providerConfigured: !(error instanceof ConfigError) && hasProviderConfigured(platform),
+			loadError: providerLoadError(providerKind, error)
 		};
 	}
 };

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -3,6 +3,14 @@
 	import WizardShell from '$lib/components/WizardShell.svelte';
 	import DomainPicker from '$lib/components/DomainPicker.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
+	import {
+		domainPickerSubtitle,
+		missingProviderHint,
+		missingProviderTitle,
+		noDomainsBody,
+		noDomainsTitle,
+		receivingHint
+	} from '$lib/provider-copy';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -78,19 +86,19 @@
 <WizardShell
 	title={step === 1 ? 'Choose your domain' : 'Create your account'}
 	subtitle={step === 1
-		? 'These are the domains your Resend account can send and receive on. Pick the one you want to use — you can add more later.'
+		? domainPickerSubtitle(data.providerKind)
 		: `You'll send and receive on ${chosen?.name}.`}
 	steps={['Domain', 'Account']}
 	current={step}
 >
 	{#if step === 1}
-		{#if !data.resendConfigured}
+		{#if !data.providerConfigured}
 			<div class="surface-lg notice notice-warn">
 				<Icon name="key-2-line" size={18} />
 				<div>
-					<p class="notice-title">Resend API key missing</p>
+					<p class="notice-title">{missingProviderTitle(data.providerKind)}</p>
 					<p class="notice-body">{data.loadError}</p>
-					<pre class="snippet">wrangler secret put RESEND_API_KEY</pre>
+					<pre class="snippet">{missingProviderHint(data.providerKind)}</pre>
 				</div>
 			</div>
 		{:else if data.loadError}
@@ -105,9 +113,9 @@
 			<div class="surface-lg notice">
 				<Icon name="global-line" size={18} />
 				<div>
-					<p class="notice-title">No domains in this Resend account</p>
+					<p class="notice-title">{noDomainsTitle(data.providerKind)}</p>
 					<p class="notice-body">
-						Add and verify a domain at resend.com/domains, then reload this page.
+						{noDomainsBody(data.providerKind)}
 					</p>
 				</div>
 			</div>
@@ -172,8 +180,7 @@
 			{#if chosen && !chosen.can_receive}
 				<p class="hint">
 					<Icon name="information-line" size={14} />
-					Receiving isn't enabled on {chosen.name} yet — you can send, but inbound mail won't arrive
-					until you add the MX record in Resend.
+					{receivingHint(data.providerKind, chosen.name)}
 				</p>
 			{/if}
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,42 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+import {
+	handleCloudflareInbound,
+	type CloudflareInboundEnv,
+	type CloudflareInboundMessage
+} from './lib/server/cloudflare-inbound';
+// Renamed from `_worker.js` by `scripts/wrap-cloudflare-worker.mjs` after `vite build`.
+// @ts-expect-error file is created at build time
+import sveltekit from '../.svelte-kit/cloudflare/_sveltekit.js';
+
+type SvelteKitWorker = {
+	fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> | Response;
+};
+
+const svelteApp = sveltekit as SvelteKitWorker;
+
+/**
+ * SvelteKit's generated Worker is fetch-only. This wrapper keeps HTTP on
+ * SvelteKit and adds Cloudflare Email Service's `email()` handler.
+ */
+export default {
+	fetch(request: Request, env: Env, ctx: ExecutionContext) {
+		if (typeof svelteApp.fetch !== 'function') {
+			throw new Error('SvelteKit worker export is missing fetch');
+		}
+		return svelteApp.fetch(request, env, ctx);
+	},
+
+	async email(message: CloudflareInboundMessage, env: Env) {
+		if (env.EMAIL_PROVIDER?.trim().toLowerCase() !== 'cloudflare') {
+			message.setReject('Cloudflare email provider is not enabled');
+			return;
+		}
+
+		const inboundEnv: CloudflareInboundEnv = {
+			DB: env.DB,
+			ATTACHMENTS: env.ATTACHMENTS
+		};
+
+		await handleCloudflareInbound(message, inboundEnv);
+	}
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,10 +26,24 @@
 		"binding": "ASSETS"
 	},
 
-	// Sending and receiving both go through Resend. Two secrets are required:
+	// Mail provider is selected by EMAIL_PROVIDER (resend | cloudflare).
+	// Resend secrets (when EMAIL_PROVIDER=resend or unset):
 	//   wrangler secret put RESEND_API_KEY
 	//   wrangler secret put RESEND_WEBHOOK_SECRET
-	// Locally, put the same values in .dev.vars (copy .dev.vars.example).
+	// Cloudflare Email uses the send_email binding below plus CLOUDFLARE_MAIL_DOMAINS.
+	// Locally, put values in .dev.vars (copy .dev.vars.example).
+
+	"vars": {
+		"EMAIL_PROVIDER": "resend"
+		// "CLOUDFLARE_MAIL_DOMAINS": "example.com"
+	},
+
+	"send_email": [
+		{
+			"name": "EMAIL",
+			"remote": true
+		}
+	],
 
 	"d1_databases": [
 		{


### PR DESCRIPTION
## Summary
- Add an `EmailProvider` adapter so a deploy uses either Resend (default) or Cloudflare Email Service, selected with `EMAIL_PROVIDER`.
- Cloudflare outbound goes through `env.EMAIL.send()`; inbound uses a Worker `email()` handler (SvelteKit build wrap + `postal-mime`) and the same D1/R2 routing as Resend.
- Rewrite the README as a setup guide: pick a provider, shared D1/R2 steps, Resend vs Cloudflare tracks, Wrangler 4.123+ for sending enable, and dashboard-only catch-all → Worker.

## Test plan
- [ ] Resend track: set `EMAIL_PROVIDER=resend`, deploy, send and receive through the existing webhook.
- [ ] Cloudflare track: `EMAIL_PROVIDER=cloudflare` + `CLOUDFLARE_MAIL_DOMAINS`, Email Sending/Routing onboarded (Wrangler ≥ 4.123 or dashboard), catch-all → this Worker.
- [ ] Setup/onboarding lists domains from the configured provider and copy matches that provider.
- [ ] `bun run check` passes.
- [ ] Confirm `vite dev` does not receive Cloudflare inbound; `bun run preview` or a deploy does.


Made with [Cursor](https://cursor.com)