### PR TITLE
Add API keys for scripted sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,38 @@ Deploys to Cloudflare Workers.
 - **Safe HTML** — received HTML renders in a sandboxed iframe.
 - **Multiple domains and users** — each user has addresses and a default sending identity. Admins get a catch-all and an unrouted-mail view.
 - **Delivery status** — Resend reports delivered / bounced / complained over webhooks. Cloudflare marks a send `sent` once the binding accepts it.
+- **Programmatic API** — each user can issue long-lived API keys and `POST /api/mail` to send from a script, no browser or session cookie needed.
 - **Light and dark themes.**
+
+---
+
+## Send from a script (API keys)
+
+Signing in with a browser only gets you a cookie that lives seven days — fine for
+a human, awkward for automation. Any user can instead mint a long-lived API key
+under **Settings → API keys** and use it as a bearer token on the mail API. It
+acts as exactly that user on any `/api/*` endpoint.
+
+```sh
+curl https://your-worker/api/mail \
+  -H "Authorization: Bearer qm_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fromAddressId": "<optional — defaults to your send identity>",
+    "to": "you@example.com",
+    "cc": "cc@example.com",
+    "subject": "hello from a script",
+    "text": "hi"
+  }'
+```
+
+`POST /api/mail` returns `{"ok": true, "id": "<emailId>"}`. List what you sent
+with `GET /api/mail?direction=outbound`. Keys only ever authenticate `/api/*` —
+the web UI still needs a normal session — and revoking a key in Settings takes
+effect immediately.
+
+> Only the SHA-256 hash of a key is stored; the raw value is shown once at
+> creation. If you lose it, revoke and mint a new one.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Deploys to Cloudflare Workers.
 - **Safe HTML** — received HTML renders in a sandboxed iframe.
 - **Multiple domains and users** — each user has addresses and a default sending identity. Admins get a catch-all and an unrouted-mail view.
 - **Delivery status** — Resend reports delivered / bounced / complained over webhooks. Cloudflare marks a send `sent` once the binding accepts it.
-- **Programmatic API** — each user can issue long-lived API keys and `POST /api/mail` to send from a script, no browser or session cookie needed.
+- **Programmatic API** — each user can issue scoped, long-lived API keys and `POST /api/mail` to send from a script, no browser or session cookie needed.
 - **Light and dark themes.**
 
 ---
@@ -43,9 +43,14 @@ curl https://your-worker/api/mail \
 ```
 
 `POST /api/mail` returns `{"ok": true, "id": "<emailId>"}`. List what you sent
-with `GET /api/mail?direction=outbound`. Keys only ever authenticate `/api/*` —
-the web UI still needs a normal session — and revoking a key in Settings takes
-effect immediately.
+with `GET /api/mail?direction=outbound`.
+
+A key is not a session. It reaches only `/api/mail`, and only with the matching
+scope — `mail:send` to send, `mail:read` to list or read. Mailbox mutations
+(trashing, starring), key management, addresses, domains and admin all stay
+session-only, so a leaked key cannot mint a replacement that survives revoking
+the original. A key used outside that gets `403`. Revoking takes effect
+immediately.
 
 > Only the SHA-256 hash of a key is stored; the raw value is shown once at
 > creation. If you lose it, revoke and mint a new one.

--- a/migrations/0009_api_tokens.sql
+++ b/migrations/0009_api_tokens.sql
@@ -1,0 +1,26 @@
+-- API tokens: long-lived bearer credentials that let automation (scripts, CI,
+-- cron jobs) hit the mail API -- POST /api/mail to send, GET /api/mail to list --
+-- without a browser session cookie.
+--
+-- Only the SHA-256 hash of a token is stored (reusing the same derivation the
+-- session uses). The raw value is shown exactly once, at creation time, so it is
+-- gone forever if the operator loses it -- create a new one instead.
+-- `token_preview` keeps a masked fragment (first 8 + last 4 chars) purely so the
+-- list UI can tell two tokens apart. It is not secret enough to authenticate.
+-- `scopes` currently gates nothing beyond the request happening as the owning
+-- user, but is kept so future stricter per-scope authorization can be added.
+
+CREATE TABLE api_tokens (
+	id            TEXT PRIMARY KEY,
+	user_id       TEXT NOT NULL,
+	name          TEXT NOT NULL,
+	token_hash    TEXT NOT NULL,
+	token_preview TEXT NOT NULL,
+	scopes        TEXT NOT NULL DEFAULT 'mail:send',
+	created_at    TEXT NOT NULL,
+	last_used_at  TEXT,
+	FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
+CREATE INDEX idx_api_tokens_hash ON api_tokens(token_hash);

--- a/migrations/0009_api_tokens.sql
+++ b/migrations/0009_api_tokens.sql
@@ -7,14 +7,15 @@
 -- gone forever if the operator loses it -- create a new one instead.
 -- `token_preview` keeps a masked fragment (first 8 + last 4 chars) purely so the
 -- list UI can tell two tokens apart. It is not secret enough to authenticate.
--- `scopes` currently gates nothing beyond the request happening as the owning
--- user, but is kept so future stricter per-scope authorization can be added.
+-- `scopes` is enforced: `mail:send` gates the send path, `mail:read` gates reads.
+-- A key is not a session -- it only reaches the handful of routes in
+-- BEARER_ROUTES (hooks.server.ts), never key management, admin or domains.
 
 CREATE TABLE api_tokens (
 	id            TEXT PRIMARY KEY,
 	user_id       TEXT NOT NULL,
 	name          TEXT NOT NULL,
-	token_hash    TEXT NOT NULL,
+	token_hash    TEXT NOT NULL UNIQUE,
 	token_preview TEXT NOT NULL,
 	scopes        TEXT NOT NULL DEFAULT 'mail:send',
 	created_at    TEXT NOT NULL,
@@ -23,4 +24,3 @@ CREATE TABLE api_tokens (
 );
 
 CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
-CREATE INDEX idx_api_tokens_hash ON api_tokens(token_hash);

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,6 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 import type { CloudflareSendEmailBinding } from '$lib/server/providers/cloudflare-provider';
+import type { ApiScope } from '$lib/server/api-tokens';
 import type { Domain, MailAddress, User } from '$lib/types';
 
 declare global {
@@ -28,6 +29,12 @@ declare global {
 			addresses: MailAddress[];
 			/** Active domain filter, or null for the combined inbox. */
 			activeDomainId: string | null;
+			/**
+			 * Set only when the request authenticated with an API key, so handlers
+			 * can authorize without a second lookup. Null means a browser session,
+			 * which is not scope-limited.
+			 */
+			apiToken: { id: string; scopes: ApiScope[] } | null;
 		}
 	}
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,6 @@
 import { redirect, type Handle } from '@sveltejs/kit';
 import { countUsers, getUserFromSession, readSessionToken } from '$lib/server/auth';
-import { getUserByApiToken, readBearerToken } from '$lib/server/api-tokens';
+import { type ApiScope, getUserByApiToken, readBearerToken } from '$lib/server/api-tokens';
 import { DOMAIN_COOKIE } from '$lib/server/constants';
 import { listAddressesForUser, listDomains } from '$lib/server/domains';
 
@@ -10,24 +10,79 @@ function isPublicPath(pathname: string): boolean {
 	return PUBLIC_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
+/**
+ * Where an API key may go, and what scope it must carry to get there. A key is
+ * a narrow credential for scripted mail, not a portable session.
+ *
+ * Only the two documented operations are reachable -- list/read mail, and send
+ * it. Everything else stays session-only, deliberately: key management (so a
+ * leaked key cannot mint its own replacement and outlive revocation), admin,
+ * domains, addresses, settings, and every mailbox mutation. Note that trashing
+ * lives on `PATCH/DELETE /api/mail/<id>` and `POST /api/mail/actions`, so those
+ * are absent here rather than merely unscoped.
+ *
+ * First match wins; a method missing from a matched rule is refused.
+ */
+const BEARER_ROUTES: { match: RegExp; scopes: Partial<Record<string, ApiScope>> }[] = [
+	// List, and send.
+	{ match: /^\/api\/mail$/, scopes: { GET: 'mail:read', POST: 'mail:send' } },
+	// Read one message, or download one of its attachments. `actions` is
+	// excluded explicitly -- it is bulk trash/star, not a message id.
+	{
+		match: /^\/api\/mail\/(?!actions$)[^/]+(?:\/attachments\/[^/]+)?$/,
+		scopes: { GET: 'mail:read' }
+	}
+];
+
+/** The scope a bearer token needs here, or null if it may not go here at all. */
+function requiredScopeFor(pathname: string, method: string): ApiScope | null {
+	const route = BEARER_ROUTES.find((candidate) => candidate.match.test(pathname));
+	return route?.scopes[method] ?? null;
+}
+
+function jsonError(status: number, message: string): Response {
+	return new Response(JSON.stringify({ error: message }), {
+		status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
 	const db = event.platform?.env.DB;
 	event.locals.user = null;
 	event.locals.domains = [];
 	event.locals.addresses = [];
 	event.locals.activeDomainId = null;
+	// Null for browser sessions -- only a bearer-authenticated request is scoped.
+	event.locals.apiToken = null;
 
 	const { pathname } = event.url;
 
 	if (db) {
 		// Browser sessions first; then, for API calls, a long-lived bearer token
 		// (generated under Settings → API keys) so scripts can authenticate
-		// without a session cookie. A bearer token is only honoured on /api/*.
+		// without a session cookie.
 		const token = readSessionToken(event.cookies);
 		event.locals.user = await getUserFromSession(db, token);
+
 		if (!event.locals.user && pathname.startsWith('/api/')) {
 			const bearer = readBearerToken(event.request);
-			if (bearer) event.locals.user = await getUserByApiToken(db, bearer);
+			const identity = bearer ? await getUserByApiToken(db, bearer) : null;
+
+			if (identity) {
+				const required = requiredScopeFor(pathname, event.request.method);
+
+				// Off the allowlist entirely, or the wrong verb on a listed route.
+				if (!required) {
+					return jsonError(403, 'This endpoint requires a signed-in session');
+				}
+				if (!identity.scopes.includes(required)) {
+					return jsonError(403, `This API key is missing the ${required} scope`);
+				}
+
+				event.locals.user = identity.user;
+				event.locals.apiToken = { id: identity.tokenId, scopes: identity.scopes };
+			}
 		}
 	}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { redirect, type Handle } from '@sveltejs/kit';
 import { countUsers, getUserFromSession, readSessionToken } from '$lib/server/auth';
+import { getUserByApiToken, readBearerToken } from '$lib/server/api-tokens';
 import { DOMAIN_COOKIE } from '$lib/server/constants';
 import { listAddressesForUser, listDomains } from '$lib/server/domains';
 
@@ -16,12 +17,19 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.addresses = [];
 	event.locals.activeDomainId = null;
 
+	const { pathname } = event.url;
+
 	if (db) {
+		// Browser sessions first; then, for API calls, a long-lived bearer token
+		// (generated under Settings → API keys) so scripts can authenticate
+		// without a session cookie. A bearer token is only honoured on /api/*.
 		const token = readSessionToken(event.cookies);
 		event.locals.user = await getUserFromSession(db, token);
+		if (!event.locals.user && pathname.startsWith('/api/')) {
+			const bearer = readBearerToken(event.request);
+			if (bearer) event.locals.user = await getUserByApiToken(db, bearer);
+		}
 	}
-
-	const { pathname } = event.url;
 
 	// Webhooks authenticate with a signature, not a session.
 	if (pathname.startsWith('/api/webhooks/')) {

--- a/src/lib/server/api-tokens.ts
+++ b/src/lib/server/api-tokens.ts
@@ -1,0 +1,174 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { hashToken } from './crypto';
+import type { ApiTokenSummary, User } from '$lib/types';
+
+/** Scopes a token can carry. For now every scope acts as the owning user. */
+export const API_SCOPES = ['mail:send', 'mail:read'] as const;
+export type ApiScope = (typeof API_SCOPES)[number];
+
+type TokenRow = {
+	id: string;
+	user_id: string;
+	name: string;
+	token_preview: string;
+	scopes: string;
+	created_at: string;
+	last_used_at: string | null;
+};
+
+/** A freshly minted token: the raw value (shown once) plus its stored summary. */
+export type CreatedApiToken = {
+	token: string;
+	summary: ApiTokenSummary;
+};
+
+export function isValidScope(scopes: unknown): scopes is ApiScope[] {
+	return (
+		Array.isArray(scopes) &&
+		scopes.length > 0 &&
+		scopes.every((scope) => API_SCOPES.includes(scope as ApiScope))
+	);
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** `qm_live_<32 random bytes, base64url>` — recognizable and collision-resistant. */
+function generateToken(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(32));
+	return `qm_live_${toBase64Url(bytes)}`;
+}
+
+/** A masked fragment (first 8 + last 4 chars) to tell tokens apart in the UI. */
+function previewFor(token: string): string {
+	return token.length > 14 ? `${token.slice(0, 8)}…${token.slice(-4)}` : token.slice(0, 8);
+}
+
+function mapRow(row: TokenRow): ApiTokenSummary {
+	return {
+		id: row.id,
+		name: row.name,
+		preview: row.token_preview,
+		scopes: (row.scopes.split(',') as ApiScope[]).filter((scope) =>
+			API_SCOPES.includes(scope)
+		),
+		created_at: row.created_at,
+		last_used_at: row.last_used_at
+	};
+}
+
+export async function createApiToken(
+	db: D1Database,
+	userId: string,
+	options: { name?: string; scopes?: ApiScope[] } = {}
+): Promise<CreatedApiToken> {
+	const token = generateToken();
+	const hash = await hashToken(token);
+	const id = crypto.randomUUID();
+	const scopes: ApiScope[] = options.scopes?.length ? options.scopes : ['mail:send'];
+	const name = (options.name ?? '').trim().slice(0, 60) || 'Default';
+	const createdAt = new Date().toISOString();
+
+	await db
+		.prepare(
+			`INSERT INTO api_tokens (id, user_id, name, token_hash, token_preview, scopes, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		)
+		.bind(id, userId, name, hash, previewFor(token), scopes.join(','), createdAt)
+		.run();
+
+	return {
+		token,
+		summary: {
+			id,
+			name,
+			preview: previewFor(token),
+			scopes,
+			created_at: createdAt,
+			last_used_at: null
+		}
+	};
+}
+
+export async function listApiTokens(db: D1Database, userId: string): Promise<ApiTokenSummary[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, user_id, name, token_preview, scopes, created_at, last_used_at
+			 FROM api_tokens WHERE user_id = ? ORDER BY created_at DESC`
+		)
+		.bind(userId)
+		.all<TokenRow>();
+	return results.map(mapRow);
+}
+
+export async function revokeApiToken(
+	db: D1Database,
+	userId: string,
+	tokenId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM api_tokens WHERE id = ? AND user_id = ?')
+		.bind(tokenId, userId)
+		.run();
+	return Boolean(result.meta.changes > 0);
+}
+
+type TokenUserRow = {
+	id: string;
+	email: string;
+	name: string;
+	is_admin: number;
+	created_at: string;
+	token_id: string;
+};
+
+/**
+ * Resolve a bearer token to its owning user. A session-independent login that
+ * scripts can use: it never rolls over and can be revoked by deleting the token.
+ * Returns null when the token is unknown or already deleted.
+ */
+export async function getUserByApiToken(
+	db: D1Database,
+	token: string
+): Promise<(User & { tokenId: string }) | null> {
+	if (!token.startsWith('qm_live_')) return null;
+	const hash = await hashToken(token);
+
+	const row = await db
+		.prepare(
+			`SELECT u.id, u.email, u.name, u.is_admin, u.created_at, t.id AS token_id
+			 FROM api_tokens t
+			 JOIN users u ON u.id = t.user_id
+			 WHERE t.token_hash = ?`
+		)
+		.bind(hash)
+		.first<TokenUserRow>();
+
+	if (!row) return null;
+
+	// Refresh the last-use marker opportunistically; a missed update is harmless.
+	await db
+		.prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
+		.bind(new Date().toISOString(), row.token_id)
+		.run();
+
+	return {
+		id: row.id,
+		email: row.email,
+		name: row.name,
+		is_admin: row.is_admin === 1,
+		created_at: row.created_at,
+		tokenId: row.token_id
+	};
+}
+
+/** Read a `Bearer <token>` value off the Authorization header, if present. */
+export function readBearerToken(request: Request): string | null {
+	const header = request.headers.get('authorization');
+	if (!header) return null;
+	const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+	return match ? match[1].trim() : null;
+}

--- a/src/lib/server/api-tokens.ts
+++ b/src/lib/server/api-tokens.ts
@@ -2,9 +2,17 @@ import type { D1Database } from '@cloudflare/workers-types';
 import { hashToken } from './crypto';
 import type { ApiTokenSummary, User } from '$lib/types';
 
-/** Scopes a token can carry. For now every scope acts as the owning user. */
+/** Scopes a token can carry. Both are enforced -- see `tokenAllows`. */
 export const API_SCOPES = ['mail:send', 'mail:read'] as const;
 export type ApiScope = (typeof API_SCOPES)[number];
+
+const TOKEN_PREFIX = 'qm_live_';
+
+/**
+ * How stale `last_used_at` is allowed to get. Without this every scripted send
+ * costs a second D1 write purely for a timestamp nobody reads that precisely.
+ */
+const LAST_USED_THROTTLE_MS = 15 * 60 * 1000;
 
 type TokenRow = {
 	id: string;
@@ -39,12 +47,22 @@ function toBase64Url(bytes: Uint8Array): string {
 /** `qm_live_<32 random bytes, base64url>` — recognizable and collision-resistant. */
 function generateToken(): string {
 	const bytes = crypto.getRandomValues(new Uint8Array(32));
-	return `qm_live_${toBase64Url(bytes)}`;
+	return `${TOKEN_PREFIX}${toBase64Url(bytes)}`;
 }
 
-/** A masked fragment (first 8 + last 4 chars) to tell tokens apart in the UI. */
+/**
+ * A masked fragment used to tell keys apart in the list. Taken from the random
+ * part only -- every token starts with the same prefix, so including it made
+ * every preview look identical.
+ */
 function previewFor(token: string): string {
-	return token.length > 14 ? `${token.slice(0, 8)}…${token.slice(-4)}` : token.slice(0, 8);
+	const random = token.startsWith(TOKEN_PREFIX) ? token.slice(TOKEN_PREFIX.length) : token;
+	if (random.length <= 8) return random;
+	return `${random.slice(0, 4)}…${random.slice(-4)}`;
+}
+
+function parseScopes(raw: string): ApiScope[] {
+	return (raw.split(',') as ApiScope[]).filter((scope) => API_SCOPES.includes(scope));
 }
 
 function mapRow(row: TokenRow): ApiTokenSummary {
@@ -52,9 +70,7 @@ function mapRow(row: TokenRow): ApiTokenSummary {
 		id: row.id,
 		name: row.name,
 		preview: row.token_preview,
-		scopes: (row.scopes.split(',') as ApiScope[]).filter((scope) =>
-			API_SCOPES.includes(scope)
-		),
+		scopes: parseScopes(row.scopes),
 		created_at: row.created_at,
 		last_used_at: row.last_used_at
 	};
@@ -123,7 +139,23 @@ type TokenUserRow = {
 	is_admin: number;
 	created_at: string;
 	token_id: string;
+	token_scopes: string;
+	token_last_used_at: string | null;
 };
+
+/** What a verified bearer token resolves to: who, plus what it may do. */
+export type ApiTokenIdentity = {
+	user: User;
+	tokenId: string;
+	scopes: ApiScope[];
+};
+
+/** Does this request's credential carry the scope a route requires? */
+export function tokenAllows(scopes: ApiScope[] | null, required: ApiScope): boolean {
+	// A browser session has no token and is not scope-limited.
+	if (scopes === null) return true;
+	return scopes.includes(required);
+}
 
 /**
  * Resolve a bearer token to its owning user. A session-independent login that
@@ -133,13 +165,15 @@ type TokenUserRow = {
 export async function getUserByApiToken(
 	db: D1Database,
 	token: string
-): Promise<(User & { tokenId: string }) | null> {
-	if (!token.startsWith('qm_live_')) return null;
+): Promise<ApiTokenIdentity | null> {
+	if (!token.startsWith(TOKEN_PREFIX)) return null;
 	const hash = await hashToken(token);
 
 	const row = await db
 		.prepare(
-			`SELECT u.id, u.email, u.name, u.is_admin, u.created_at, t.id AS token_id
+			`SELECT u.id, u.email, u.name, u.is_admin, u.created_at,
+			        t.id AS token_id, t.scopes AS token_scopes,
+			        t.last_used_at AS token_last_used_at
 			 FROM api_tokens t
 			 JOIN users u ON u.id = t.user_id
 			 WHERE t.token_hash = ?`
@@ -149,19 +183,26 @@ export async function getUserByApiToken(
 
 	if (!row) return null;
 
-	// Refresh the last-use marker opportunistically; a missed update is harmless.
-	await db
-		.prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
-		.bind(new Date().toISOString(), row.token_id)
-		.run();
+	// Only refresh the marker once it has actually gone stale. A scripted sender
+	// hits this on every request, and the timestamp is not read at that precision.
+	const lastUsed = row.token_last_used_at ? Date.parse(row.token_last_used_at) : 0;
+	if (!Number.isFinite(lastUsed) || Date.now() - lastUsed > LAST_USED_THROTTLE_MS) {
+		await db
+			.prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
+			.bind(new Date().toISOString(), row.token_id)
+			.run();
+	}
 
 	return {
-		id: row.id,
-		email: row.email,
-		name: row.name,
-		is_admin: row.is_admin === 1,
-		created_at: row.created_at,
-		tokenId: row.token_id
+		user: {
+			id: row.id,
+			email: row.email,
+			name: row.name,
+			is_admin: row.is_admin === 1,
+			created_at: row.created_at
+		},
+		tokenId: row.token_id,
+		scopes: parseScopes(row.token_scopes)
 	};
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,20 @@ export type User = {
 	created_at: string;
 };
 
+/**
+ * A stored API token used for scripted access to the mail API. Everything but
+ * the raw value — which is shown exactly once at creation and only ever kept as
+ * a SHA-256 hash. `preview` is a masked fragment for the UI.
+ */
+export type ApiTokenSummary = {
+	id: string;
+	name: string;
+	preview: string;
+	scopes: ('mail:send' | 'mail:read')[];
+	created_at: string;
+	last_used_at: string | null;
+};
+
 export type DeliveryStatus =
 	| 'queued'
 	| 'sent'

--- a/src/routes/api/apikeys/+server.ts
+++ b/src/routes/api/apikeys/+server.ts
@@ -6,6 +6,12 @@ export const GET: RequestHandler = async ({ locals, platform }) => {
 	if (!db || !locals.user) {
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
+	// Belt and braces: the hook already keeps bearer tokens off this route, but a
+	// key must never be able to mint or revoke keys even if that list changes.
+	if (locals.apiToken) {
+		return json({ error: 'Key management requires a signed-in session' }, { status: 403 });
+	}
+
 	return json({ tokens: await listApiTokens(db, locals.user.id) });
 };
 
@@ -18,6 +24,12 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	const db = platform?.env.DB;
 	if (!db || !locals.user) {
 		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	// Belt and braces: the hook already keeps bearer tokens off this route, but a
+	// key must never be able to mint or revoke keys even if that list changes.
+	if (locals.apiToken) {
+		return json({ error: 'Key management requires a signed-in session' }, { status: 403 });
 	}
 
 	const body = (await request.json().catch(() => null)) as CreateTokenBody | null;

--- a/src/routes/api/apikeys/+server.ts
+++ b/src/routes/api/apikeys/+server.ts
@@ -1,0 +1,36 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { createApiToken, isValidScope, listApiTokens, type ApiScope } from '$lib/server/api-tokens';
+
+export const GET: RequestHandler = async ({ locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+	return json({ tokens: await listApiTokens(db, locals.user.id) });
+};
+
+type CreateTokenBody = {
+	name?: string;
+	scopes?: ApiScope[];
+};
+
+export const POST: RequestHandler = async ({ request, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const body = (await request.json().catch(() => null)) as CreateTokenBody | null;
+	const scopes = body?.scopes ?? [];
+	if (body && !isValidScope(scopes)) {
+		return json({ error: 'Scopes must be a subset of mail:send, mail:read' }, { status: 400 });
+	}
+
+	const created = await createApiToken(db, locals.user.id, {
+		name: body?.name,
+		scopes: scopes.length ? scopes : undefined
+	});
+
+	// The raw token is only ever returned here — the table stores just its hash.
+	return json({ ok: true, token: created.token, tokenMeta: created.summary }, { status: 201 });
+};

--- a/src/routes/api/apikeys/[id]/+server.ts
+++ b/src/routes/api/apikeys/[id]/+server.ts
@@ -1,0 +1,16 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { listApiTokens, revokeApiToken } from '$lib/server/api-tokens';
+
+export const DELETE: RequestHandler = async ({ locals, platform, params }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const removed = await revokeApiToken(db, locals.user.id, params.id!);
+	if (!removed) {
+		return json({ error: 'Token not found' }, { status: 404 });
+	}
+
+	return json({ ok: true, tokens: await listApiTokens(db, locals.user.id) });
+};

--- a/src/routes/api/apikeys/[id]/+server.ts
+++ b/src/routes/api/apikeys/[id]/+server.ts
@@ -7,6 +7,12 @@ export const DELETE: RequestHandler = async ({ locals, platform, params }) => {
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
+	// Belt and braces: the hook already keeps bearer tokens off this route, but a
+	// key must never be able to mint or revoke keys even if that list changes.
+	if (locals.apiToken) {
+		return json({ error: 'Key management requires a signed-in session' }, { status: 403 });
+	}
+
 	const removed = await revokeApiToken(db, locals.user.id, params.id!);
 	if (!removed) {
 		return json({ error: 'Token not found' }, { status: 404 });

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,15 +1,15 @@
 import type { PageServerLoad } from './$types';
 import { getEmailSignature } from '$lib/server/email-signature';
+import { listApiTokens } from '$lib/server/api-tokens';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
-	const signature =
-		locals.user && platform?.env.DB
-			? await getEmailSignature(platform.env.DB, locals.user.id)
-			: '';
+	const db = platform?.env.DB;
+	const signature = locals.user && db ? await getEmailSignature(db, locals.user.id) : '';
 
 	return {
 		domains: locals.domains,
 		addresses: locals.addresses,
-		signature
+		signature,
+		apiTokens: db && locals.user ? await listApiTokens(db, locals.user.id) : []
 	};
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -364,11 +364,11 @@
 			</div>
 
 			<div class="scope-row">
-				<label class="scope-check">
+				<label class="scope-check" title="Send mail — POST /api/mail">
 					<input type="checkbox" bind:checked={sendScope} />
 					<span>send</span>
 				</label>
-				<label class="scope-check">
+				<label class="scope-check" title="List and read mail — GET /api/mail">
 					<input type="checkbox" bind:checked={readScope} />
 					<span>read</span>
 				</label>
@@ -410,9 +410,10 @@
 
 		<p class="hint">
 			<Icon name="shield-keyhole-line" size={14} />
-			Send this with <code>Authorization: Bearer <em>your-key</em></code> on any
-			<code>/api/*</code> request. Revoking deletes the key immediately; scripts using it will
-			get <code>401 Unauthorized</code>.
+			Send this as <code>Authorization: Bearer <em>your-key</em></code>. Keys reach only
+			<code>/api/mail</code> — sending needs <code>send</code>, reading needs
+			<code>read</code>. Everything else, including this page, stays session-only. Revoking
+			takes effect immediately.
 		</p>
 	</section>
 </div>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -9,7 +9,7 @@
 		type ThemePreference
 	} from '$lib/theme';
 	import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
-	import type { MailAddress } from '$lib/types';
+	import type { ApiTokenSummary, MailAddress } from '$lib/types';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -117,6 +117,88 @@
 			return;
 		}
 		edited = body.addresses;
+	}
+
+	// --- API keys -----------------------------------------------------------
+
+	let keyName = $state('');
+	let sendScope = $state(true);
+	let readScope = $state(false);
+	// Server-seeded list of stored keys (no raw values — those are shown once).
+	let tokens = $state<ApiTokenSummary[]>([]);
+	let hydrated = $state(false);
+	$effect(() => {
+		if (!hydrated) {
+			tokens = data.apiTokens;
+			hydrated = true;
+		}
+	});
+	let keyBusy = $state(false);
+	let keyError = $state('');
+
+	// The freshly created raw token, only ever shown once, in a confirmation box.
+	let revealed = $state<{ summary: ApiTokenSummary; token: string } | null>(null);
+	let copied = $state(false);
+
+	async function createKey(event?: SubmitEvent) {
+		if (event) event.preventDefault();
+		keyBusy = true;
+		keyError = '';
+		try {
+			const scopes = [];
+			if (sendScope) scopes.push('mail:send');
+			if (readScope) scopes.push('mail:read');
+
+			const res = await fetch('/api/apikeys', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: keyName, scopes })
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				keyError = body.error ?? 'Could not create the API key';
+				return;
+			}
+			tokens = [body.tokenMeta, ...tokens.filter((token) => token.id !== body.tokenMeta.id)];
+			revealed = { summary: body.tokenMeta, token: body.token };
+			copied = false;
+			keyName = '';
+		} catch {
+			keyError = 'Network error';
+		} finally {
+			keyBusy = false;
+		}
+	}
+
+	async function copyKey() {
+		if (!revealed) return;
+		try {
+			await navigator.clipboard.writeText(revealed.token);
+			copied = true;
+			setTimeout(() => (copied = false), 1600);
+		} catch {
+			/* clipboard unavailable — the box is still selectable */
+		}
+	}
+
+	function closeRevealed() {
+		revealed = null;
+		copied = false;
+	}
+
+	async function revokeKey(id: string) {
+		if (!confirm('Revoke this API key? Anything using it will stop working.')) return;
+		const res = await fetch(`/api/apikeys/${id}`, { method: 'DELETE' });
+		const body = await res.json();
+		if (!res.ok) {
+			keyError = body.error ?? 'Could not revoke that key';
+			return;
+		}
+		tokens = body.tokens;
+	}
+
+	function formatDate(value: string): string {
+		return new Date(value).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
 	}
 </script>
 
@@ -265,7 +347,116 @@
 			{/each}
 		</ul>
 	</section>
+
+	<section class="surface-lg card">
+		<h2><Icon name="key-2-line" size={18} /> API keys</h2>
+		<p class="card-hint">
+			Long-lived bearer tokens for scripted access to the mail API — send with
+			<code>POST /api/mail</code>, list with <code>GET /api/mail?direction=outbound</code> — for
+			the address below. A key is shown once when created; keep it somewhere safe.
+		</p>
+
+		<form class="key-form" onsubmit={createKey}>
+			<div class="key-field">
+				<label class="sr-only" for="apikey-name">Key name</label>
+				<input
+					id="apikey-name"
+					class="text-input"
+					placeholder="Name (e.g. my-cron-job)"
+					value={keyName}
+					oninput={(event) => (keyName = event.currentTarget.value)}
+				/>
+			</div>
+
+			<div class="scope-row">
+				<label class="scope-check">
+					<input type="checkbox" bind:checked={sendScope} />
+					<span>send</span>
+				</label>
+				<label class="scope-check">
+					<input type="checkbox" bind:checked={readScope} />
+					<span>read</span>
+				</label>
+			</div>
+
+			<button type="submit" class="btn-primary" disabled={keyBusy || (!sendScope && !readScope)}>
+				{keyBusy ? 'Creating…' : 'Generate key'}
+			</button>
+		</form>
+
+		{#if keyError}<p class="error">{keyError}</p>{/if}
+
+		{#if tokens.length}
+			<ul class="key-list">
+				{#each tokens as token (token.id)}
+					<li class="key-row">
+						<div class="min-w-0 flex-1">
+							<p class="key-name">{token.name}</p>
+							<p class="key-meta">
+								<code>{token.preview}</code>
+								<span class="caps">
+									{#each token.scopes as scope (scope)}<span class="chip">{scope}</span>{/each}
+								</span>
+							</p>
+						</div>
+						<span class="key-created">{formatDate(token.created_at)}</span>
+						<button
+							type="button"
+							class="icon-btn"
+							aria-label="Revoke {token.name}"
+							onclick={() => revokeKey(token.id)}
+						>
+							<Icon name="delete-bin-line" size={15} />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+
+		<p class="hint">
+			<Icon name="shield-keyhole-line" size={14} />
+			Send this with <code>Authorization: Bearer <em>your-key</em></code> on any
+			<code>/api/*</code> request. Revoking deletes the key immediately; scripts using it will
+			get <code>401 Unauthorized</code>.
+		</p>
+	</section>
 </div>
+
+{#if revealed}
+	<div
+		class="modal-backdrop"
+		role="presentation"
+		tabindex="-1"
+		onclick={(event) => {
+			if (event.target === event.currentTarget) closeRevealed();
+		}}
+		onkeydown={(event) => {
+			if (event.key === 'Escape') closeRevealed();
+		}}
+	>
+		<div
+			class="reveal-card"
+			role="dialog"
+			aria-modal="true"
+			aria-label="New API key"
+			tabindex="-1"
+		>
+			<h3><Icon name="key-2-line" size={16} /> New API key — copy it now</h3>
+			<p class="card-hint">
+				<strong>{revealed.summary.name}</strong> was created. It can't be shown again — if you
+				lose it, revoke and make a new one.
+			</p>
+			<pre class="token-box">{revealed.token}</pre>
+			<div class="reveal-actions">
+				<button type="button" class="btn-primary" onclick={copyKey}>
+					<Icon name={copied ? 'check-line' : 'copy-line'} size={15} />
+					{copied ? 'Copied' : 'Copy key'}
+				</button>
+				<button type="button" class="btn-ghost" onclick={closeRevealed}>Done</button>
+			</div>
+		</div>
+	</div>
+{/if}
 
 <style>
 	.settings-page {
@@ -566,5 +757,150 @@
 		margin-top: 0.75rem;
 		font-size: 0.8125rem;
 		color: var(--color-danger);
+	}
+
+	.key-form {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		flex-wrap: wrap;
+		margin-top: 1rem;
+	}
+
+	.key-field {
+		flex: 1;
+		min-width: 12rem;
+	}
+
+	.text-input {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border-radius: 0.625rem;
+		font-size: 0.875rem;
+		color: var(--color-text);
+		background: var(--color-surface);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		transition: box-shadow 0.15s;
+	}
+
+	.text-input::placeholder {
+		color: var(--color-muted);
+	}
+
+	.text-input:focus {
+		outline: none;
+		box-shadow: inset 0 0 0 2px var(--color-accent);
+	}
+
+	.scope-row {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.scope-check {
+		display: flex;
+		align-items: center;
+		gap: 0.3125rem;
+		padding: 0.3125rem 0.5625rem;
+		border-radius: 0.5rem;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		cursor: pointer;
+	}
+
+	.key-list {
+		margin-top: 1.25rem;
+	}
+
+	.key-row {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.75rem 0;
+	}
+
+	.key-row + .key-row {
+		box-shadow: inset 0 1px 0 var(--color-line);
+	}
+
+	.key-name {
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+
+	.key-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.1875rem;
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.key-meta code {
+		font-size: 0.75rem;
+	}
+
+	.key-created {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 40;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		background: rgba(0, 0, 0, 0.45);
+	}
+
+	.reveal-card {
+		width: 100%;
+		max-width: 30rem;
+		padding: 1.5rem;
+		border-radius: 1rem;
+		background: var(--color-card);
+		box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+	}
+
+	.reveal-card h3 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.token-box {
+		overflow-x: auto;
+		margin-top: 1rem;
+		padding: 0.75rem;
+		border-radius: 0.625rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		word-break: break-all;
+		white-space: pre-wrap;
+		color: var(--color-text);
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+	}
+
+	.reveal-actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 1.25rem;
+	}
+
+	.reveal-actions .btn-primary,
+	.reveal-actions .btn-ghost {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.375rem;
 	}
 </style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -350,11 +350,6 @@
 
 	<section class="surface-lg card">
 		<h2><Icon name="key-2-line" size={18} /> API keys</h2>
-		<p class="card-hint">
-			Long-lived bearer tokens for scripted access to the mail API — send with
-			<code>POST /api/mail</code>, list with <code>GET /api/mail?direction=outbound</code> — for
-			the address below. A key is shown once when created; keep it somewhere safe.
-		</p>
 
 		<form class="key-form" onsubmit={createKey}>
 			<div class="key-field">
@@ -857,16 +852,16 @@
 		align-items: center;
 		justify-content: center;
 		padding: 1rem;
-		background: rgba(0, 0, 0, 0.45);
+		background: var(--color-scrim);
 	}
 
 	.reveal-card {
 		width: 100%;
 		max-width: 30rem;
 		padding: 1.5rem;
-		border-radius: 1rem;
-		background: var(--color-card);
-		box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.25);
+		border-radius: 1.25rem;
+		background: var(--color-surface);
+		box-shadow: var(--shadow-md);
 	}
 
 	.reveal-card h3 {


### PR DESCRIPTION
Signing in only gets you a session cookie that lives seven days — fine for a person, awkward for a script. This adds long-lived bearer tokens so automation can hit the mail API without a browser.

Any user mints a key under **Settings → API keys** and sends it as `Authorization: Bearer qm_live_…` on `/api/*`:

```sh
curl https://your-worker/api/mail \
  -H "Authorization: Bearer qm_live_..." \
  -H "Content-Type: application/json" \
  -d '{"to":"you@example.com","subject":"hi","text":"from a script"}'
```

## How it works

- `migrations/0008_api_tokens.sql` — new `api_tokens` table, `ON DELETE CASCADE` off `users`, indexed on `user_id` and `token_hash`.
- `src/lib/server/api-tokens.ts` — create / list / revoke, plus `getUserByApiToken`. Tokens are `qm_live_` + 32 random bytes base64url. Only the SHA-256 hash is stored, reusing the existing `hashToken` from `crypto.ts`; the raw value is returned exactly once at creation. A masked `first-8…last-4` preview is kept so the list can tell two keys apart.
- `src/hooks.server.ts` — the bearer lookup runs **only after** the session lookup misses, and **only** when `pathname.startsWith('/api/')`. The web UI still requires a normal session, so this doesn't widen browser auth.
- `src/routes/api/apikeys/` — `GET`/`POST` to list and mint, `DELETE /api/apikeys/[id]` to revoke. Revoke is scoped `WHERE id = ? AND user_id = ?`, so one user can't delete another's key.
- Settings page gains a key list, a create form, and a one-time reveal box with copy-to-clipboard.

## Notes for review

- **Scopes are stored but not enforced.** The `scopes` column and the send/read checkboxes are recorded, but a key currently acts as its owning user on any `/api/*` route — the column exists so per-scope authorization can be layered on later without another migration. Happy to either enforce them in this PR or drop the checkboxes until they mean something, whichever you prefer.
- A key can also call `/api/apikeys` and mint more keys. That's no more authority than the key already has, but say the word if you'd rather that route be session-only.
- `last_used_at` is updated opportunistically on each authenticated request; a missed write is harmless.

## Testing

- `svelte-check` — 0 errors, 0 warnings across 414 files.
- `vite build` + the Cloudflare worker wrap step — both pass.
- `scripts/check-template-clean.mjs` — clean.
- Manually: minted a key, sent through `POST /api/mail` with the bearer header, revoked it in Settings, and confirmed the same request then returns `401 Unauthorized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)