### PR TITLE
Add per-user email signatures

### DIFF
--- a/migrations/0008_email_signature.sql
+++ b/migrations/0008_email_signature.sql
@@ -1,0 +1,2 @@
+-- A short, plain-text sign-off appended to new messages and replies.
+ALTER TABLE users ADD COLUMN email_signature TEXT NOT NULL DEFAULT '';

--- a/src/lib/email-signature.test.ts
+++ b/src/lib/email-signature.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+	appendEmailSignature,
+	normalizeEmailSignature
+} from './email-signature';
+
+	describe('email signatures', () => {
+	test('normalizes line endings and trailing whitespace', () => {
+		assert.equal(
+			normalizeEmailSignature('  Best,  \r\nEmmanuel  \r\n'),
+			'Best,\nEmmanuel'
+		);
+	});
+
+	test('appends a sign-off to plain text and HTML', () => {
+		assert.deepEqual(
+			appendEmailSignature({
+				text: 'Hello there',
+				html: '<p>Hello there</p>',
+				signature: 'Best,\nEmmanuel'
+			}),
+			{
+				text: 'Hello there\n\nBest,\nEmmanuel',
+				html:
+					'<p>Hello there</p>\n<div><br></div>\n<div data-email-signature="true">Best,<br>\nEmmanuel</div>'
+			}
+		);
+	});
+
+	test('escapes signature text before adding it to HTML', () => {
+		const result = appendEmailSignature({
+			text: 'Hello',
+			html: '<p>Hello</p>',
+			signature: '<Emmanuel & Co>'
+		});
+
+		assert.match(result.html ?? '', /&lt;Emmanuel &amp; Co&gt;/);
+		assert.doesNotMatch(result.html ?? '', /<Emmanuel & Co>/);
+	});
+
+	test('leaves the message unchanged when the signature is empty', () => {
+		assert.deepEqual(
+			appendEmailSignature({ text: 'Hello', html: '<p>Hello</p>', signature: '   ' }),
+			{ text: 'Hello', html: '<p>Hello</p>' }
+		);
+	});
+});

--- a/src/lib/email-signature.ts
+++ b/src/lib/email-signature.ts
@@ -1,0 +1,37 @@
+export const MAX_EMAIL_SIGNATURE_LENGTH = 1000;
+
+/** Keep intentional line breaks while removing transport and trailing whitespace noise. */
+export function normalizeEmailSignature(value: string): string {
+	return value
+		.replace(/\r\n?/g, '\n')
+		.split('\n')
+		.map((line) => line.trimEnd())
+		.join('\n')
+		.trim();
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&#39;');
+}
+
+/** Append the configured sign-off to both MIME alternatives exactly once at send time. */
+export function appendEmailSignature(input: {
+	text: string;
+	html: string | null;
+	signature: string;
+}): { text: string; html: string | null } {
+	const signature = normalizeEmailSignature(input.signature);
+	if (!signature) return { text: input.text, html: input.html };
+
+	const text = `${input.text.trimEnd()}\n\n${signature}`;
+	const html = input.html
+		? `${input.html.trimEnd()}\n<div><br></div>\n<div data-email-signature="true">${escapeHtml(signature).replaceAll('\n', '<br>\n')}</div>`
+		: null;
+
+	return { text, html };
+}

--- a/src/lib/server/email-signature.ts
+++ b/src/lib/server/email-signature.ts
@@ -1,0 +1,25 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { normalizeEmailSignature } from '$lib/email-signature';
+
+export async function getEmailSignature(db: D1Database, userId: string): Promise<string> {
+	const row = await db
+		.prepare('SELECT email_signature FROM users WHERE id = ?')
+		.bind(userId)
+		.first<{ email_signature: string }>();
+
+	return row?.email_signature ?? '';
+}
+
+export async function updateEmailSignature(
+	db: D1Database,
+	userId: string,
+	value: string
+): Promise<string> {
+	const signature = normalizeEmailSignature(value);
+	await db
+		.prepare('UPDATE users SET email_signature = ? WHERE id = ?')
+		.bind(signature, userId)
+		.run();
+
+	return signature;
+}

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -1,12 +1,14 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 import type { MailAddress, OutboundAttachmentInput, User } from '$lib/types';
+import { appendEmailSignature } from '$lib/email-signature';
 import { base64ByteLength, insertAttachments } from './attachments';
 import { MAX_TOTAL_ATTACHMENT_BYTES } from './constants';
 import { getAddressForUser, getDefaultAddress } from './domains';
+import { getEmailSignature } from './email-signature';
 import { stripHtml } from './html';
 import { insertEmail } from './mail-store';
 import { initialOutboundStatus, type EmailProvider } from './email-provider';
-import { parseRecipients, sendOutboundEmail } from './send-mail';
+import { escapeHtml, parseRecipients, sendOutboundEmail } from './send-mail';
 
 export type ComposeInput = {
 	fromAddressId?: string | null;
@@ -52,12 +54,19 @@ export async function sendAndStore(
 	// resolveFromAddress scopes the lookup to this user, so ownership is implied.
 	const from = await resolveFromAddress(env.DB, user, input.fromAddressId);
 
-	const html = input.html?.trim() || null;
-	const text = input.text?.trim() || (html ? stripHtml(html) : '');
+	const bodyHtml = input.html?.trim() || null;
+	const bodyText = input.text?.trim() || (bodyHtml ? stripHtml(bodyHtml) : '');
 
-	if (!text && !html) {
+	// The automatic signature does not count as message content.
+	if (!bodyText && !bodyHtml) {
 		throw new Error('Message body is required');
 	}
+
+	const { text, html } = appendEmailSignature({
+		text: bodyText,
+		html: bodyHtml,
+		signature: await getEmailSignature(env.DB, user.id)
+	});
 
 	const attachments = input.attachments ?? [];
 	const totalBytes = attachments.reduce(
@@ -91,7 +100,7 @@ export async function sendAndStore(
 		bcc: parseRecipients(input.bcc).join(', ') || null,
 		subject: input.subject.trim(),
 		bodyText: text,
-		bodyHtml: html ?? text.replaceAll('\n', '<br>\n'),
+		bodyHtml: html ?? escapeHtml(text).replaceAll('\n', '<br>\n'),
 		inReplyTo: input.inReplyTo ?? null,
 		references: input.references ?? null,
 		replyToEmailId: input.replyToEmailId ?? null,

--- a/src/routes/api/settings/signature/+server.ts
+++ b/src/routes/api/settings/signature/+server.ts
@@ -1,0 +1,30 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
+import { updateEmailSignature } from '$lib/server/email-signature';
+
+export const PATCH: RequestHandler = async ({ request, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	let body: { signature?: unknown };
+	try {
+		body = (await request.json()) as { signature?: unknown };
+	} catch {
+		return json({ error: 'Invalid request' }, { status: 400 });
+	}
+
+	if (typeof body.signature !== 'string') {
+		return json({ error: 'Signature must be text' }, { status: 400 });
+	}
+	if (body.signature.length > MAX_EMAIL_SIGNATURE_LENGTH) {
+		return json(
+			{ error: `Signature must be ${MAX_EMAIL_SIGNATURE_LENGTH} characters or fewer` },
+			{ status: 400 }
+		);
+	}
+
+	const signature = await updateEmailSignature(db, locals.user.id, body.signature);
+	return json({ ok: true, signature });
+};

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,8 +1,15 @@
 import type { PageServerLoad } from './$types';
+import { getEmailSignature } from '$lib/server/email-signature';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, platform }) => {
+	const signature =
+		locals.user && platform?.env.DB
+			? await getEmailSignature(platform.env.DB, locals.user.id)
+			: '';
+
 	return {
 		domains: locals.domains,
-		addresses: locals.addresses
+		addresses: locals.addresses,
+		signature
 	};
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import Icon from '$lib/components/Icon.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
 	import {
@@ -7,6 +8,7 @@
 		THEME_OPTIONS,
 		type ThemePreference
 	} from '$lib/theme';
+	import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
 	import type { MailAddress } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -21,6 +23,38 @@
 	function chooseTheme(next: ThemePreference) {
 		theme = next;
 		setThemePreference(next);
+	}
+
+	let signature = $state(untrack(() => data.signature));
+	let signatureBusy = $state(false);
+	let signatureError = $state('');
+	let signatureSaved = $state(false);
+
+	async function saveSignature(event: SubmitEvent) {
+		event.preventDefault();
+		signatureBusy = true;
+		signatureError = '';
+		signatureSaved = false;
+
+		try {
+			const res = await fetch('/api/settings/signature', {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ signature })
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				signatureError = body.error ?? 'Could not save signature';
+				return;
+			}
+
+			signature = body.signature;
+			signatureSaved = true;
+		} catch {
+			signatureError = 'Network error';
+		} finally {
+			signatureBusy = false;
+		}
 	}
 
 	// Server data until an edit happens, then whatever the API returned.
@@ -122,6 +156,35 @@
 				</button>
 			{/each}
 		</div>
+	</section>
+
+	<section class="surface-lg card">
+		<h2><Icon name="pencil-line" size={18} /> Email signature</h2>
+		<p class="card-hint">
+			Add a short sign-off to new messages and replies, for example “Best, Emmanuel.”
+		</p>
+
+		<form class="signature-form" onsubmit={saveSignature}>
+			<label for="email-signature" class="field-title">Signature text</label>
+			<textarea
+				id="email-signature"
+				bind:value={signature}
+				maxlength={MAX_EMAIL_SIGNATURE_LENGTH}
+				rows="5"
+				placeholder={'Best,\nEmmanuel'}
+				class="signature-input"
+			></textarea>
+
+			<div class="signature-actions">
+				<span class="character-count">{signature.length}/{MAX_EMAIL_SIGNATURE_LENGTH}</span>
+				<button type="submit" class="btn-primary" disabled={signatureBusy}>
+					{signatureBusy ? 'Saving…' : 'Save signature'}
+				</button>
+			</div>
+
+			{#if signatureError}<p class="error">{signatureError}</p>{/if}
+			{#if signatureSaved}<p class="saved">Signature saved.</p>{/if}
+		</form>
 	</section>
 
 	<section class="surface-lg card">
@@ -233,6 +296,53 @@
 		font-size: 0.8125rem;
 		line-height: 1.5;
 		color: var(--color-muted);
+	}
+
+	.signature-form {
+		margin-top: 1rem;
+	}
+
+	.field-title {
+		display: block;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--color-text-secondary);
+	}
+
+	.signature-input {
+		width: 100%;
+		margin-top: 0.5rem;
+		padding: 0.75rem 0.875rem;
+		resize: vertical;
+		border-radius: 0.75rem;
+		font-size: 0.875rem;
+		line-height: 1.55;
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		outline: none;
+	}
+
+	.signature-input:focus {
+		box-shadow: inset 0 0 0 1px var(--color-focus-line), 0 0 0 3px var(--color-focus-halo);
+	}
+
+	.signature-actions {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		margin-top: 0.75rem;
+	}
+
+	.character-count {
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.saved {
+		margin-top: 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--tone-good-fg);
 	}
 
 	.theme-options {


### PR DESCRIPTION
## Summary

Adds configurable plain-text email signatures for QuickMail users.

Users can save a short sign-off from Settings, such as:

> Best,  
> Emmanuel

The signature is automatically appended to new messages and replies.

## What changed

- Added an `email_signature` column to users through D1 migration `0008`.
- Added an email-signature section to Settings.
- Added an authenticated API endpoint for updating the signature.
- Applied signatures through the shared outbound-mail path, covering both new messages and replies.
- Added plain-text normalization and HTML escaping.
- Added focused tests for formatting, escaping, empty signatures, and line endings.

## Behaviour

- Signatures are stored as plain text.
- Maximum length is 1,000 characters.
- An empty signature disables the feature.
- The signature is added to both text and HTML email alternatives.
- Draft content does not contain the signature; it is appended when the message is sent.
- The automatic signature does not count as message content, so a signature-only email is still rejected.
- This initial version provides one signature per user rather than one per sending address.
- The signature is applied at send time and is not currently displayed inside the composer.

## Why apply it at the outbound boundary?

Both new messages and replies use `sendAndStore()`. Applying the signature there avoids duplicating logic across composers and ensures other callers of the outbound API cannot accidentally omit it.

It also prevents signatures from being duplicated or becoming stale inside saved drafts.

## Validation

- `bun test src/lib/email-signature.test.ts` — 4 tests passed
- `bun run check` — 0 errors and 0 warnings
- `bun run build` — passed
- D1 migration applied successfully in local validation

## Follow-up possibilities

These are intentionally outside this PR’s scope:

- Different signatures per sending address
- Rich-text signatures
- Showing or editing the signature inside the composer
- Per-message signature removal