### PR TITLE
Fix dark-mode mail text

### DIFF
--- a/src/lib/components/AddressField.svelte
+++ b/src/lib/components/AddressField.svelte
@@ -63,6 +63,7 @@
 		flex: 1;
 		min-width: 0;
 		font-size: 0.9375rem;
+		color: var(--color-text);
 		background: transparent;
 		outline: none;
 	}

--- a/src/lib/components/RichTextEditor.svelte
+++ b/src/lib/components/RichTextEditor.svelte
@@ -109,6 +109,10 @@
 		padding: 0.375rem 0.5rem;
 	}
 
+	.editor {
+		color: var(--color-text);
+	}
+
 	.editor:empty::before {
 		content: attr(data-placeholder);
 		color: var(--color-muted);

--- a/src/lib/utils/email-html.ts
+++ b/src/lib/utils/email-html.ts
@@ -68,7 +68,8 @@ html, body { height: auto !important; }
    not enough: a frame whose colour scheme differs from its embedder's is denied
    transparency and painted in its own scheme instead, so the scheme has to be
    declared in here too — see the dark rule below. */
-html { color-scheme: light; overflow-x: auto; overflow-y: hidden; background: transparent; }
+html { overflow-x: auto; overflow-y: hidden; background: transparent; }
+html:not([data-theme='dark']) { color-scheme: light; }
 body {
 	margin: 0;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -113,7 +114,7 @@ blockquote { border-color: rgba(0, 0, 0, 0.12) !important; }
  * outrank stylesheets, hence !important.
  */
 :root[data-theme='dark'] { color-scheme: dark; }
-:root[data-theme='dark'] body { color: #a8a8b3; background-color: transparent !important; }
+:root[data-theme='dark'] body { color: #a8a8b3 !important; background-color: transparent !important; }
 :root[data-theme='dark'] body *:not(a):not(.quote-toggle) {
 	color: inherit !important;
 	background-color: transparent !important;


### PR DESCRIPTION
## Summary
- Override inline near-black mail colors in dark mode so thread messages stay readable
- Give the composer and address field an explicit theme text color so they cannot fall back to black

## Test plan
- [ ] Open a sent or inbound message in dark mode — body text should be light gray, not `#111`
- [ ] Compose a new message in dark mode — typed text should match the theme
- [ ] Designed/newsletter HTML can still sit on a white card


Made with [Cursor](https://cursor.com)