### PR TITLE
Add a domain setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ body and attachments from Resend. Cloudflare delivers the full MIME on
 
 # Setup
 
-Budget about 30 minutes. Most of it is DNS.
+The wizard installs tools, logs you into Cloudflare, creates D1/R2, writes
+env and wrangler config, and onboards your domain:
+
+```bash
+bun run setup
+# if bun isn't installed yet:
+bash scripts/setup.sh
+```
+
+It asks for the mail domain, Resend vs Cloudflare Email, and any API keys —
+then does the rest. Budget about 30 minutes; most of that is DNS.
 
 **You need**
 
@@ -51,7 +61,11 @@ Budget about 30 minutes. Most of it is DNS.
 2. A [Cloudflare](https://dash.cloudflare.com) account.
 3. Either a [Resend](https://resend.com) account, **or** the domain on Cloudflare DNS plus a Workers paid plan (Cloudflare Email Sending).
 
-## 1. Install
+## Manual setup
+
+Do this only if you cannot run the wizard.
+
+### 1. Install
 
 ```bash
 bun install          # or: npm install
@@ -62,7 +76,7 @@ Use **Wrangler 4.123 or newer** for Cloudflare Email Sending. `4.96` calls an
 old `/email/sending/enable` path and gets a 404. Check with
 `bunx wrangler --version`. Upgrade with `bun add -d wrangler@latest`.
 
-## 2. Create D1 and R2
+### 2. Create D1 and R2
 
 ```bash
 bunx wrangler d1 create quickmail
@@ -304,6 +318,7 @@ src/
     server/          providers, inbound, D1, auth
     utils/           HTML, quoting, dates, attachments
 scripts/
+  setup.sh / setup.mjs   first-run wizard (tools, login, domain, env)
   wrap-cloudflare-worker.mjs   attach email() after the SvelteKit build
 migrations/          D1 schema, applied in order
 ```

--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ bun run setup
 bash scripts/setup.sh
 ```
 
-It asks for the mail domain, Resend vs Cloudflare Email, and any API keys —
-then does the rest. Budget about 30 minutes; most of that is DNS.
+It asks for the mail domain, Resend vs Cloudflare Email, Worker / D1 / R2
+names, and any API keys — then does the rest. If `quickmail` or
+`quickmail-attachments` already exist on the account, it suggests new names
+so you do not overwrite another project. Budget about 30 minutes; most of
+that is DNS.
 
 **You need**
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,8 @@ bash scripts/setup.sh
 ```
 
 It asks for the mail domain, Resend vs Cloudflare Email, Worker / D1 / R2
-names, and any API keys — then does the rest. If `quickmail` or
-`quickmail-attachments` already exist on the account, it suggests new names
-so you do not overwrite another project. Budget about 30 minutes; most of
-that is DNS.
+names, and any API keys — then does the rest. Budget about 30 minutes; most
+of that is DNS.
 
 **You need**
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2",
         "vite": "^8.0.7",
-        "wrangler": "^4.96.0",
+        "wrangler": "^4.124.0",
       },
     },
   },
@@ -30,15 +30,15 @@
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
 
-    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260529.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-gxh5sXw0CsBxNCNj8uJnrAxqFM7+R8SZI9WIqYMKz6uaPxgg+eTcBDTxjKczMs6bS21FkTEF6ohIzB5+UvxwKw=="],
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260815.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g=="],
 
-    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260529.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B8xOwqd8ok8oaWBPhrpmNVSYou6AejFrYf3VzsJF6pg6TEA2tYbdThAGXgtLPQ8d1RD7GXYjVth2dSMg9napDA=="],
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260815.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw=="],
 
-    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260529.1", "", { "os": "linux", "cpu": "x64" }, "sha512-M1EKzsfoKmmno7MNPkuIc8iOdHLhFnE7ltEYaGGEoOj1MTJfMBK/JkIrhdkzc/06wpyPZPiBfBBmUppbeaMqUg=="],
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260815.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw=="],
 
-    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260529.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Mn/Qpl1FAHDLtPthw6ti5gsHRj582jJdtK4OMUlW1CN0v+pmmxaav3KSqq7CS6a+5W0o2e8o9fKnjVilBxVVmQ=="],
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260815.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg=="],
 
-    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260529.1", "", { "os": "win32", "cpu": "x64" }, "sha512-78xgJJeXxkKYumWdKGH1pybUsEjTreSvbJqirW9cth7ZGonqdv5pzAVt+WWcbu0OFcSHrtQFX6zWioPNFp0/xQ=="],
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260601.1", "", {}, "sha512-pYORr1EKlDu55HCHhln8XSXoOSvKAkrTkovJL66bX8xw6DAT2fhs39B6FLjCJD+x++hjBEE2bmKB1TcFKS+0Dw=="],
 
@@ -104,53 +104,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -332,7 +336,7 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "miniflare": ["miniflare@4.20260529.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.8", "workerd": "1.20260529.1", "ws": "8.20.1", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-4pj7WZQR/uYqVMa0cpAmmPBKEb0JegSocuystaXCubY455iqWdPUqgVD9R6N28oneWyPiUyAu5N8QpLbK+MU/Q=="],
+    "miniflare": ["miniflare@5.20260815.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260815.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -364,11 +368,11 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
-    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
@@ -392,7 +396,7 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -402,13 +406,13 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "workerd": ["workerd@1.20260529.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260529.1", "@cloudflare/workerd-darwin-arm64": "1.20260529.1", "@cloudflare/workerd-linux-64": "1.20260529.1", "@cloudflare/workerd-linux-arm64": "1.20260529.1", "@cloudflare/workerd-windows-64": "1.20260529.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-G1rurOKEdzCtFE0yUPR9J9mUnPzMU8NdsD7NKM1/oMyCr1j3VEtWJzc5VbhgFQHNBVWrHzCL0JgVPuBirRW31g=="],
+    "workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
 
     "worktop": ["worktop@0.8.0-next.18", "", { "dependencies": { "mrmime": "^2.0.0", "regexparam": "^3.0.0" } }, "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw=="],
 
-    "wrangler": ["wrangler@4.96.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260529.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260529.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260529.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-8WuiMutalyfBB74wwRyy4VKKJEHjQuEnwcvdUav1M5AfQ8VaTYY5ZQnzvVZPOVXap40k5Mntz1LY3SPWpPukTg=="],
+    "wrangler": ["wrangler@4.124.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260815.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260815.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260815.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog=="],
 
-    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
@@ -417,6 +421,8 @@
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -430,6 +436,60 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"dev": "vite dev",
 		"build": "vite build && bun scripts/wrap-cloudflare-worker.mjs",
 		"preview": "bun run build && wrangler dev",
+		"setup": "node scripts/setup.mjs",
 		"deploy": "bun run build && wrangler deploy",
 		"db:migrate:local": "wrangler d1 migrations apply quickmail --local",
 		"db:migrate:remote": "wrangler d1 migrations apply quickmail --remote",
@@ -30,7 +31,7 @@
 		"tailwindcss": "^4.2.2",
 		"typescript": "^6.0.2",
 		"vite": "^8.0.7",
-		"wrangler": "^4.96.0"
+		"wrangler": "^4.124.0"
 	},
 	"dependencies": {
 		"postal-mime": "^3.0.0",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -69,8 +69,8 @@ wrangler config, and onboards your mail domain.
 Options:
   --domain <name>      Mail domain (e.g. example.com)
   --provider <name>    resend | cloudflare
-  --d1-name <name>     D1 database name (default: quickmail, or unique if taken)
-  --r2-name <name>     R2 bucket name (default: quickmail-attachments, or unique if taken)
+  --d1-name <name>     D1 database name (e.g. quickmail)
+  --r2-name <name>     R2 bucket name (e.g. quickmail-attachments)
   --yes                Accept defaults (still requires --domain)
   --skip-deploy        Do not deploy at the end
   --help               Show this help
@@ -441,37 +441,6 @@ function isR2BucketName(value) {
 	);
 }
 
-function slugDomain(domain) {
-	return domain.replace(/\./g, '-').replace(/[^a-z0-9-]/g, '');
-}
-
-function uniqueName(base, taken, maxLen = 63) {
-	const takenSet = taken instanceof Set ? taken : new Set(taken);
-	const clip = (value) => {
-		let name = value.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
-		name = name.replace(/^-+/, '').replace(/-+$/, '');
-		if (name.length > maxLen) name = name.slice(0, maxLen).replace(/-+$/, '');
-		if (name.length < 3) name = `${name}db`.slice(0, maxLen);
-		return name;
-	};
-
-	let candidate = clip(base);
-	if (!takenSet.has(candidate)) return candidate;
-	for (let n = 2; n < 100; n++) {
-		const suffix = `-${n}`;
-		candidate = clip(`${base.slice(0, Math.max(3, maxLen - suffix.length))}${suffix}`);
-		if (!takenSet.has(candidate)) return candidate;
-	}
-	return clip(`${base}-${Date.now().toString(36).slice(-4)}`);
-}
-
-function previewNames(names, limit = 8) {
-	const list = [...names];
-	if (list.length === 0) return '';
-	const shown = list.slice(0, limit).join(', ');
-	return list.length > limit ? `${shown}, …` : shown;
-}
-
 function nodeMajor() {
 	const path = which('node');
 	if (!path) return null;
@@ -695,52 +664,18 @@ async function askHostname(domain) {
 	return host;
 }
 
-async function askCloudResource({
-	label,
-	current,
-	taken,
-	altBase,
-	flagValue,
-	validate,
-	invalidHint
-}) {
-	const takenSet = new Set(taken);
-	let suggested = current;
-	if (takenSet.has(current)) {
-		warn(`${label} "${current}" already exists on this account — probably another project.`);
-		suggested = uniqueName(altBase, takenSet);
-		log(`  ${c.dim(`Suggested new name: ${suggested}`)}`);
-	}
-
+async function askResourceName(question, fallback, flagValue, validate, invalidHint) {
 	if (flagValue) {
 		const name = flagValue.trim().toLowerCase();
-		if (!validate(name)) throw new Error(`Invalid ${label} name "${flagValue}". ${invalidHint}`);
-		if (takenSet.has(name) && !args.yes) {
-			if (!(await confirm(`Reuse existing ${label} "${name}"?`, false))) {
-				throw new Error(`Pick a different --${label === 'D1' ? 'd1' : 'r2'}-name. "${name}" already exists.`);
-			}
-		} else if (takenSet.has(name)) {
-			warn(`Reusing existing ${label} "${name}".`);
-		}
+		if (!validate(name)) throw new Error(`Invalid ${question}: "${flagValue}". ${invalidHint}`);
 		return name;
 	}
-
-	if (args.yes) return suggested;
-
+	if (args.yes) return fallback;
 	while (true) {
-		const name = (await prompt(`${label} name`, suggested)).toLowerCase();
-		if (!validate(name)) {
-			warn(invalidHint);
-			continue;
-		}
-		if (takenSet.has(name)) {
-			if (await confirm(`Reuse existing ${label} "${name}"? This will share it with whatever already uses it.`, false)) {
-				return name;
-			}
-			warn('Enter a different name to create a new one.');
-			continue;
-		}
-		return name;
+		const raw = await prompt(question);
+		const name = (raw || fallback).toLowerCase();
+		if (validate(name)) return name;
+		warn(invalidHint);
 	}
 }
 
@@ -1146,33 +1081,22 @@ async function main() {
 	if (hostname) ok(`UI hostname ${hostname}`);
 
 	section(4, total, 'D1 and R2');
-	const existingD1 = listD1();
-	const existingR2 = listR2Names();
-	const d1Taken = existingD1.map((row) => row.name);
-	if (d1Taken.length) log(`  Existing D1: ${previewNames(d1Taken)}`);
-	if (existingR2.length) log(`  Existing R2: ${previewNames(existingR2)}`);
-
-	const domainSlug = slugDomain(domain);
-	const databaseName = await askCloudResource({
-		label: 'D1',
-		current: jsoncString(source, 'database_name') || 'quickmail',
-		taken: d1Taken,
-		altBase: `${workerName}-${domainSlug}`,
-		flagValue: args.d1Name,
-		validate: isWorkerName,
-		invalidHint: 'Use lowercase letters, numbers, and hyphens.'
-	});
-	const bucketName = await askCloudResource({
-		label: 'R2',
-		current: jsoncString(source, 'bucket_name') || 'quickmail-attachments',
-		taken: existingR2,
-		altBase: `${workerName}-${domainSlug}-attachments`,
-		flagValue: args.r2Name,
-		validate: isR2BucketName,
-		invalidHint: '3–63 characters, lowercase letters, numbers, and hyphens.'
-	});
-	ok(`D1 name ${databaseName}`);
-	ok(`R2 name ${bucketName}`);
+	const databaseName = await askResourceName(
+		'D1 database name (e.g. quickmail)',
+		jsoncString(source, 'database_name') || 'quickmail',
+		args.d1Name,
+		isWorkerName,
+		'Use lowercase letters, numbers, and hyphens.'
+	);
+	const bucketName = await askResourceName(
+		'R2 bucket name (e.g. quickmail-attachments)',
+		jsoncString(source, 'bucket_name') || 'quickmail-attachments',
+		args.r2Name,
+		isR2BucketName,
+		'3–63 characters, lowercase letters, numbers, and hyphens.'
+	);
+	ok(`D1 ${databaseName}`);
+	ok(`R2 ${bucketName}`);
 	const databaseId = await ensureD1(databaseName);
 	ensureR2(bucketName);
 

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,0 +1,1134 @@
+#!/usr/bin/env node
+/**
+ * Interactive first-run setup for QuickMail.
+ *
+ * Installs tools, logs into Cloudflare, creates D1/R2, writes env and
+ * wrangler config, and onboards a mail domain (Resend or Cloudflare Email).
+ *
+ * Usage:
+ *   bun run setup
+ *   node scripts/setup.mjs
+ *   bash scripts/setup.sh
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import readline from 'node:readline/promises';
+import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const wranglerFile = join(root, 'wrangler.jsonc');
+const devVarsFile = join(root, '.dev.vars');
+const devVarsExample = join(root, '.dev.vars.example');
+const envFile = join(root, '.env');
+
+const D1_PLACEHOLDER = 'REPLACE_WITH_YOUR_D1_DATABASE_ID';
+const MIN_WRANGLER = [4, 123, 0];
+const ADDRESSES_WRANGLER = [4, 113, 0];
+const MIN_NODE_MAJOR = 20;
+const BUN_INSTALL_DIR = process.env.BUN_INSTALL || join(homedir(), '.bun');
+const RESEND_WEBHOOK_EVENTS = [
+	'email.received',
+	'email.sent',
+	'email.delivered',
+	'email.bounced',
+	'email.complained',
+	'email.delivery_delayed',
+	'email.failed'
+];
+
+const tty = Boolean(stdoutStream.isTTY);
+const c = {
+	dim: (s) => (tty ? `\x1b[2m${s}\x1b[0m` : s),
+	bold: (s) => (tty ? `\x1b[1m${s}\x1b[0m` : s),
+	green: (s) => (tty ? `\x1b[32m${s}\x1b[0m` : s),
+	yellow: (s) => (tty ? `\x1b[33m${s}\x1b[0m` : s),
+	red: (s) => (tty ? `\x1b[31m${s}\x1b[0m` : s)
+};
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+	printHelp();
+	process.exit(0);
+}
+
+let rl = null;
+
+function printHelp() {
+	console.log(`QuickMail setup
+
+Installs tools, logs you into Cloudflare, creates D1/R2, writes env and
+wrangler config, and onboards your mail domain.
+
+  bun run setup
+  bash scripts/setup.sh
+  node scripts/setup.mjs [options]
+
+Options:
+  --domain <name>      Mail domain (e.g. example.com)
+  --provider <name>    resend | cloudflare
+  --yes                Accept defaults (still requires --domain)
+  --skip-deploy        Do not deploy at the end
+  --help               Show this help
+`);
+}
+
+function parseArgs(argv) {
+	const out = { help: false, yes: false, skipDeploy: false, domain: null, provider: null };
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		switch (arg) {
+			case '--help':
+			case '-h':
+				out.help = true;
+				break;
+			case '--yes':
+			case '-y':
+				out.yes = true;
+				break;
+			case '--skip-deploy':
+				out.skipDeploy = true;
+				break;
+			case '--domain':
+				out.domain = argv[++i] ?? '';
+				break;
+			case '--provider':
+				out.provider = argv[++i] ?? '';
+				break;
+			default:
+				if (arg.startsWith('--domain=')) out.domain = arg.slice('--domain='.length);
+				else if (arg.startsWith('--provider=')) out.provider = arg.slice('--provider='.length);
+				else {
+					console.error(`Unknown option: ${arg}`);
+					printHelp();
+					process.exit(1);
+				}
+		}
+	}
+	if (out.provider) {
+		out.provider = out.provider.trim().toLowerCase();
+		if (out.provider !== 'resend' && out.provider !== 'cloudflare') {
+			console.error('--provider must be "resend" or "cloudflare".');
+			process.exit(1);
+		}
+	}
+	return out;
+}
+
+function log(message = '') {
+	console.log(message);
+}
+
+function ok(message) {
+	console.log(`  ${c.green('✓')} ${message}`);
+}
+
+function warn(message) {
+	console.log(`  ${c.yellow('!')} ${message}`);
+}
+
+function fail(message) {
+	console.error(`  ${c.red('✗')} ${message}`);
+}
+
+function section(step, total, title) {
+	console.log(`\n${c.bold(`── ${step}/${total}  ${title}`)}`);
+}
+
+function which(cmd) {
+	const probe =
+		process.platform === 'win32'
+			? spawnSync('where', [cmd], { encoding: 'utf8' })
+			: spawnSync('sh', ['-c', `command -v ${shellQuote(cmd)}`], { encoding: 'utf8' });
+	const path = probe.stdout?.trim().split(/\r?\n/)[0];
+	return probe.status === 0 && path ? path : null;
+}
+
+function shellQuote(value) {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function bunBin() {
+	return which('bun') || (existsSync(join(BUN_INSTALL_DIR, 'bin', 'bun')) ? join(BUN_INSTALL_DIR, 'bin', 'bun') : null);
+}
+
+function hasBun() {
+	return Boolean(bunBin());
+}
+
+function childEnv(extra = {}) {
+	const bunDir = join(BUN_INSTALL_DIR, 'bin');
+	const bins = [join(root, 'node_modules', '.bin'), bunDir].filter((dir) => existsSync(dir) || dir === bunDir);
+	return {
+		...process.env,
+		PATH: `${bins.join(delimiter)}${delimiter}${process.env.PATH ?? ''}`,
+		...extra
+	};
+}
+
+function run(command, commandArgs, { inherit = false, input, env, allowFail = false, stdio } = {}) {
+	const result = spawnSync(command, commandArgs, {
+		cwd: root,
+		encoding: 'utf8',
+		env: childEnv(env),
+		input,
+		stdio: stdio ?? (inherit ? 'inherit' : ['pipe', 'pipe', 'pipe'])
+	});
+	if (result.status !== 0 && !allowFail) {
+		const detail = [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
+		const error = new Error(
+			detail || `${command} ${commandArgs.join(' ')} failed (exit ${result.status ?? 'null'})`
+		);
+		error.output = detail;
+		error.status = result.status;
+		throw error;
+	}
+	return result;
+}
+
+function wrangler(wranglerArgs, options = {}) {
+	const local = join(
+		root,
+		'node_modules',
+		'.bin',
+		process.platform === 'win32' ? 'wrangler.cmd' : 'wrangler'
+	);
+	if (existsSync(local)) {
+		return run(local, wranglerArgs, options);
+	}
+	if (hasBun()) {
+		return run(bunBin(), ['x', 'wrangler', ...wranglerArgs], options);
+	}
+	return run('npx', ['wrangler', ...wranglerArgs], options);
+}
+
+function parseJsonOutput(text) {
+	if (!text) return null;
+	const start = text.search(/[\[{]/);
+	if (start === -1) return null;
+	try {
+		return JSON.parse(text.slice(start));
+	} catch {
+		return null;
+	}
+}
+
+function parseVersion(text) {
+	const match = String(text).match(/(\d+)\.(\d+)\.(\d+)/);
+	return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : [0, 0, 0];
+}
+
+function versionGte(version, minimum) {
+	for (let i = 0; i < 3; i++) {
+		if (version[i] > minimum[i]) return true;
+		if (version[i] < minimum[i]) return false;
+	}
+	return true;
+}
+
+function formatVersion(version) {
+	return version.join('.');
+}
+
+async function ensureReadline() {
+	if (!rl) {
+		rl = readline.createInterface({ input: stdinStream, output: stdoutStream });
+	}
+	return rl;
+}
+
+async function closeReadline() {
+	if (rl) {
+		rl.close();
+		rl = null;
+	}
+}
+
+async function prompt(question, fallback = '') {
+	if (args.yes) return fallback;
+	if (!stdinStream.isTTY) {
+		if (fallback) return fallback;
+		throw new Error(`Non-interactive run needs a value for: ${question}`);
+	}
+	const suffix = fallback ? ` ${c.dim(`(${fallback})`)}` : '';
+	const input = await (await ensureReadline()).question(`  ${question}${suffix}: `);
+	return input.trim() || fallback;
+}
+
+async function confirm(question, defaultYes = true) {
+	if (args.yes) return defaultYes;
+	if (!stdinStream.isTTY) return defaultYes;
+	const hint = defaultYes ? 'Y/n' : 'y/N';
+	const input = (await prompt(`${question} [${hint}]`)).toLowerCase();
+	if (!input) return defaultYes;
+	return input === 'y' || input === 'yes';
+}
+
+async function promptSecret(question) {
+	if (!stdinStream.isTTY) {
+		throw new Error(`Non-interactive run cannot prompt for ${question}. Omit it or run in a terminal.`);
+	}
+	await closeReadline();
+	stdoutStream.write(`  ${question}: `);
+	const value = await readMutedLine();
+	stdoutStream.write('\n');
+	return value.trim();
+}
+
+function readMutedLine() {
+	return new Promise((resolve, reject) => {
+		if (typeof stdinStream.setRawMode !== 'function') {
+			const lineRl = readline.createInterface({ input: stdinStream, output: stdoutStream });
+			lineRl
+				.question('')
+				.then((answer) => {
+					lineRl.close();
+					resolve(answer);
+				}, reject);
+			return;
+		}
+
+		stdinStream.setRawMode(true);
+		stdinStream.resume();
+		stdinStream.setEncoding('utf8');
+		let value = '';
+
+		const restore = () => {
+			stdinStream.setRawMode(false);
+			stdinStream.pause();
+			stdinStream.removeListener('data', onData);
+		};
+
+		const onData = (char) => {
+			if (char === '\n' || char === '\r' || char === '\u0004') {
+				restore();
+				resolve(value);
+				return;
+			}
+			if (char === '\u0003') {
+				restore();
+				stdoutStream.write('\n');
+				process.exit(1);
+			}
+			if (char === '\u007f' || char === '\b') {
+				value = value.slice(0, -1);
+				return;
+			}
+			if (char < ' ') return;
+			value += char;
+			stdoutStream.write('•');
+		};
+
+		stdinStream.on('data', onData);
+	});
+}
+
+function readWrangler() {
+	if (!existsSync(wranglerFile)) {
+		throw new Error('wrangler.jsonc is missing. Run this from the QuickMail repo root.');
+	}
+	return readFileSync(wranglerFile, 'utf8');
+}
+
+function writeWrangler(source) {
+	writeFileSync(wranglerFile, source.endsWith('\n') ? source : `${source}\n`);
+}
+
+function jsoncString(source, key) {
+	return source.match(new RegExp(`"${key}"\\s*:\\s*"([^"]*)"`))?.[1] ?? null;
+}
+
+function setFirstString(source, key, value) {
+	return source.replace(new RegExp(`("${key}"\\s*:\\s*")[^"]*(")`), `$1${value}$2`);
+}
+
+function setVars(source, { provider, domains }) {
+	const lines = [`\t\t"EMAIL_PROVIDER": "${provider}"`];
+	if (provider === 'cloudflare' && domains) {
+		lines.push(`\t\t"CLOUDFLARE_MAIL_DOMAINS": "${domains}"`);
+	} else {
+		lines.push(`\t\t// "CLOUDFLARE_MAIL_DOMAINS": "example.com"`);
+	}
+	const block = `\t"vars": {\n${lines.join(',\n')}\n\t}`;
+	if (/\t"vars"\s*:\s*\{[\s\S]*?\n\t\}/.test(source)) {
+		return source.replace(/\t"vars"\s*:\s*\{[\s\S]*?\n\t\}/, block);
+	}
+	return source.replace(/\n(\t"send_email")/, `\n${block},\n\n$1`);
+}
+
+function setAddresses(source, addresses) {
+	const rendered = `"addresses": ${JSON.stringify(addresses)}`;
+	if (/"addresses"\s*:/.test(source)) {
+		return source.replace(/"addresses"\s*:\s*\[[^\]]*\]/, rendered);
+	}
+	return source.replace(/\n(\t*"send_email")/, `\n\t${rendered},\n\n$1`);
+}
+
+function removeAddresses(source) {
+	return source.replace(/\n\t"addresses"\s*:\s*\[[^\]]*\]\s*,?/, '\n');
+}
+
+function setRoutes(source, hostname) {
+	const block = `\t"routes": [\n\t\t{\n\t\t\t"pattern": "${hostname}",\n\t\t\t"custom_domain": true\n\t\t}\n\t],\n`;
+	if (/^\t"routes": \[/m.test(source)) {
+		return source.replace(/\t"routes": \[[\s\S]*?\],\n/, block);
+	}
+	if (/\t\/\/ "routes": \[[\s\S]*?\t\/\/ \],\n/.test(source)) {
+		return source.replace(/\t\/\/ "routes": \[[\s\S]*?\t\/\/ \],\n/, block);
+	}
+	return source.replace(/("workers_dev": true,\n)/, `$1\n${block}`);
+}
+
+function upsertEnvFile(file, updates, { fromExample = false } = {}) {
+	let text = existsSync(file)
+		? readFileSync(file, 'utf8')
+		: fromExample && existsSync(devVarsExample)
+			? readFileSync(devVarsExample, 'utf8')
+			: '';
+
+	for (const [key, value] of Object.entries(updates)) {
+		if (value == null) continue;
+		const line = `${key}=${value}`;
+		const re = new RegExp(`^#?\\s*${key}=.*$`, 'm');
+		if (re.test(text)) text = text.replace(re, line);
+		else text = `${text.trimEnd()}\n${line}\n`;
+	}
+
+	writeFileSync(file, text.endsWith('\n') ? text : `${text}\n`);
+}
+
+function normalizeDomain(raw) {
+	let value = String(raw).trim().toLowerCase();
+	value = value.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+	if (value.includes('@')) value = value.slice(value.lastIndexOf('@') + 1);
+	value = value.replace(/\.$/, '').replace(/^www\./, '');
+	return value;
+}
+
+function isDomain(value) {
+	return /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/i.test(value);
+}
+
+function isWorkerName(value) {
+	return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(value);
+}
+
+function nodeMajor() {
+	const path = which('node');
+	if (!path) return null;
+	const result = spawnSync(path, ['-v'], { encoding: 'utf8' });
+	const version = parseVersion(result.stdout || '');
+	return version[0] || null;
+}
+
+async function ensureRuntime() {
+	if (process.platform === 'win32' && !hasBun() && !which('node')) {
+		throw new Error(
+			'Install Node.js 20+ from https://nodejs.org or Bun from https://bun.sh, then re-run setup.'
+		);
+	}
+
+	if (hasBun()) {
+		ok(`bun ${run(bunBin(), ['--version'], { allowFail: true }).stdout.trim() || 'installed'}`);
+		return;
+	}
+
+	warn('Bun is not installed. QuickMail scripts (build, deploy, migrate) expect bun.');
+	if (await confirm('Install bun now?', true)) {
+		if (process.platform === 'win32') {
+			throw new Error('Install bun from https://bun.sh on Windows, then re-run setup.');
+		}
+		run('sh', ['-c', 'curl -fsSL https://bun.sh/install | bash'], { inherit: true });
+		if (!hasBun()) {
+			throw new Error(
+				`Bun installed but not on PATH. Open a new terminal or add ${join(BUN_INSTALL_DIR, 'bin')} to PATH.`
+			);
+		}
+		ok(`bun ${run(bunBin(), ['--version']).stdout.trim()}`);
+		return;
+	}
+
+	const major = nodeMajor();
+	if (major && major >= MIN_NODE_MAJOR) {
+		ok(`node v${process.versions.node} (bun skipped; some npm scripts still call bun)`);
+		return;
+	}
+	if (major) {
+		throw new Error(`Node ${major} is too old. Install Node ${MIN_NODE_MAJOR}+ or bun, then re-run.`);
+	}
+	throw new Error('Need bun (https://bun.sh) or Node 20+ (https://nodejs.org).');
+}
+
+function installDeps() {
+	if (hasBun()) {
+		run(bunBin(), ['install'], { inherit: true });
+		ok('dependencies installed (bun)');
+		return;
+	}
+	run('npm', ['install'], { inherit: true });
+	ok('dependencies installed (npm)');
+}
+
+function wranglerVersion() {
+	const result = wrangler(['--version'], { allowFail: true });
+	return parseVersion(`${result.stdout}\n${result.stderr}`);
+}
+
+function upgradeWrangler() {
+	if (hasBun()) {
+		run(bunBin(), ['add', '-d', 'wrangler@latest'], { inherit: true });
+	} else {
+		run('npm', ['install', '-D', 'wrangler@latest'], { inherit: true });
+	}
+}
+
+async function ensureWrangler(needLatest) {
+	if (!existsSync(join(root, 'node_modules', 'wrangler')) && !which('wrangler')) {
+		installDeps();
+	}
+
+	let version = wranglerVersion();
+	ok(`wrangler ${formatVersion(version)}`);
+
+	if (!needLatest && versionGte(version, MIN_WRANGLER)) return version;
+	if (needLatest && versionGte(version, MIN_WRANGLER)) return version;
+
+	warn(
+		`Wrangler ${formatVersion(version)} is too old. Cloudflare Email Sending needs ${formatVersion(MIN_WRANGLER)}+.`
+	);
+	if (!(await confirm('Upgrade wrangler to latest?', true))) {
+		if (needLatest) {
+			throw new Error(`Upgrade wrangler (bun add -d wrangler@latest) and re-run.`);
+		}
+		return version;
+	}
+	upgradeWrangler();
+	version = wranglerVersion();
+	ok(`wrangler ${formatVersion(version)}`);
+	return version;
+}
+
+function parseWhoami(text) {
+	const combined = text.trim();
+	const unauthenticated = /not (logged in|authenticated)|please run.*login|login to continue/i.test(
+		combined
+	);
+	const email =
+		combined.match(/email ['"]([^'"]+)['"]/i)?.[1] ??
+		combined.match(/\b([\w.+-]+@[\w.-]+\.[a-z]{2,})\b/i)?.[1] ??
+		null;
+	const accounts = [];
+	const seen = new Set();
+	for (const match of combined.matchAll(/([^\n│|]{2,64}?)[│|]\s*([0-9a-f]{32})/gi)) {
+		const name = match[1].replace(/[│|]/g, '').trim();
+		const id = match[2].toLowerCase();
+		if (seen.has(id)) continue;
+		seen.add(id);
+		accounts.push({ name: name || id, id });
+	}
+	if (accounts.length === 0) {
+		for (const match of combined.matchAll(/\b([0-9a-f]{32})\b/gi)) {
+			const id = match[1].toLowerCase();
+			if (seen.has(id)) continue;
+			seen.add(id);
+			accounts.push({ name: id, id });
+		}
+	}
+	return { email, accounts, unauthenticated };
+}
+
+async function ensureLogin() {
+	const who = wrangler(['whoami'], { allowFail: true });
+	const parsed = parseWhoami(`${who.stdout}\n${who.stderr}`);
+	if (who.status === 0 && !parsed.unauthenticated && (parsed.email || parsed.accounts.length)) {
+		ok(parsed.email ? `logged in as ${parsed.email}` : 'logged in to Cloudflare');
+		return pickAccount(parsed.accounts);
+	}
+
+	log(`  ${c.dim('Opening a browser for wrangler login…')}`);
+	wrangler(['login'], { inherit: true });
+
+	const again = wrangler(['whoami'], { allowFail: true });
+	const next = parseWhoami(`${again.stdout}\n${again.stderr}`);
+	if (again.status !== 0 || next.unauthenticated) {
+		throw new Error('Cloudflare login did not complete. Run `bunx wrangler login` and re-run setup.');
+	}
+	ok(next.email ? `logged in as ${next.email}` : 'logged in to Cloudflare');
+	return pickAccount(next.accounts);
+}
+
+async function pickAccount(accounts) {
+	if (accounts.length === 0) return null;
+	if (accounts.length === 1) {
+		ok(`account ${accounts[0].name}`);
+		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		return accounts[0];
+	}
+
+	log('  This login can see more than one Cloudflare account:');
+	accounts.forEach((account, index) => {
+		log(`    ${index + 1}) ${account.name}  ${c.dim(account.id)}`);
+	});
+
+	if (args.yes) {
+		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		ok(`using ${accounts[0].name}`);
+		return accounts[0];
+	}
+
+	let chosen = null;
+	while (!chosen) {
+		const raw = await prompt('Account number', '1');
+		const index = Number(raw) - 1;
+		chosen = accounts[index];
+		if (!chosen) warn('Pick a number from the list.');
+	}
+	upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: chosen.id });
+	ok(`using ${chosen.name}`);
+	return chosen;
+}
+
+async function askDomain() {
+	if (args.domain) {
+		const domain = normalizeDomain(args.domain);
+		if (!isDomain(domain)) throw new Error(`Invalid --domain "${args.domain}".`);
+		return domain;
+	}
+	while (true) {
+		const domain = normalizeDomain(await prompt('Mail domain (e.g. example.com)'));
+		if (isDomain(domain)) return domain;
+		warn('Enter a domain like example.com — no URL, no @.');
+	}
+}
+
+async function askProvider() {
+	if (args.provider) return args.provider;
+	if (args.yes) return 'resend';
+
+	log(`  ${c.bold('Mail provider')}`);
+	log('    1) Cloudflare Email  — zone already on Cloudflare DNS; Workers paid plan for sending');
+	log('    2) Resend            — any DNS host; Resend account');
+	while (true) {
+		const choice = await prompt('Choice (1/2)', '2');
+		if (choice === '1' || choice === 'cloudflare') return 'cloudflare';
+		if (choice === '2' || choice === 'resend') return 'resend';
+		warn('Enter 1 or 2.');
+	}
+}
+
+async function askWorkerName(current) {
+	const fallback = current && isWorkerName(current) ? current : 'quickmail';
+	while (true) {
+		const name = (await prompt('Worker name', fallback)).toLowerCase();
+		if (isWorkerName(name)) return name;
+		warn('Use lowercase letters, numbers, and hyphens.');
+	}
+}
+
+async function askHostname(domain) {
+	const raw = await prompt(`Web UI hostname (blank = workers.dev)`, '');
+	if (!raw) return null;
+	const host = normalizeDomain(raw.includes('.') ? raw : `${raw}.${domain}`);
+	if (!isDomain(host)) {
+		warn(`Ignoring invalid hostname "${raw}". Deploying to workers.dev.`);
+		return null;
+	}
+	return host;
+}
+
+function listD1() {
+	const result = wrangler(['d1', 'list', '--json'], { allowFail: true });
+	const parsed = parseJsonOutput(`${result.stdout}\n${result.stderr}`);
+	const rows = Array.isArray(parsed) ? parsed : parsed?.databases ?? parsed?.result ?? [];
+	const fromJson = rows
+		.map((row) => ({
+			name: row.name ?? row.database_name,
+			id: row.uuid ?? row.id ?? row.database_id
+		}))
+		.filter((row) => row.name && row.id);
+	if (fromJson.length > 0) return fromJson;
+
+	const table = wrangler(['d1', 'list'], { allowFail: true });
+	const text = `${table.stdout}\n${table.stderr}`;
+	const found = [];
+	for (const line of text.split('\n')) {
+		const id = line.match(/\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i)?.[1];
+		if (!id) continue;
+		const name = line.match(/\b(quickmail|[a-z0-9][a-z0-9-]{1,62})\b/i)?.[1];
+		if (name) found.push({ name, id });
+	}
+	return found;
+}
+
+function createD1(name) {
+	const result = wrangler(['d1', 'create', name], {
+		allowFail: true,
+		env: { CI: 'true' }
+	});
+	const text = `${result.stdout}\n${result.stderr}`;
+	const id =
+		text.match(/"database_id"\s*:\s*"([^"]+)"/)?.[1] ??
+		text.match(/database_id\s*=\s*"([^"]+)"/)?.[1];
+	if (result.status === 0 && id) return id;
+	if (/already exists/i.test(text)) {
+		const existing = listD1().find((row) => row.name === name);
+		if (existing) return existing.id;
+	}
+	throw new Error(text.trim() || `Failed to create D1 database "${name}".`);
+}
+
+async function ensureD1(databaseName, currentId) {
+	if (currentId && currentId !== D1_PLACEHOLDER) {
+		ok(`D1 ${databaseName} (${currentId})`);
+		return currentId;
+	}
+
+	const existing = listD1().find((row) => row.name === databaseName);
+	if (existing) {
+		ok(`reusing D1 ${databaseName} (${existing.id})`);
+		return existing.id;
+	}
+
+	log(`  ${c.dim(`Creating D1 database ${databaseName}…`)}`);
+	const id = createD1(databaseName);
+	ok(`D1 ${databaseName} (${id})`);
+	return id;
+}
+
+function r2BucketExists(bucketName) {
+	const result = wrangler(['r2', 'bucket', 'list', '--json'], { allowFail: true });
+	const parsed = parseJsonOutput(`${result.stdout}\n${result.stderr}`);
+	const rows = Array.isArray(parsed) ? parsed : parsed?.buckets ?? parsed?.result ?? [];
+	const names = rows
+		.map((row) => (typeof row === 'string' ? row : row.name ?? row.Name))
+		.filter(Boolean);
+	if (names.includes(bucketName)) return true;
+
+	const table = wrangler(['r2', 'bucket', 'list'], { allowFail: true });
+	return new RegExp(`\\b${bucketName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(
+		`${table.stdout}\n${table.stderr}`
+	);
+}
+
+function ensureR2(bucketName) {
+	if (r2BucketExists(bucketName)) {
+		ok(`R2 bucket ${bucketName}`);
+		return;
+	}
+
+	log(`  ${c.dim(`Creating R2 bucket ${bucketName}…`)}`);
+	const result = wrangler(['r2', 'bucket', 'create', bucketName], {
+		allowFail: true,
+		env: { CI: 'true' }
+	});
+	const text = `${result.stdout}\n${result.stderr}`;
+	if (result.status === 0 || /already exists/i.test(text)) {
+		ok(`R2 bucket ${bucketName}`);
+		return;
+	}
+	throw new Error(text.trim() || `Failed to create R2 bucket "${bucketName}".`);
+}
+
+function putSecret(name, value) {
+	wrangler(['secret', 'put', name], {
+		input: value,
+		stdio: ['pipe', 'inherit', 'inherit']
+	});
+	ok(`stored ${name} as a Worker secret`);
+}
+
+function wranglerOutputLooksEnabled(text, kind) {
+	if (kind === 'sending') {
+		return /enabled:\s*yes|status:\s*(enabled|ready)|successfully enabled/i.test(text);
+	}
+	return /enabled:\s*true|status:\s*ready|successfully enabled/i.test(text);
+}
+
+function tryWrangler(wranglerArgs) {
+	const result = wrangler(wranglerArgs, { allowFail: true });
+	return {
+		ok: result.status === 0,
+		text: `${result.stdout}\n${result.stderr}`.trim()
+	};
+}
+
+async function setupCloudflare(domain, workerName, wranglerVer) {
+	log(`  ${c.dim('Enabling Email Sending (needs a Workers paid plan)…')}`);
+	const sending = tryWrangler(['email', 'sending', 'enable', domain]);
+	if (sending.ok) ok(`Email Sending enabled on ${domain}`);
+	else {
+		warn('Could not enable Email Sending from the CLI.');
+		log(`  ${sending.text.split('\n').slice(0, 8).join('\n  ')}`);
+		log(
+			`  ${c.dim('Dashboard: https://dash.cloudflare.com/?to=/:account/email-service/sending')}`
+		);
+	}
+
+	log(`  ${c.dim('Enabling Email Routing…')}`);
+	const routing = tryWrangler(['email', 'routing', 'enable', domain]);
+	if (routing.ok) ok(`Email Routing enabled on ${domain}`);
+	else {
+		warn('Could not enable Email Routing from the CLI.');
+		log(`  ${routing.text.split('\n').slice(0, 8).join('\n  ')}`);
+		log(
+			`  ${c.dim('Dashboard: https://dash.cloudflare.com/?to=/:account/email-service/routing')}`
+		);
+	}
+
+	const sendingDns = tryWrangler(['email', 'sending', 'dns', 'get', domain]);
+	if (sendingDns.text) {
+		log(`\n  ${c.bold('Sending DNS (Cloudflare usually adds these for you)')}`);
+		log(
+			sendingDns.text
+				.split('\n')
+				.map((line) => `    ${line}`)
+				.join('\n')
+		);
+	}
+	const routingDns = tryWrangler(['email', 'routing', 'dns', 'get', domain]);
+	if (routingDns.text) {
+		log(`\n  ${c.bold('Routing DNS (apex MX must point at Cloudflare)')}`);
+		log(
+			routingDns.text
+				.split('\n')
+				.map((line) => `    ${line}`)
+				.join('\n')
+		);
+	}
+
+	tryWrangler(['email', 'sending', 'list']);
+	const settings = tryWrangler(['email', 'routing', 'settings', domain]);
+	if (settings.text && wranglerOutputLooksEnabled(settings.text, 'routing')) {
+		ok('Email Routing reports enabled');
+	}
+
+	return {
+		useAddresses: versionGte(wranglerVer, ADDRESSES_WRANGLER),
+		workerName
+	};
+}
+
+async function listResendDomains(apiKey) {
+	const response = await fetch('https://api.resend.com/domains?limit=100', {
+		headers: { Authorization: `Bearer ${apiKey}` }
+	});
+	const raw = await response.text();
+	const parsed = raw ? parseJsonOutput(raw) : null;
+	if (!response.ok) {
+		const message = parsed?.message ?? parsed?.error ?? `Resend API ${response.status}`;
+		throw new Error(message);
+	}
+	return parsed?.data ?? [];
+}
+
+async function listResendWebhooks(apiKey) {
+	const response = await fetch('https://api.resend.com/webhooks', {
+		headers: { Authorization: `Bearer ${apiKey}` }
+	});
+	const raw = await response.text();
+	const parsed = raw ? parseJsonOutput(raw) : null;
+	if (!response.ok) return [];
+	return parsed?.data ?? [];
+}
+
+async function createResendWebhook(apiKey, endpoint) {
+	const response = await fetch('https://api.resend.com/webhooks', {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({ endpoint, events: RESEND_WEBHOOK_EVENTS })
+	});
+	const raw = await response.text();
+	const parsed = raw ? parseJsonOutput(raw) : null;
+	if (!response.ok) {
+		throw new Error(parsed?.message ?? parsed?.error ?? `Resend webhook create failed (${response.status})`);
+	}
+	return parsed;
+}
+
+async function setupResend(domain) {
+	log('  Create an API key at https://resend.com/api-keys with send + domains + receiving.');
+	log('  Add the domain in Resend (Domains → Add Domain) and copy every DNS record, including apex MX.');
+
+	let apiKey = '';
+	if (stdinStream.isTTY && !args.yes) {
+		apiKey = await promptSecret('Resend API key (starts with re_, blank to skip)');
+	} else {
+		warn('Skipped API key prompt. Set RESEND_API_KEY later with wrangler secret put.');
+	}
+
+	if (!apiKey) {
+		return { apiKey: '', webhookSecret: '', domainOk: false };
+	}
+
+	if (!apiKey.startsWith('re_')) {
+		warn('That does not look like a Resend key (usually starts with re_). Storing it anyway.');
+	}
+
+	putSecret('RESEND_API_KEY', apiKey);
+
+	try {
+		const domains = await listResendDomains(apiKey);
+		if (domains.length === 0) {
+			warn('This key sees no domains yet. Add one in the Resend dashboard before going live.');
+			return { apiKey, webhookSecret: '', domainOk: false };
+		}
+		log('  Resend domains on this key:');
+		for (const item of domains) {
+			const receiving = item.capabilities?.receiving === 'enabled' ? 'receive on' : 'receive off';
+			log(`    • ${item.name}  ${c.dim(`${item.status}, ${receiving}`)}`);
+		}
+		const match = domains.find((item) => item.name?.toLowerCase() === domain);
+		if (!match) {
+			warn(`${domain} is not on this Resend account yet. Add it, then finish DNS.`);
+			return { apiKey, webhookSecret: '', domainOk: false };
+		}
+		ok(`${domain} is in Resend (${match.status})`);
+		if (match.capabilities?.receiving !== 'enabled') {
+			warn('Enable sending and receiving on the domain in Resend or inbound mail will not arrive.');
+		}
+		return { apiKey, webhookSecret: '', domainOk: match.status === 'verified' };
+	} catch (error) {
+		warn(`Could not list Resend domains: ${error.message}`);
+		return { apiKey, webhookSecret: '', domainOk: false };
+	}
+}
+
+function migrate(local, remote) {
+	const databaseName = jsoncString(readWrangler(), 'database_name') || 'quickmail';
+	if (local) {
+		wrangler(['d1', 'migrations', 'apply', databaseName, '--local'], { inherit: true });
+		ok('local D1 migrations applied');
+	}
+	if (remote) {
+		wrangler(['d1', 'migrations', 'apply', databaseName, '--remote'], { inherit: true });
+		ok('remote D1 migrations applied');
+	}
+}
+
+function parseDeployUrl(text) {
+	const workers = text.match(/https:\/\/[a-z0-9.-]+\.workers\.dev/i);
+	if (workers) return workers[0];
+	const https = text.match(/https:\/\/[a-z0-9.-]+\.[a-z]{2,}[^\s]*/i);
+	return https ? https[0].replace(/[).,]+$/, '') : null;
+}
+
+function deploy() {
+	if (hasBun()) {
+		const result = run(bunBin(), ['run', 'deploy'], { inherit: true, allowFail: true });
+		return { ok: result.status === 0, text: '' };
+	}
+	const result = run('npm', ['run', 'deploy'], { inherit: true, allowFail: true });
+	return { ok: result.status === 0, text: '' };
+}
+
+function deployCaptured() {
+	if (hasBun()) {
+		const result = run(bunBin(), ['run', 'deploy'], { allowFail: true });
+		const text = `${result.stdout}\n${result.stderr}`;
+		if (text.trim()) console.log(text);
+		return { ok: result.status === 0, text };
+	}
+	const result = run('npm', ['run', 'deploy'], { allowFail: true });
+	const text = `${result.stdout}\n${result.stderr}`;
+	if (text.trim()) console.log(text);
+	return { ok: result.status === 0, text };
+}
+
+async function maybeCreateWebhook(apiKey, publicUrl) {
+	if (!apiKey || !publicUrl) return '';
+	const endpoint = `${publicUrl.replace(/\/$/, '')}/api/webhooks/resend`;
+	const existing = await listResendWebhooks(apiKey);
+	const already = existing.find((hook) => hook.endpoint === endpoint);
+	if (already) {
+		warn(`Resend already has a webhook at ${endpoint}. The signing secret is only shown once — keep the existing RESEND_WEBHOOK_SECRET.`);
+		return '';
+	}
+	if (!(await confirm(`Create Resend webhook at ${endpoint}?`, true))) return '';
+	const created = await createResendWebhook(apiKey, endpoint);
+	const secret = created?.signing_secret ?? created?.svix_secret ?? '';
+	if (!secret) {
+		warn('Webhook created but no signing secret in the response. Copy it from the Resend dashboard.');
+		return '';
+	}
+	putSecret('RESEND_WEBHOOK_SECRET', secret);
+	log(`  ${c.dim('Signing secret stored. It is not shown again.')}`);
+	return secret;
+}
+
+function printNextSteps(state) {
+	log(`\n${c.bold('Next')}`);
+	const app = state.publicUrl ? `${state.publicUrl}/setup` : 'the deployed URL /setup (or http://localhost:5173/setup after bun run dev)';
+
+	if (state.provider === 'cloudflare') {
+		if (state.useAddresses && state.deployed) {
+			log(`  1. Confirm catch-all: Email Routing → ${state.domain} → Catch-all → Send to a Worker → ${state.workerName}.`);
+			log('     Deploy tried to attach `*@' + state.domain + '` via wrangler `addresses`. If mail never arrives, set that catch-all in the dashboard.');
+		} else {
+			log(`  1. Catch-all → Worker (CLI cannot set this to a Worker on older Wrangler):`);
+			log('     https://dash.cloudflare.com/?to=/:account/email-service/routing');
+			log(`     Enable Catch-all → Send to a Worker → ${state.workerName}.`);
+		}
+		log('     The dashboard may ask you to verify a personal destination first. Do not forward production mail there.');
+		log(`  2. Open ${app} and create the admin (name, local-part, password).`);
+		log('  3. Send yourself a message from another account. Inbound only hits a deployed Worker — not vite dev.');
+	} else {
+		let n = 1;
+		if (!state.resendDomainOk) {
+			log(`  ${n++}. In Resend, add ${state.domain} and every DNS record they show, including apex MX. Enable sending and receiving.`);
+		}
+		if (!state.webhookSecret && state.publicUrl) {
+			log(`  ${n++}. Create a webhook at https://resend.com/webhooks → ${state.publicUrl}/api/webhooks/resend`);
+			log('     Events: received, sent, delivered, bounced, complained, delivery_delayed, failed.');
+			log('     Then: bunx wrangler secret put RESEND_WEBHOOK_SECRET && bun run deploy');
+		} else if (!state.publicUrl) {
+			log(`  ${n++}. Deploy, then create the Resend webhook pointing at https://<worker>/api/webhooks/resend`);
+			log('     Save the signing secret (shown once) and wrangler secret put RESEND_WEBHOOK_SECRET.');
+		}
+		log(`  ${n++}. Open ${app} and create the admin (name, local-part, password).`);
+		log('  Local inbound needs a tunnel (cloudflared) — production uses the public Worker URL.');
+	}
+
+	log(`\n  ${c.dim('wrangler.jsonc now has a real D1 id. Do not commit that back to the public template.')}`);
+	if (state.publicUrl) log(`\n  ${c.green(state.publicUrl)}`);
+}
+
+async function main() {
+	if (!stdinStream.isTTY && !args.yes) {
+		throw new Error('Non-interactive shells need --yes and --domain. See --help.');
+	}
+	if (args.yes && !args.domain) {
+		throw new Error('--yes requires --domain.');
+	}
+
+	log(`\n${c.bold('QuickMail setup')}`);
+	log(c.dim('  A mailbox on your domain, on Cloudflare.\n'));
+
+	const total = 8;
+
+	section(1, total, 'Tools');
+	await ensureRuntime();
+	installDeps();
+
+	section(2, total, 'Cloudflare login');
+	await ensureLogin();
+
+	section(3, total, 'Domain and provider');
+	const domain = await askDomain();
+	ok(domain);
+	const provider = await askProvider();
+	ok(provider === 'cloudflare' ? 'Cloudflare Email' : 'Resend');
+
+	const wranglerVer = await ensureWrangler(provider === 'cloudflare');
+
+	let source = readWrangler();
+	const workerName = await askWorkerName(jsoncString(source, 'name') || 'quickmail');
+	const hostname = await askHostname(domain);
+	if (hostname) ok(`UI hostname ${hostname}`);
+
+	section(4, total, 'D1 and R2');
+	const databaseName = jsoncString(source, 'database_name') || 'quickmail';
+	const bucketName = jsoncString(source, 'bucket_name') || 'quickmail-attachments';
+	const databaseId = await ensureD1(databaseName, jsoncString(source, 'database_id'));
+	ensureR2(bucketName);
+
+	section(5, total, 'Config');
+	source = readWrangler();
+	source = setFirstString(source, 'name', workerName);
+	source = setFirstString(source, 'database_id', databaseId);
+	source = setFirstString(source, 'bucket_name', bucketName);
+	source = setVars(source, {
+		provider,
+		domains: provider === 'cloudflare' ? domain : ''
+	});
+	if (hostname) source = setRoutes(source, hostname);
+	if (provider === 'cloudflare' && versionGte(wranglerVer, ADDRESSES_WRANGLER)) {
+		source = setAddresses(source, [`*@${domain}`]);
+	} else {
+		source = removeAddresses(source);
+	}
+	writeWrangler(source);
+	ok('updated wrangler.jsonc');
+
+	const devVars = {
+		EMAIL_PROVIDER: provider
+	};
+	if (provider === 'cloudflare') {
+		devVars.CLOUDFLARE_MAIL_DOMAINS = domain;
+	}
+	upsertEnvFile(devVarsFile, devVars, { fromExample: true });
+	ok('updated .dev.vars');
+
+	section(6, total, 'Provider');
+	let useAddresses = false;
+	let resend = { apiKey: '', webhookSecret: '', domainOk: false };
+	if (provider === 'cloudflare') {
+		const cf = await setupCloudflare(domain, workerName, wranglerVer);
+		useAddresses = cf.useAddresses;
+	} else {
+		resend = await setupResend(domain);
+		if (resend.apiKey) {
+			upsertEnvFile(devVarsFile, { RESEND_API_KEY: resend.apiKey });
+			ok('wrote RESEND_API_KEY to .dev.vars');
+		}
+	}
+
+	section(7, total, 'Database');
+	migrate(true, false);
+
+	section(8, total, 'Deploy');
+	let deployed = false;
+	let publicUrl = hostname ? `https://${hostname}` : null;
+	const shouldDeploy = args.skipDeploy ? false : await confirm('Deploy now?', true);
+	if (shouldDeploy) {
+		migrate(false, true);
+		const result = deployCaptured();
+		deployed = result.ok;
+		const parsed = parseDeployUrl(result.text);
+		if (parsed) publicUrl = parsed;
+		if (deployed) ok('deployed');
+		else warn('Deploy failed. Fix the error above, then bun run deploy.');
+
+		if (deployed && provider === 'resend' && resend.apiKey && publicUrl) {
+			try {
+				const secret = await maybeCreateWebhook(resend.apiKey, publicUrl);
+				if (secret) {
+					resend.webhookSecret = secret;
+					upsertEnvFile(devVarsFile, { RESEND_WEBHOOK_SECRET: secret });
+					log(`  ${c.dim('Redeploying so the Worker has RESEND_WEBHOOK_SECRET…')}`);
+					const again = deploy();
+					if (!again.ok) warn('Second deploy failed. Run bun run deploy after checking the secret.');
+				}
+			} catch (error) {
+				warn(`Webhook setup failed: ${error.message}`);
+			}
+		}
+	} else {
+		log(`  ${c.dim('Skipped deploy. bun run db:migrate:remote && bun run deploy when you are ready.')}`);
+	}
+
+	printNextSteps({
+		provider,
+		domain,
+		workerName,
+		useAddresses,
+		deployed,
+		publicUrl,
+		resendDomainOk: resend.domainOk,
+		webhookSecret: resend.webhookSecret
+	});
+}
+
+try {
+	await main();
+} catch (error) {
+	fail(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+} finally {
+	await closeReadline();
+}

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -24,7 +24,6 @@ const devVarsFile = join(root, '.dev.vars');
 const devVarsExample = join(root, '.dev.vars.example');
 const envFile = join(root, '.env');
 
-const D1_PLACEHOLDER = 'REPLACE_WITH_YOUR_D1_DATABASE_ID';
 const MIN_WRANGLER = [4, 123, 0];
 const ADDRESSES_WRANGLER = [4, 113, 0];
 const MIN_NODE_MAJOR = 20;
@@ -70,6 +69,8 @@ wrangler config, and onboards your mail domain.
 Options:
   --domain <name>      Mail domain (e.g. example.com)
   --provider <name>    resend | cloudflare
+  --d1-name <name>     D1 database name (default: quickmail, or unique if taken)
+  --r2-name <name>     R2 bucket name (default: quickmail-attachments, or unique if taken)
   --yes                Accept defaults (still requires --domain)
   --skip-deploy        Do not deploy at the end
   --help               Show this help
@@ -77,7 +78,15 @@ Options:
 }
 
 function parseArgs(argv) {
-	const out = { help: false, yes: false, skipDeploy: false, domain: null, provider: null };
+	const out = {
+		help: false,
+		yes: false,
+		skipDeploy: false,
+		domain: null,
+		provider: null,
+		d1Name: null,
+		r2Name: null
+	};
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		switch (arg) {
@@ -98,9 +107,17 @@ function parseArgs(argv) {
 			case '--provider':
 				out.provider = argv[++i] ?? '';
 				break;
+			case '--d1-name':
+				out.d1Name = argv[++i] ?? '';
+				break;
+			case '--r2-name':
+				out.r2Name = argv[++i] ?? '';
+				break;
 			default:
 				if (arg.startsWith('--domain=')) out.domain = arg.slice('--domain='.length);
 				else if (arg.startsWith('--provider=')) out.provider = arg.slice('--provider='.length);
+				else if (arg.startsWith('--d1-name=')) out.d1Name = arg.slice('--d1-name='.length);
+				else if (arg.startsWith('--r2-name=')) out.r2Name = arg.slice('--r2-name='.length);
 				else {
 					console.error(`Unknown option: ${arg}`);
 					printHelp();
@@ -416,6 +433,45 @@ function isWorkerName(value) {
 	return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(value);
 }
 
+function isR2BucketName(value) {
+	return (
+		value.length >= 3 &&
+		value.length <= 63 &&
+		/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(value)
+	);
+}
+
+function slugDomain(domain) {
+	return domain.replace(/\./g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+function uniqueName(base, taken, maxLen = 63) {
+	const takenSet = taken instanceof Set ? taken : new Set(taken);
+	const clip = (value) => {
+		let name = value.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-');
+		name = name.replace(/^-+/, '').replace(/-+$/, '');
+		if (name.length > maxLen) name = name.slice(0, maxLen).replace(/-+$/, '');
+		if (name.length < 3) name = `${name}db`.slice(0, maxLen);
+		return name;
+	};
+
+	let candidate = clip(base);
+	if (!takenSet.has(candidate)) return candidate;
+	for (let n = 2; n < 100; n++) {
+		const suffix = `-${n}`;
+		candidate = clip(`${base.slice(0, Math.max(3, maxLen - suffix.length))}${suffix}`);
+		if (!takenSet.has(candidate)) return candidate;
+	}
+	return clip(`${base}-${Date.now().toString(36).slice(-4)}`);
+}
+
+function previewNames(names, limit = 8) {
+	const list = [...names];
+	if (list.length === 0) return '';
+	const shown = list.slice(0, limit).join(', ');
+	return list.length > limit ? `${shown}, …` : shown;
+}
+
 function nodeMajor() {
 	const path = which('node');
 	if (!path) return null;
@@ -639,6 +695,55 @@ async function askHostname(domain) {
 	return host;
 }
 
+async function askCloudResource({
+	label,
+	current,
+	taken,
+	altBase,
+	flagValue,
+	validate,
+	invalidHint
+}) {
+	const takenSet = new Set(taken);
+	let suggested = current;
+	if (takenSet.has(current)) {
+		warn(`${label} "${current}" already exists on this account — probably another project.`);
+		suggested = uniqueName(altBase, takenSet);
+		log(`  ${c.dim(`Suggested new name: ${suggested}`)}`);
+	}
+
+	if (flagValue) {
+		const name = flagValue.trim().toLowerCase();
+		if (!validate(name)) throw new Error(`Invalid ${label} name "${flagValue}". ${invalidHint}`);
+		if (takenSet.has(name) && !args.yes) {
+			if (!(await confirm(`Reuse existing ${label} "${name}"?`, false))) {
+				throw new Error(`Pick a different --${label === 'D1' ? 'd1' : 'r2'}-name. "${name}" already exists.`);
+			}
+		} else if (takenSet.has(name)) {
+			warn(`Reusing existing ${label} "${name}".`);
+		}
+		return name;
+	}
+
+	if (args.yes) return suggested;
+
+	while (true) {
+		const name = (await prompt(`${label} name`, suggested)).toLowerCase();
+		if (!validate(name)) {
+			warn(invalidHint);
+			continue;
+		}
+		if (takenSet.has(name)) {
+			if (await confirm(`Reuse existing ${label} "${name}"? This will share it with whatever already uses it.`, false)) {
+				return name;
+			}
+			warn('Enter a different name to create a new one.');
+			continue;
+		}
+		return name;
+	}
+}
+
 function listD1() {
 	const result = wrangler(['d1', 'list', '--json'], { allowFail: true });
 	const parsed = parseJsonOutput(`${result.stdout}\n${result.stderr}`);
@@ -680,12 +785,7 @@ function createD1(name) {
 	throw new Error(text.trim() || `Failed to create D1 database "${name}".`);
 }
 
-async function ensureD1(databaseName, currentId) {
-	if (currentId && currentId !== D1_PLACEHOLDER) {
-		ok(`D1 ${databaseName} (${currentId})`);
-		return currentId;
-	}
-
+async function ensureD1(databaseName) {
 	const existing = listD1().find((row) => row.name === databaseName);
 	if (existing) {
 		ok(`reusing D1 ${databaseName} (${existing.id})`);
@@ -698,24 +798,28 @@ async function ensureD1(databaseName, currentId) {
 	return id;
 }
 
-function r2BucketExists(bucketName) {
+function listR2Names() {
 	const result = wrangler(['r2', 'bucket', 'list', '--json'], { allowFail: true });
 	const parsed = parseJsonOutput(`${result.stdout}\n${result.stderr}`);
 	const rows = Array.isArray(parsed) ? parsed : parsed?.buckets ?? parsed?.result ?? [];
-	const names = rows
+	const fromJson = rows
 		.map((row) => (typeof row === 'string' ? row : row.name ?? row.Name))
 		.filter(Boolean);
-	if (names.includes(bucketName)) return true;
+	if (fromJson.length > 0) return fromJson;
 
 	const table = wrangler(['r2', 'bucket', 'list'], { allowFail: true });
-	return new RegExp(`\\b${bucketName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(
-		`${table.stdout}\n${table.stderr}`
-	);
+	const text = `${table.stdout}\n${table.stderr}`;
+	const names = [];
+	for (const line of text.split('\n')) {
+		const match = line.match(/\b([a-z0-9][a-z0-9-]{1,61}[a-z0-9])\b/i);
+		if (match && !/^(name|creation|location|id)$/i.test(match[1])) names.push(match[1]);
+	}
+	return names;
 }
 
 function ensureR2(bucketName) {
-	if (r2BucketExists(bucketName)) {
-		ok(`R2 bucket ${bucketName}`);
+	if (listR2Names().includes(bucketName)) {
+		ok(`reusing R2 bucket ${bucketName}`);
 		return;
 	}
 
@@ -730,6 +834,16 @@ function ensureR2(bucketName) {
 		return;
 	}
 	throw new Error(text.trim() || `Failed to create R2 bucket "${bucketName}".`);
+}
+
+function setPackageMigrateScripts(databaseName) {
+	const pkgPath = join(root, 'package.json');
+	if (!existsSync(pkgPath)) return;
+	const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+	if (!pkg.scripts) return;
+	pkg.scripts['db:migrate:local'] = `wrangler d1 migrations apply ${databaseName} --local`;
+	pkg.scripts['db:migrate:remote'] = `wrangler d1 migrations apply ${databaseName} --remote`;
+	writeFileSync(pkgPath, `${JSON.stringify(pkg, null, '\t')}\n`);
 }
 
 function putSecret(name, value) {
@@ -1032,14 +1146,40 @@ async function main() {
 	if (hostname) ok(`UI hostname ${hostname}`);
 
 	section(4, total, 'D1 and R2');
-	const databaseName = jsoncString(source, 'database_name') || 'quickmail';
-	const bucketName = jsoncString(source, 'bucket_name') || 'quickmail-attachments';
-	const databaseId = await ensureD1(databaseName, jsoncString(source, 'database_id'));
+	const existingD1 = listD1();
+	const existingR2 = listR2Names();
+	const d1Taken = existingD1.map((row) => row.name);
+	if (d1Taken.length) log(`  Existing D1: ${previewNames(d1Taken)}`);
+	if (existingR2.length) log(`  Existing R2: ${previewNames(existingR2)}`);
+
+	const domainSlug = slugDomain(domain);
+	const databaseName = await askCloudResource({
+		label: 'D1',
+		current: jsoncString(source, 'database_name') || 'quickmail',
+		taken: d1Taken,
+		altBase: `${workerName}-${domainSlug}`,
+		flagValue: args.d1Name,
+		validate: isWorkerName,
+		invalidHint: 'Use lowercase letters, numbers, and hyphens.'
+	});
+	const bucketName = await askCloudResource({
+		label: 'R2',
+		current: jsoncString(source, 'bucket_name') || 'quickmail-attachments',
+		taken: existingR2,
+		altBase: `${workerName}-${domainSlug}-attachments`,
+		flagValue: args.r2Name,
+		validate: isR2BucketName,
+		invalidHint: '3–63 characters, lowercase letters, numbers, and hyphens.'
+	});
+	ok(`D1 name ${databaseName}`);
+	ok(`R2 name ${bucketName}`);
+	const databaseId = await ensureD1(databaseName);
 	ensureR2(bucketName);
 
 	section(5, total, 'Config');
 	source = readWrangler();
 	source = setFirstString(source, 'name', workerName);
+	source = setFirstString(source, 'database_name', databaseName);
 	source = setFirstString(source, 'database_id', databaseId);
 	source = setFirstString(source, 'bucket_name', bucketName);
 	source = setVars(source, {
@@ -1054,6 +1194,8 @@ async function main() {
 	}
 	writeWrangler(source);
 	ok('updated wrangler.jsonc');
+	setPackageMigrateScripts(databaseName);
+	if (databaseName !== 'quickmail') ok(`updated package.json migrate scripts for ${databaseName}`);
 
 	const devVars = {
 		EMAIL_PROVIDER: provider

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Bootstrap QuickMail setup: install bun if needed, install deps, run the wizard.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+say() { printf '%s\n' "$*"; }
+ok() { printf '  ✓ %s\n' "$*"; }
+warn() { printf '  ! %s\n' "$*"; }
+
+has_bun() {
+	command -v bun >/dev/null 2>&1
+}
+
+has_node() {
+	command -v node >/dev/null 2>&1
+}
+
+node_major() {
+	node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1
+}
+
+ask_yes() {
+	# $1 prompt, default yes
+	local reply
+	if [[ ! -t 0 ]]; then
+		return 0
+	fi
+	read -r -p "  $1 [Y/n] " reply || true
+	reply="$(printf '%s' "$reply" | tr '[:upper:]' '[:lower:]')"
+	[[ -z "$reply" || "$reply" == y || "$reply" == yes ]]
+}
+
+say ""
+say "QuickMail setup"
+say "  Installing anything that's missing, then the domain wizard."
+say ""
+
+if ! has_bun; then
+	warn "Bun is not installed. QuickMail's build and deploy scripts use bun."
+	if ask_yes "Install bun now?"; then
+		if [[ "$(uname -s)" == "MINGW"* || "$(uname -s)" == "MSYS"* || "$(uname -s)" == "CYGWIN"* ]]; then
+			say "  Install bun from https://bun.sh on Windows, then re-run: bash scripts/setup.sh"
+			exit 1
+		fi
+		curl -fsSL https://bun.sh/install | bash
+		export PATH="$BUN_INSTALL/bin:$PATH"
+		if ! has_bun; then
+			say "  Bun installed, but this shell cannot see it yet."
+			say "  Add $BUN_INSTALL/bin to PATH and re-run: bash scripts/setup.sh"
+			exit 1
+		fi
+		ok "bun $(bun --version)"
+	elif has_node; then
+		major="$(node_major)"
+		if [[ -n "$major" && "$major" -ge 20 ]]; then
+			warn "Continuing with Node $(node -v). Some package.json scripts still call bun."
+		else
+			say "  Need bun (https://bun.sh) or Node 20+ (https://nodejs.org)."
+			exit 1
+		fi
+	else
+		say "  Need bun (https://bun.sh) or Node 20+ (https://nodejs.org)."
+		exit 1
+	fi
+else
+	ok "bun $(bun --version)"
+fi
+
+if has_bun; then
+	bun install
+	ok "dependencies installed"
+	exec bun "$ROOT/scripts/setup.mjs" "$@"
+fi
+
+npm install
+ok "dependencies installed"
+exec node "$ROOT/scripts/setup.mjs" "$@"

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,7 @@
 		"binding": "ASSETS"
 	},
 
+	// Prefer `bun run setup` (or `bash scripts/setup.sh`) over editing this by hand.
 	// Mail provider is selected by EMAIL_PROVIDER (resend | cloudflare).
 	// Resend secrets (when EMAIL_PROVIDER=resend or unset):
 	//   wrangler secret put RESEND_API_KEY
@@ -49,7 +50,7 @@
 		{
 			"binding": "DB",
 			"database_name": "quickmail",
-			// Run `wrangler d1 create quickmail` and paste the id it prints here.
+			// `bun run setup` fills this in, or: wrangler d1 create quickmail
 			"database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID",
 			"migrations_dir": "migrations"
 		}
@@ -58,7 +59,7 @@
 	"r2_buckets": [
 		{
 			"binding": "ATTACHMENTS",
-			// Run `wrangler r2 bucket create quickmail-attachments`.
+			// `bun run setup` creates this, or: wrangler r2 bucket create quickmail-attachments
 			"bucket_name": "quickmail-attachments"
 		}
 	],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,7 +50,7 @@
 		{
 			"binding": "DB",
 			"database_name": "quickmail",
-			// `bun run setup` fills this in, or: wrangler d1 create quickmail
+			// `bun run setup` fills this in, or: wrangler d1 create <name>
 			"database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID",
 			"migrations_dir": "migrations"
 		}
@@ -59,7 +59,7 @@
 	"r2_buckets": [
 		{
 			"binding": "ATTACHMENTS",
-			// `bun run setup` creates this, or: wrangler r2 bucket create quickmail-attachments
+			// `bun run setup` creates this, or: wrangler r2 bucket create <name>
 			"bucket_name": "quickmail-attachments"
 		}
 	],


### PR DESCRIPTION
## Summary
- Add `bun run setup` / `bash scripts/setup.sh` to install tools, log in to Cloudflare, create D1/R2, write env/config, and onboard a Resend or Cloudflare Email domain.
- Point the README and wrangler comments at the wizard; keep the old numbered steps as manual setup.
- Bump Wrangler to `^4.124.0` so Email Sending enable and inbound `addresses` work.

## Test plan
- [ ] `node scripts/setup.mjs --help` prints flags
- [ ] `bash scripts/setup.sh` (or `bun run setup`) prompts for domain and provider without crashing
- [ ] Cloudflare track: login, D1/R2, `wrangler.jsonc` vars + `addresses`, `.dev.vars` updated
- [ ] Resend track: API key stored via `wrangler secret put` (not in argv), `.dev.vars` updated
- [ ] `bun run check:clean` still passes (no live D1 id or secrets in tracked files)
- [ ] `bun run check` and `bun run build` succeed


Made with [Cursor](https://cursor.com)