### PR TITLE
Add scoped API keys, CLI, and MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Deploys to Cloudflare Workers.
 - **Multiple domains and users** — each user has addresses and a default sending identity. Admins get a catch-all and an unrouted-mail view.
 - **Delivery status** — Resend reports delivered / bounced / complained over webhooks. Cloudflare marks a send `sent` once the binding accepts it.
 - **Light and dark themes.**
+- **Programmatic API** — each user can issue long-lived API keys and `POST /api/mail` to send from a script, no browser or session cookie needed.
+- **CLI and MCP** — the same keys drive `quickmail` in the terminal and an MCP server for agents.
 
 ---
 
@@ -308,6 +310,89 @@ That in-app catch-all is separate from Cloudflare Email Routing's catch-all.
 Routing's catch-all gets the message **into** the Worker. QuickMail's catch-all
 decides **which user** sees it.
 
+## Send from a script (API keys)
+
+Signing in with a browser only gets you a cookie that lives seven days — fine for
+a human, awkward for automation. Any user can instead mint a long-lived API key
+under **Settings → API keys** and use it as a bearer token on the mail API.
+
+```sh
+curl https://your-worker/api/mail \
+  -H "Authorization: Bearer qm_live_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fromAddressId": "<optional — defaults to your send identity>",
+    "to": "you@example.com",
+    "cc": "cc@example.com",
+    "subject": "hello from a script",
+    "text": "hi"
+  }'
+```
+
+`POST /api/mail` returns `{"ok": true, "id": "<emailId>"}`. List conversations
+with `GET /api/mail?view=inbox` (or `?direction=outbound` for sent). Keys only
+ever authenticate an allowlisted set
+of `/api/*` routes — the web UI and **Settings → API keys** still need a normal
+session — and revoking a key in Settings takes effect immediately.
+
+Scopes are enforced: `mail:read` cannot send, `mail:send` cannot hit admin
+routes, and a key cannot mint another key. Apply `migrations/0009_api_tokens.sql`
+after pulling.
+
+> Only the SHA-256 hash of a key is stored; the raw value is shown once at
+> creation. If you lose it, revoke and mint a new one.
+
+## CLI and MCP
+
+Install the CLI from GitHub (no npm). The command is also on **Settings → API keys**:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DivinPrince/quickmail/main/scripts/install.sh | sh
+quickmail login --url https://<your-quickmail-instance> --token <key from Settings>
+quickmail inbox
+quickmail search "invoice"
+quickmail read <thread-id>
+quickmail send --to someone@example.com --subject "Hi" --body "Hello"
+quickmail users list          # admin scope
+quickmail unrouted            # admin scope
+```
+
+Install from `main` by default (`QUICKMAIL_REF` selects another ref). Your
+instance URL is only for `quickmail login --url` — optional:
+`curl -fsSL https://<your-instance>/install.sh | sh` sets `QUICKMAIL_URL` then
+runs the GitHub installer.
+
+Create the key under **Settings → API keys**. The installer never asks for a token.
+`QUICKMAIL_URL` and `QUICKMAIL_TOKEN` override the saved config.
+
+From this repo, or via npm: `bunx quickmail …` / `bun run quickmail -- inbox`.
+
+The same credentials drive an MCP server for Claude, Cursor, and other agents
+(`bunx` keeps the MCP SDK available; the curl install skips `mcp.ts`):
+
+```bash
+bunx quickmail mcp
+```
+
+Tools: `list_threads`, `get_thread`, `search_mail`, `send_message`, `reply`, `list_attachments`.
+
+Claude Desktop / Cursor example:
+
+```json
+{
+  "mcpServers": {
+    "quickmail": {
+      "command": "bunx",
+      "args": ["quickmail", "mcp"],
+      "env": {
+        "QUICKMAIL_URL": "https://mail.example.com",
+        "QUICKMAIL_TOKEN": "qm_live_…"
+      }
+    }
+  }
+}
+```
+
 ## Layout
 
 ```
@@ -320,7 +405,10 @@ src/
     utils/           HTML, quoting, dates, attachments
 scripts/
   setup.sh / setup.mjs   first-run wizard (tools, login, domain, env)
+  install.sh             GitHub CLI installer (instance /install.sh is a thin wrapper)
   wrap-cloudflare-worker.mjs   attach email() after the SvelteKit build
+cli/                 quickmail CLI + MCP server (talks to a deployed instance)
+bin/quickmail.mjs
 migrations/          D1 schema, applied in order
 ```
 

--- a/bin/quickmail.mjs
+++ b/bin/quickmail.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import '../cli/main.ts';

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,10 @@
     "": {
       "name": "mail",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "postal-mime": "^3.0.0",
         "remixicon": "^4.9.1",
+        "zod": "^3.25.0",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260601.1",
@@ -102,6 +104,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
@@ -165,6 +169,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -266,7 +272,13 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
@@ -274,37 +286,127 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "esrap": ["esrap@2.2.9", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.6.2", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.5.0", "", {}, "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -336,15 +438,41 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "miniflare": ["miniflare@5.20260815.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260815.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -354,9 +482,19 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "postal-mime": ["postal-mime@3.0.0", "", {}, "sha512-Z4a9ar2Bv3YpK3IXag+Yda30k7bMZfpRuUGyqtHnZ2pjHG8Bl62EhZIk4n1dzv00gfzP9g+94e9kd8+XmjVWLA=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -364,19 +502,45 @@
 
     "remixicon": ["remixicon@4.9.1", "", {}, "sha512-36gLSoujkabnCFZFDyP17VNh9piuBA/rsXUb4auSJWLGsHVXtmxLj/EM5FjaEAGnk8oIAj1Azob/DZ2N+90lAQ=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
 
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -390,9 +554,13 @@
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
@@ -402,15 +570,23 @@
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
 
     "worktop": ["worktop@0.8.0-next.18", "", { "dependencies": { "mrmime": "^2.0.0", "regexparam": "^3.0.0" } }, "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw=="],
 
     "wrangler": ["wrangler@4.124.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260815.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260815.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260815.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
@@ -419,6 +595,10 @@
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
@@ -435,6 +615,14 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "type-is/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
     "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/cli/client.test.ts
+++ b/cli/client.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { safeDownloadName } from './client.ts';
+
+describe('safeDownloadName', () => {
+	test('strips directory components and absolute paths', () => {
+		assert.equal(safeDownloadName('../../.ssh/authorized_keys'), 'authorized_keys');
+		assert.equal(safeDownloadName('/tmp/payload'), 'payload');
+		assert.equal(safeDownloadName('C:\\Windows\\win.ini'), 'win.ini');
+		assert.equal(safeDownloadName('invoice.pdf'), 'invoice.pdf');
+	});
+
+	test('falls back when the name is empty or a traversal residue', () => {
+		assert.equal(safeDownloadName(''), 'attachment');
+		assert.equal(safeDownloadName('..'), 'attachment');
+		assert.equal(safeDownloadName('/'), 'attachment');
+	});
+});

--- a/cli/client.ts
+++ b/cli/client.ts
@@ -1,0 +1,268 @@
+import { basename } from 'node:path';
+import { normalizeUrl } from './config.ts';
+
+/** Keep downloads inside the working directory — never honor `../` or absolute names. */
+export function safeDownloadName(name: string): string {
+	const base = basename(name.replaceAll('\\', '/'));
+	if (!base || base === '.' || base === '..') return 'attachment';
+	return base;
+}
+
+export class QuickMailError extends Error {
+	constructor(
+		readonly status: number,
+		message: string
+	) {
+		super(message);
+		this.name = 'QuickMailError';
+	}
+}
+
+export type MailboxView = 'inbox' | 'starred' | 'drafts' | 'sent' | 'trash';
+
+export type ThreadSummary = {
+	thread_id: string;
+	latest_id: string;
+	subject: string;
+	preview: string;
+	participants: { label: string; address: string; self: boolean }[];
+	message_count: number;
+	is_read: boolean;
+	is_starred: boolean;
+	created_at: string;
+};
+
+export type ThreadMessage = {
+	id: string;
+	direction: 'inbound' | 'outbound';
+	from_addr: string;
+	to_addr: string;
+	cc_addr: string | null;
+	subject: string;
+	body_text: string | null;
+	body_html: string | null;
+	created_at: string;
+	attachments: {
+		id: string;
+		filename: string;
+		content_type: string;
+		size_bytes: number;
+	}[];
+};
+
+export type MailboxPage = {
+	threads: ThreadSummary[];
+	total: number;
+	page: number;
+	pageCount: number;
+	pageSize: number;
+};
+
+export type User = {
+	id: string;
+	email: string;
+	name: string;
+	is_admin: boolean;
+};
+
+export type Domain = {
+	id: string;
+	name: string;
+	status: string;
+	sending_enabled: boolean;
+	receiving_enabled: boolean;
+};
+
+export type MailAddress = {
+	id: string;
+	user_id: string;
+	domain_id: string;
+	domain_name: string;
+	address: string;
+	is_default: boolean;
+};
+
+export type UnroutedEmail = {
+	id: string;
+	from_addr: string;
+	to_addr: string;
+	subject: string | null;
+	reason: string;
+	created_at: string;
+};
+
+export type ListThreadsQuery = {
+	view?: MailboxView;
+	q?: string;
+	page?: number;
+	unread?: boolean;
+	starred?: boolean;
+	attachments?: boolean;
+	domain?: string;
+};
+
+export class QuickMailClient {
+	readonly url: string;
+
+	constructor(
+		url: string,
+		readonly token: string
+	) {
+		this.url = normalizeUrl(url);
+	}
+
+	async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+		const headers = new Headers(init.headers);
+		headers.set('authorization', `Bearer ${this.token}`);
+		headers.set('accept', 'application/json');
+		if (init.body && !headers.has('content-type')) {
+			headers.set('content-type', 'application/json');
+		}
+
+		const res = await fetch(`${this.url}${path}`, { ...init, headers });
+		if (res.headers.get('content-type')?.includes('application/json')) {
+			const body = (await res.json()) as T & { error?: string };
+			if (!res.ok) {
+				throw new QuickMailError(res.status, body.error ?? res.statusText);
+			}
+			return body;
+		}
+
+		if (!res.ok) {
+			throw new QuickMailError(res.status, res.statusText);
+		}
+		return undefined as T;
+	}
+
+	async whoami(): Promise<User> {
+		const body = await this.request<{ user: User }>('/api/auth/me');
+		return body.user;
+	}
+
+	async listThreads(query: ListThreadsQuery = {}): Promise<MailboxPage> {
+		const params = new URLSearchParams();
+		if (query.view) params.set('view', query.view);
+		if (query.q) params.set('q', query.q);
+		if (query.page && query.page > 1) params.set('page', String(query.page));
+		if (query.unread) params.set('unread', '1');
+		if (query.starred) params.set('starred', '1');
+		if (query.attachments) params.set('attachments', '1');
+		if (query.domain) params.set('domain', query.domain);
+		const suffix = params.size > 0 ? `?${params}` : '';
+		return this.request<MailboxPage>(`/api/mail${suffix}`);
+	}
+
+	async getThread(id: string): Promise<{ threadId: string; subject: string; messages: ThreadMessage[] }> {
+		return this.request(`/api/mail/${encodeURIComponent(id)}`);
+	}
+
+	async sendMessage(input: {
+		to: string;
+		subject: string;
+		text?: string;
+		html?: string;
+		cc?: string;
+		bcc?: string;
+		fromAddressId?: string;
+	}): Promise<{ id: string }> {
+		return this.request('/api/mail', {
+			method: 'POST',
+			body: JSON.stringify(input)
+		});
+	}
+
+	async reply(id: string, input: { text?: string; html?: string; fromAddressId?: string }): Promise<{ id: string }> {
+		return this.request(`/api/mail/${encodeURIComponent(id)}`, {
+			method: 'POST',
+			body: JSON.stringify(input)
+		});
+	}
+
+	async listAddresses(all = false): Promise<MailAddress[]> {
+		const suffix = all ? '?all=1' : '';
+		const body = await this.request<{ addresses: MailAddress[] }>(`/api/addresses${suffix}`);
+		return body.addresses;
+	}
+
+	async downloadAttachment(emailId: string, attachmentId: string): Promise<{ bytes: Uint8Array; filename: string; type: string }> {
+		const res = await fetch(
+			`${this.url}/api/mail/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(attachmentId)}?download=1`,
+			{ headers: { authorization: `Bearer ${this.token}` } }
+		);
+		if (!res.ok) {
+			throw new QuickMailError(res.status, 'Failed to download attachment');
+		}
+
+		const disposition = res.headers.get('content-disposition') ?? '';
+		const match = /filename="([^"]+)"/.exec(disposition);
+		const filename = safeDownloadName(match ? decodeURIComponent(match[1]) : attachmentId);
+
+		return {
+			bytes: new Uint8Array(await res.arrayBuffer()),
+			filename,
+			type: res.headers.get('content-type') ?? 'application/octet-stream'
+		};
+	}
+
+	async listUsers(): Promise<{ users: User[]; addresses: MailAddress[] }> {
+		return this.request('/api/admin/users');
+	}
+
+	async createUser(input: {
+		name: string;
+		domainId: string;
+		localPart: string;
+		password: string;
+	}): Promise<{ user: User; address: MailAddress }> {
+		return this.request('/api/admin/users', {
+			method: 'POST',
+			body: JSON.stringify(input)
+		});
+	}
+
+	async deleteUser(id: string): Promise<void> {
+		await this.request(`/api/admin/users/${encodeURIComponent(id)}`, { method: 'DELETE' });
+	}
+
+	async resetPassword(id: string, password: string): Promise<void> {
+		await this.request(`/api/admin/users/${encodeURIComponent(id)}`, {
+			method: 'PATCH',
+			body: JSON.stringify({ password })
+		});
+	}
+
+	async listDomains(): Promise<{ connected: Domain[]; available: { id: string; name: string; connected: boolean }[] }> {
+		return this.request('/api/domains');
+	}
+
+	async connectDomain(domainId: string): Promise<void> {
+		await this.request('/api/domains', {
+			method: 'POST',
+			body: JSON.stringify({ domainId })
+		});
+	}
+
+	async disconnectDomain(id: string): Promise<void> {
+		await this.request(`/api/domains/${encodeURIComponent(id)}`, { method: 'DELETE' });
+	}
+
+	async createAddress(input: {
+		domainId: string;
+		localPart: string;
+		userId?: string;
+		label?: string;
+	}): Promise<MailAddress> {
+		const body = await this.request<{ address: MailAddress }>('/api/addresses', {
+			method: 'POST',
+			body: JSON.stringify(input)
+		});
+		return body.address;
+	}
+
+	async listUnrouted(limit = 50): Promise<UnroutedEmail[]> {
+		const body = await this.request<{ unrouted: UnroutedEmail[] }>(
+			`/api/admin/unrouted?limit=${limit}`
+		);
+		return body.unrouted;
+	}
+}

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -1,0 +1,94 @@
+import { chmod, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export type CliConfig = {
+	url: string;
+	token: string;
+};
+
+function configPath(): string {
+	const override = process.env.QUICKMAIL_CONFIG;
+	if (override) return override;
+	const base = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
+	return join(base, 'quickmail', 'config.json');
+}
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+/** Require http(s). HTTP is only allowed for loopback. Never echo the input. */
+export function normalizeUrl(url: string): string {
+	let parsed: URL;
+	try {
+		parsed = new URL(url.trim());
+	} catch {
+		throw new Error('QuickMail URL is invalid.');
+	}
+
+	if (parsed.username || parsed.password) {
+		throw new Error('QuickMail URL must not include credentials.');
+	}
+
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		throw new Error('QuickMail URL must use http or https.');
+	}
+
+	if (!parsed.hostname) {
+		throw new Error('QuickMail URL is invalid.');
+	}
+
+	const host = parsed.hostname.toLowerCase();
+	if (parsed.protocol === 'http:' && !LOCAL_HOSTS.has(host)) {
+		throw new Error('HTTP is only allowed for localhost.');
+	}
+
+	return parsed.href.replace(/\/+$/, '');
+}
+
+export async function loadConfig(): Promise<CliConfig> {
+	const envUrl = process.env.QUICKMAIL_URL;
+	const envToken = process.env.QUICKMAIL_TOKEN;
+	if (envUrl && envToken) {
+		return { url: normalizeUrl(envUrl), token: envToken };
+	}
+
+	let raw: Partial<CliConfig>;
+	try {
+		raw = JSON.parse(await readFile(configPath(), 'utf8')) as Partial<CliConfig>;
+	} catch {
+		throw new Error(
+			'Not logged in. Run `quickmail login --url <instance> --token <key>` or set QUICKMAIL_URL and QUICKMAIL_TOKEN.'
+		);
+	}
+
+	const url = envUrl ?? raw.url;
+	const token = envToken ?? raw.token;
+	if (!url || !token) {
+		throw new Error(
+			'Not logged in. Run `quickmail login --url <instance> --token <key>` or set QUICKMAIL_URL and QUICKMAIL_TOKEN.'
+		);
+	}
+	return { url: normalizeUrl(url), token };
+}
+
+export async function saveConfig(config: CliConfig): Promise<string> {
+	const path = configPath();
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(
+		path,
+		`${JSON.stringify({ url: normalizeUrl(config.url), token: config.token }, null, 2)}\n`,
+		{ mode: 0o600 }
+	);
+	await chmod(path, 0o600);
+	return path;
+}
+
+export async function clearConfig(): Promise<void> {
+	try {
+		await unlink(configPath());
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+	}
+}
+
+export { configPath };

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,0 +1,488 @@
+import { writeFile } from 'node:fs/promises';
+import { stdin as stdinStream } from 'node:process';
+import {
+	QuickMailClient,
+	QuickMailError,
+	safeDownloadName,
+	type MailboxView,
+	type ThreadSummary
+} from './client.ts';
+import { clearConfig, loadConfig, saveConfig } from './config.ts';
+
+const HELP = `quickmail — operate a QuickMail instance from the terminal
+
+Usage:
+  quickmail login --url <https://mail.example.com> --token <qm_live_…>
+  quickmail logout
+  quickmail whoami
+
+Mail:
+  quickmail inbox [--page N] [--unread] [--domain ID]
+  quickmail search <query> [--view inbox|sent|drafts|starred|trash]
+  quickmail read <thread-or-message-id>
+  quickmail send --to <addr> --subject <text> [--body <text>] [--from <address-id>]
+  quickmail reply <id> [--body <text>]
+  quickmail attachments <id>
+  quickmail download <email-id> <attachment-id> [--out file]
+
+Admin:
+  quickmail users list
+  quickmail users create --name <name> --local <part> --domain <id> --password <pw>
+  quickmail users delete <id>
+  quickmail users passwd <id-or-email> --password <pw>
+  quickmail domains list
+  quickmail domains connect <id>
+  quickmail domains disconnect <id>
+  quickmail addresses list [--all]
+  quickmail addresses create --local <part> --domain <id> [--user <id>]
+  quickmail unrouted
+
+MCP:
+  quickmail mcp
+
+Auth is a Settings → API keys bearer token. QUICKMAIL_URL and QUICKMAIL_TOKEN
+override the saved config. Use --json on mail/admin commands for raw output.
+`;
+
+type Flags = Record<string, string | boolean>;
+
+function parseArgv(argv: string[]): { command: string[]; flags: Flags } {
+	const command: string[] = [];
+	const flags: Flags = {};
+
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === '--') {
+			command.push(...argv.slice(i + 1));
+			break;
+		}
+		if (arg.startsWith('--')) {
+			const [rawKey, inline] = arg.slice(2).split('=', 2);
+			const key = alias(rawKey);
+			if (inline !== undefined) {
+				flags[key] = inline;
+			} else if (argv[i + 1] && !argv[i + 1].startsWith('-')) {
+				flags[key] = argv[i + 1];
+				i += 1;
+			} else {
+				flags[key] = true;
+			}
+			continue;
+		}
+		if (arg.startsWith('-') && arg.length === 2) {
+			const key = alias(arg.slice(1));
+			if (argv[i + 1] && !argv[i + 1].startsWith('-')) {
+				flags[key] = argv[i + 1];
+				i += 1;
+			} else {
+				flags[key] = true;
+			}
+			continue;
+		}
+		command.push(arg);
+	}
+
+	return { command, flags };
+}
+
+function alias(key: string): string {
+	switch (key) {
+		case 't':
+			return 'to';
+		case 's':
+			return 'subject';
+		case 'b':
+			return 'body';
+		case 'q':
+			return 'query';
+		case 'h':
+			return 'help';
+		case 'u':
+			return 'url';
+		default:
+			return key;
+	}
+}
+
+function flagString(flags: Flags, key: string): string | undefined {
+	const value = flags[key];
+	return typeof value === 'string' ? value : undefined;
+}
+
+function flagBool(flags: Flags, key: string): boolean {
+	return flags[key] === true || flags[key] === '1' || flags[key] === 'true';
+}
+
+async function readBody(flags: Flags): Promise<string> {
+	const inline = flagString(flags, 'body');
+	if (inline) return inline;
+	if (!stdinStream.isTTY) {
+		const chunks: Buffer[] = [];
+		for await (const chunk of stdinStream) chunks.push(Buffer.from(chunk));
+		return Buffer.concat(chunks).toString('utf8').trim();
+	}
+	return '';
+}
+
+function printJson(value: unknown): void {
+	console.log(JSON.stringify(value, null, 2));
+}
+
+function printThreads(page: { threads: ThreadSummary[]; total: number; page: number; pageCount: number }): void {
+	if (page.threads.length === 0) {
+		console.log('No conversations.');
+		return;
+	}
+
+	for (const thread of page.threads) {
+		const who = thread.participants
+			.map((participant) => (participant.self ? 'me' : participant.label || participant.address))
+			.join(', ');
+		const unread = thread.is_read ? ' ' : '*';
+		console.log(`${unread} ${thread.thread_id}  ${who}`);
+		console.log(`  ${thread.subject || '(no subject)'}  — ${thread.preview}`);
+	}
+	console.log(`\n${page.total} conversation${page.total === 1 ? '' : 's'}  page ${page.page}/${page.pageCount}`);
+}
+
+async function clientFromConfig(): Promise<QuickMailClient> {
+	const config = await loadConfig();
+	return new QuickMailClient(config.url, config.token);
+}
+
+async function resolveUserId(client: QuickMailClient, idOrEmail: string): Promise<string> {
+	if (!idOrEmail.includes('@')) return idOrEmail;
+	const { users } = await client.listUsers();
+	const user = users.find((entry) => entry.email.toLowerCase() === idOrEmail.toLowerCase());
+	if (!user) throw new Error(`No user with email ${idOrEmail}`);
+	return user.id;
+}
+
+function mailboxView(value: string | undefined): MailboxView {
+	switch (value) {
+		case 'inbox':
+		case 'starred':
+		case 'drafts':
+		case 'sent':
+		case 'trash':
+			return value;
+		case undefined:
+			return 'inbox';
+		default:
+			throw new Error('view must be inbox, sent, drafts, starred, or trash');
+	}
+}
+
+async function run(argv: string[]): Promise<number> {
+	const { command, flags } = parseArgv(argv);
+	if (flagBool(flags, 'help') || command[0] === 'help' || command.length === 0) {
+		console.log(HELP);
+		return 0;
+	}
+
+	const json = flagBool(flags, 'json');
+	const [head, sub, ...rest] = command;
+
+	switch (head) {
+		case 'login': {
+			const url = flagString(flags, 'url');
+			const token = flagString(flags, 'token') ?? process.env.QUICKMAIL_TOKEN;
+			if (!url) {
+				throw new Error('login requires --url');
+			}
+			if (!token) {
+				throw new Error('login requires --token or QUICKMAIL_TOKEN (create a key in Settings → API keys)');
+			}
+			const client = new QuickMailClient(url, token);
+			const user = await client.whoami();
+			const path = await saveConfig({ url, token });
+			console.log(`Logged in as ${user.email} (${path})`);
+			return 0;
+		}
+		case 'logout':
+			await clearConfig();
+			console.log('Logged out.');
+			return 0;
+		case 'whoami': {
+			const user = await (await clientFromConfig()).whoami();
+			if (json) printJson(user);
+			else console.log(`${user.name} <${user.email}>${user.is_admin ? '  admin' : ''}`);
+			return 0;
+		}
+		case 'inbox':
+		case 'list': {
+			const client = await clientFromConfig();
+			const page = await client.listThreads({
+				view: 'inbox',
+				page: Number(flagString(flags, 'page')) || 1,
+				unread: flagBool(flags, 'unread'),
+				domain: flagString(flags, 'domain')
+			});
+			if (json) printJson(page);
+			else printThreads(page);
+			return 0;
+		}
+		case 'search': {
+			const q = rest[0] ?? sub ?? flagString(flags, 'query');
+			if (!q) throw new Error('search requires a query');
+			const client = await clientFromConfig();
+			const page = await client.listThreads({
+				q,
+				view: mailboxView(flagString(flags, 'view')),
+				page: Number(flagString(flags, 'page')) || 1
+			});
+			if (json) printJson(page);
+			else printThreads(page);
+			return 0;
+		}
+		case 'read':
+		case 'thread': {
+			const id = sub;
+			if (!id) throw new Error('read requires a thread or message id');
+			const client = await clientFromConfig();
+			const thread = await client.getThread(id);
+			if (json) {
+				printJson(thread);
+				return 0;
+			}
+			console.log(thread.subject);
+			for (const message of thread.messages) {
+				console.log(`\n--- ${message.from_addr} → ${message.to_addr}  ${message.created_at}`);
+				console.log(message.body_text?.trim() || '(no text body)');
+				if (message.attachments.length > 0) {
+					console.log(
+						message.attachments
+							.map((attachment) => `  attachment ${attachment.id}  ${attachment.filename}`)
+							.join('\n')
+					);
+				}
+			}
+			return 0;
+		}
+		case 'send': {
+			const to = flagString(flags, 'to');
+			const subject = flagString(flags, 'subject');
+			const text = await readBody(flags);
+			if (!to || !subject || !text) {
+				throw new Error('send requires --to, --subject, and --body (or stdin)');
+			}
+			const result = await (
+				await clientFromConfig()
+			).sendMessage({
+				to,
+				subject,
+				text,
+				cc: flagString(flags, 'cc'),
+				bcc: flagString(flags, 'bcc'),
+				fromAddressId: flagString(flags, 'from')
+			});
+			if (json) printJson(result);
+			else console.log(`Sent ${result.id}`);
+			return 0;
+		}
+		case 'reply': {
+			const id = sub;
+			const text = await readBody(flags);
+			if (!id || !text) throw new Error('reply requires an id and --body (or stdin)');
+			const result = await (await clientFromConfig()).reply(id, { text });
+			if (json) printJson(result);
+			else console.log(`Sent ${result.id}`);
+			return 0;
+		}
+		case 'attachments': {
+			const id = sub;
+			if (!id) throw new Error('attachments requires a thread or message id');
+			const thread = await (await clientFromConfig()).getThread(id);
+			const rows = thread.messages.flatMap((message) =>
+				message.attachments.map((attachment) => ({
+					email_id: message.id,
+					...attachment
+				}))
+			);
+			if (json) printJson(rows);
+			else if (rows.length === 0) console.log('No attachments.');
+			else {
+				for (const row of rows) {
+					console.log(`${row.email_id}  ${row.id}  ${row.filename}  ${row.size_bytes}B`);
+				}
+			}
+			return 0;
+		}
+		case 'download': {
+			const emailId = sub;
+			const attachmentId = rest[0];
+			if (!emailId || !attachmentId) throw new Error('download requires <email-id> <attachment-id>');
+			const file = await (await clientFromConfig()).downloadAttachment(emailId, attachmentId);
+			const out = flagString(flags, 'out') ?? safeDownloadName(file.filename);
+			await writeFile(out, file.bytes);
+			console.log(out);
+			return 0;
+		}
+		case 'users':
+			return usersCommand(sub, rest, flags, json);
+		case 'domains':
+			return domainsCommand(sub, rest, flags, json);
+		case 'addresses':
+			return addressesCommand(sub, rest, flags, json);
+		case 'unrouted': {
+			const items = await (await clientFromConfig()).listUnrouted(Number(flagString(flags, 'limit')) || 50);
+			if (json) printJson(items);
+			else if (items.length === 0) console.log('No unrouted mail.');
+			else {
+				for (const item of items) {
+					console.log(`${item.created_at}  ${item.from_addr} → ${item.to_addr}`);
+					console.log(`  ${item.subject ?? '(no subject)'}  — ${item.reason}`);
+				}
+			}
+			return 0;
+		}
+		case 'mcp': {
+			// Lazy-load MCP so curl-installed mail commands never import @modelcontextprotocol/sdk.
+			const { startMcpServer } = await import('./mcp.ts');
+			await startMcpServer();
+			return 0;
+		}
+		default:
+			throw new Error(`Unknown command "${head}". Run quickmail --help.`);
+	}
+}
+
+async function usersCommand(sub: string | undefined, rest: string[], flags: Flags, json: boolean): Promise<number> {
+	const client = await clientFromConfig();
+
+	switch (sub) {
+		case 'list': {
+			const data = await client.listUsers();
+			if (json) printJson(data);
+			else {
+				for (const user of data.users) {
+					const addrs = data.addresses
+						.filter((address) => address.user_id === user.id)
+						.map((address) => address.address)
+						.join(', ');
+					console.log(`${user.id}  ${user.name}  ${user.email}${user.is_admin ? '  admin' : ''}`);
+					if (addrs) console.log(`  ${addrs}`);
+				}
+			}
+			return 0;
+		}
+		case 'create': {
+			const name = flagString(flags, 'name');
+			const localPart = flagString(flags, 'local');
+			const domainId = flagString(flags, 'domain');
+			const password = flagString(flags, 'password');
+			if (!name || !localPart || !domainId || !password) {
+				throw new Error('users create requires --name, --local, --domain, and --password');
+			}
+			const created = await client.createUser({ name, localPart, domainId, password });
+			if (json) printJson(created);
+			else console.log(`Created ${created.user.email} (${created.user.id})`);
+			return 0;
+		}
+		case 'delete': {
+			const id = rest[0];
+			if (!id) throw new Error('users delete requires a user id');
+			await client.deleteUser(id);
+			console.log(`Deleted ${id}`);
+			return 0;
+		}
+		case 'passwd':
+		case 'password': {
+			const idOrEmail = rest[0];
+			const password = flagString(flags, 'password');
+			if (!idOrEmail || !password) throw new Error('users passwd requires <id-or-email> and --password');
+			const id = await resolveUserId(client, idOrEmail);
+			await client.resetPassword(id, password);
+			console.log(`Password reset for ${idOrEmail}`);
+			return 0;
+		}
+		default:
+			throw new Error('users commands: list, create, delete, passwd');
+	}
+}
+
+async function domainsCommand(sub: string | undefined, rest: string[], flags: Flags, json: boolean): Promise<number> {
+	const client = await clientFromConfig();
+	void flags;
+
+	switch (sub) {
+		case 'list': {
+			const data = await client.listDomains();
+			if (json) printJson(data);
+			else {
+				console.log('Connected');
+				for (const domain of data.connected) {
+					console.log(
+						`  ${domain.id}  ${domain.name}  ${domain.status}  send=${domain.sending_enabled} receive=${domain.receiving_enabled}`
+					);
+				}
+				if (data.available.length > 0) {
+					console.log('Available');
+					for (const domain of data.available) {
+						console.log(`  ${domain.id}  ${domain.name}${domain.connected ? '  connected' : ''}`);
+					}
+				}
+			}
+			return 0;
+		}
+		case 'connect': {
+			const id = rest[0];
+			if (!id) throw new Error('domains connect requires a domain id');
+			await client.connectDomain(id);
+			console.log(`Connected ${id}`);
+			return 0;
+		}
+		case 'disconnect': {
+			const id = rest[0];
+			if (!id) throw new Error('domains disconnect requires a domain id');
+			await client.disconnectDomain(id);
+			console.log(`Disconnected ${id}`);
+			return 0;
+		}
+		default:
+			throw new Error('domains commands: list, connect, disconnect');
+	}
+}
+
+async function addressesCommand(sub: string | undefined, rest: string[], flags: Flags, json: boolean): Promise<number> {
+	const client = await clientFromConfig();
+	void rest;
+
+	switch (sub) {
+		case 'list': {
+			const addresses = await client.listAddresses(flagBool(flags, 'all'));
+			if (json) printJson(addresses);
+			else {
+				for (const address of addresses) {
+					console.log(
+						`${address.id}  ${address.address}${address.is_default ? '  default' : ''}  ${address.user_id}`
+					);
+				}
+			}
+			return 0;
+		}
+		case 'create': {
+			const localPart = flagString(flags, 'local');
+			const domainId = flagString(flags, 'domain');
+			if (!localPart || !domainId) throw new Error('addresses create requires --local and --domain');
+			const address = await client.createAddress({
+				localPart,
+				domainId,
+				userId: flagString(flags, 'user')
+			});
+			if (json) printJson(address);
+			else console.log(`Created ${address.address}`);
+			return 0;
+		}
+		default:
+			throw new Error('addresses commands: list, create');
+	}
+}
+
+const code = await run(process.argv.slice(2)).catch((error) => {
+	const message = error instanceof QuickMailError ? `${error.status} ${error.message}` : error.message;
+	console.error(message);
+	return 1;
+});
+
+if (code !== 0) process.exit(code);

--- a/cli/mcp.ts
+++ b/cli/mcp.ts
@@ -1,0 +1,167 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { QuickMailClient, QuickMailError, type MailboxView } from './client.ts';
+import { loadConfig } from './config.ts';
+
+const views = ['inbox', 'starred', 'drafts', 'sent', 'trash'] as const;
+
+function textResult(value: unknown, isError = false) {
+	return {
+		content: [{ type: 'text' as const, text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) }],
+		isError
+	};
+}
+
+function fail(error: unknown) {
+	if (error instanceof QuickMailError) {
+		return textResult(`${error.status} ${error.message}`, true);
+	}
+	return textResult(error instanceof Error ? error.message : 'Request failed', true);
+}
+
+export async function startMcpServer(): Promise<void> {
+	const config = await loadConfig();
+	const client = new QuickMailClient(config.url, config.token);
+
+	const server = new McpServer({ name: 'quickmail', version: '1.0.0' });
+
+	server.registerTool(
+		'list_threads',
+		{
+			description: 'List mailbox conversations for the authenticated QuickMail user.',
+			inputSchema: {
+				view: z.enum(views).optional().describe('Mailbox to list. Defaults to inbox.'),
+				q: z.string().optional().describe('Search participants, subject, and body.'),
+				page: z.number().int().positive().optional(),
+				unread: z.boolean().optional(),
+				domain: z.string().optional().describe('Connected domain id to filter by.')
+			}
+		},
+		async ({ view, q, page, unread, domain }) => {
+			try {
+				return textResult(
+					await client.listThreads({
+						view: view as MailboxView | undefined,
+						q,
+						page,
+						unread,
+						domain
+					})
+				);
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	server.registerTool(
+		'get_thread',
+		{
+			description: 'Read every message in a conversation. Pass a thread id or any message id from it.',
+			inputSchema: { id: z.string().describe('Thread id or message id.') }
+		},
+		async ({ id }) => {
+			try {
+				return textResult(await client.getThread(id));
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	server.registerTool(
+		'search_mail',
+		{
+			description: 'Search mailbox conversations by participants, subject, or body.',
+			inputSchema: {
+				q: z.string().describe('Search text.'),
+				view: z.enum(views).optional(),
+				page: z.number().int().positive().optional()
+			}
+		},
+		async ({ q, view, page }) => {
+			try {
+				return textResult(await client.listThreads({ q, view: view as MailboxView | undefined, page }));
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	server.registerTool(
+		'send_message',
+		{
+			description: 'Send a new email from the authenticated user.',
+			inputSchema: {
+				to: z.string(),
+				subject: z.string(),
+				text: z.string().optional(),
+				html: z.string().optional(),
+				cc: z.string().optional(),
+				bcc: z.string().optional(),
+				fromAddressId: z.string().optional()
+			}
+		},
+		async (input) => {
+			try {
+				if (!input.text?.trim() && !input.html?.trim()) {
+					return textResult('text or html is required', true);
+				}
+				return textResult(await client.sendMessage(input));
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	server.registerTool(
+		'reply',
+		{
+			description: 'Reply to a message or thread. Recipients and subject are taken from the original.',
+			inputSchema: {
+				id: z.string().describe('Message id to reply to.'),
+				text: z.string().optional(),
+				html: z.string().optional(),
+				fromAddressId: z.string().optional()
+			}
+		},
+		async ({ id, text, html, fromAddressId }) => {
+			try {
+				if (!text?.trim() && !html?.trim()) {
+					return textResult('text or html is required', true);
+				}
+				return textResult(await client.reply(id, { text, html, fromAddressId }));
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	server.registerTool(
+		'list_attachments',
+		{
+			description: 'List attachments on every message in a thread.',
+			inputSchema: { id: z.string().describe('Thread id or message id.') }
+		},
+		async ({ id }) => {
+			try {
+				const thread = await client.getThread(id);
+				const attachments = thread.messages.flatMap((message) =>
+					message.attachments.map((attachment) => ({
+						...attachment,
+						email_id: message.id,
+						from: message.from_addr,
+						subject: message.subject
+					}))
+				);
+				return textResult({ threadId: thread.threadId, attachments });
+			} catch (error) {
+				return fail(error);
+			}
+		}
+	);
+
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+}

--- a/migrations/0009_api_tokens.sql
+++ b/migrations/0009_api_tokens.sql
@@ -1,0 +1,18 @@
+-- Long-lived bearer tokens for the CLI and MCP server. Only the SHA-256 hash
+-- is stored (same derivation as sessions). The raw value is shown once at
+-- create time. `token_preview` is a non-secret fragment so the Settings list
+-- can tell keys apart.
+
+CREATE TABLE api_tokens (
+	id            TEXT PRIMARY KEY,
+	user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	name          TEXT NOT NULL,
+	token_hash    TEXT NOT NULL,
+	token_preview TEXT NOT NULL,
+	scopes        TEXT NOT NULL DEFAULT 'mail:read,mail:send',
+	created_at    TEXT NOT NULL,
+	last_used_at  TEXT
+);
+
+CREATE INDEX idx_api_tokens_user ON api_tokens(user_id);
+CREATE UNIQUE INDEX idx_api_tokens_hash ON api_tokens(token_hash);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"version": "1.0.0",
 	"license": "MIT",
 	"type": "module",
+	"bin": {
+		"quickmail": "./bin/quickmail.mjs"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && bun scripts/wrap-cloudflare-worker.mjs",
@@ -16,7 +19,9 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:clean": "bun scripts/check-template-clean.mjs",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"cf-typegen": "wrangler types"
+		"cf-typegen": "wrangler types",
+		"quickmail": "bun cli/main.ts",
+		"test": "bun test src/lib/email-signature.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",
@@ -34,7 +39,9 @@
 		"wrangler": "^4.124.0"
 	},
 	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.29.0",
 		"postal-mime": "^3.0.0",
-		"remixicon": "^4.9.1"
+		"remixicon": "^4.9.1",
+		"zod": "^3.25.0"
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Install the QuickMail CLI from GitHub (no npm).
+#   curl -fsSL https://raw.githubusercontent.com/DivinPrince/quickmail/main/scripts/install.sh | sh
+# Default QUICKMAIL_REF is main; override to install from another ref.
+# Piped `sh` is often dash; re-exec with bash before any bash-only syntax.
+if [ -z "${BASH_VERSION:-}" ]; then
+	command -v bash >/dev/null 2>&1 || { printf '%s\n' "Need bash."; exit 1; }
+	if [ -f "$0" ] && [ -r "$0" ] && [ "${0##*/}" != "sh" ] && [ "${0##*/}" != "dash" ]; then
+		exec bash "$0" "$@"
+	fi
+	exec bash -c "$(cat)" -- "$@"
+fi
+set -euo pipefail
+
+say() { printf '%s\n' "$*"; }
+ok() { printf '  ✓ %s\n' "$*"; }
+warn() { printf '  ! %s\n' "$*"; }
+
+REPO="DivinPrince/quickmail"
+REF="${QUICKMAIL_REF:-main}"
+
+case "$REF" in
+	''|*..*|*[[:space:]]*|*@*|*'?'*|*#*|*'\\'*|*://*|/*)
+		say "Invalid QUICKMAIL_REF: $REF"
+		exit 1
+		;;
+esac
+case "$REF" in
+	[A-Za-z0-9]*) ;;
+	*)
+		say "Invalid QUICKMAIL_REF: $REF"
+		exit 1
+		;;
+esac
+
+RAW="https://raw.githubusercontent.com/${REPO}/${REF}"
+
+ORIGIN="${QUICKMAIL_URL:-}"
+while [ -n "$ORIGIN" ] && [ "$ORIGIN" != "${ORIGIN%/}" ]; do
+	ORIGIN="${ORIGIN%/}"
+done
+
+if [ -n "$ORIGIN" ]; then
+	case "$ORIGIN" in
+		*[[:space:]]*|*@*|*'?'*|*#*|*://*/*)
+			say "Invalid QUICKMAIL_URL: $ORIGIN"
+			exit 1
+			;;
+	esac
+
+	host="${ORIGIN#*://}"
+	if [ -z "$host" ]; then
+		say "Invalid QUICKMAIL_URL: $ORIGIN"
+		exit 1
+	fi
+
+	case "$ORIGIN" in
+		https://*) ;;
+		http://localhost|http://localhost:*|http://127.0.0.1|http://127.0.0.1:*) ;;
+		http://*)
+			say "HTTP is only allowed for localhost."
+			exit 1
+			;;
+		*)
+			say "QUICKMAIL_URL must be http or https."
+			exit 1
+			;;
+	esac
+fi
+
+if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ]; then
+	say "Refusing to install with HOME=${HOME:-unset}"
+	exit 1
+fi
+
+case "$HOME" in
+	/*) ;;
+	*)
+		say "HOME must be an absolute path."
+		exit 1
+		;;
+esac
+
+if [ "$(id -u)" -eq 0 ] && [ "$HOME" = "/" ]; then
+	say "Refusing to run as root with HOME=/"
+	exit 1
+fi
+
+CLI_DIR="$HOME/.quickmail/cli"
+BIN_DIR="$HOME/.local/bin"
+LAUNCHER="$BIN_DIR/quickmail"
+
+case "$CLI_DIR" in
+	"$HOME"/*) ;;
+	*)
+		say "Refusing to install outside \$HOME"
+		exit 1
+		;;
+esac
+
+case "$LAUNCHER" in
+	"$HOME"/*) ;;
+	*)
+		say "Refusing to install outside \$HOME"
+		exit 1
+		;;
+esac
+
+if [[ "$(uname -s)" == "MINGW"* || "$(uname -s)" == "MSYS"* || "$(uname -s)" == "CYGWIN"* ]]; then
+	say "Install bun from https://bun.sh on Windows, then re-run this installer."
+	exit 1
+fi
+
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+has_bun() {
+	command -v bun >/dev/null 2>&1
+}
+
+download() {
+	local url="$1"
+	local dest="$2"
+	local tmp
+	tmp="$(mktemp "${TMPDIR:-/tmp}/quickmail.XXXXXX")"
+	if command -v curl >/dev/null 2>&1; then
+		if ! curl -fsSL "$url" -o "$tmp"; then
+			rm -f "$tmp"
+			say "Download failed: $url"
+			exit 1
+		fi
+	elif command -v wget >/dev/null 2>&1; then
+		if ! wget -qO "$tmp" "$url"; then
+			rm -f "$tmp"
+			say "Download failed: $url"
+			exit 1
+		fi
+	else
+		say "Need curl or wget."
+		exit 1
+	fi
+	if [[ ! -s "$tmp" ]]; then
+		rm -f "$tmp"
+		say "Download failed (empty): $url"
+		exit 1
+	fi
+	mv "$tmp" "$dest"
+}
+
+say ""
+say "QuickMail CLI"
+say "  Installing from github.com/${REPO} @ ${REF}"
+say ""
+
+if ! has_bun; then
+	warn "Bun is not installed. The CLI is TypeScript and needs bun."
+	curl -fsSL https://bun.sh/install | bash
+	export PATH="$BUN_INSTALL/bin:$PATH"
+	if ! has_bun; then
+		say "  Bun installed, but this shell cannot see it yet."
+		say "  Add $BUN_INSTALL/bin to PATH and re-run this installer."
+		exit 1
+	fi
+	ok "bun $(bun --version)"
+else
+	ok "bun $(bun --version)"
+fi
+
+umask 077
+mkdir -p "$CLI_DIR" "$BIN_DIR"
+
+# Mail commands only — mcp.ts pulls in npm deps and is skipped on purpose.
+download "$RAW/cli/main.ts" "$CLI_DIR/main.ts"
+ok "main.ts"
+download "$RAW/cli/client.ts" "$CLI_DIR/client.ts"
+ok "client.ts"
+download "$RAW/cli/config.ts" "$CLI_DIR/config.ts"
+ok "config.ts"
+
+tmp_launcher="$(mktemp "${TMPDIR:-/tmp}/quickmail.XXXXXX")"
+cat > "$tmp_launcher" <<'EOF'
+#!/usr/bin/env bash
+export BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+export PATH="$BUN_INSTALL/bin:$PATH"
+exec bun "$HOME/.quickmail/cli/main.ts" "$@"
+EOF
+chmod +x "$tmp_launcher"
+mv "$tmp_launcher" "$LAUNCHER"
+ok "$LAUNCHER"
+
+case ":$PATH:" in
+	*":$BIN_DIR:"*) ;;
+	*)
+		warn "Add $BIN_DIR to PATH, then open a new shell:"
+		say "  export PATH=\"$BIN_DIR:\$PATH\""
+		;;
+esac
+
+say ""
+say "Next:"
+if [ -n "$ORIGIN" ]; then
+	say "  quickmail login --url $ORIGIN --token <key from Settings>"
+else
+	say "  quickmail login --url <https://your-instance> --token <key from Settings>"
+fi
+say ""

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { ApiScope, AuthMethod } from '$lib/server/api-access';
 import type { CloudflareSendEmailBinding } from '$lib/server/providers/cloudflare-provider';
 import type { Domain, MailAddress, User } from '$lib/types';
 
@@ -22,6 +23,11 @@ declare global {
 		}
 		interface Locals {
 			user: User | null;
+			/** How this request authenticated — sessions are unrestricted. */
+			authMethod: AuthMethod | null;
+			/** Scopes on the bearer token; empty for a browser session. */
+			apiScopes: ApiScope[];
+			apiTokenId: string | null;
 			/** Connected domains, loaded once per request for the switcher. */
 			domains: Domain[];
 			/** The signed-in user's sending identities. */

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,27 +1,60 @@
 import { redirect, type Handle } from '@sveltejs/kit';
+import { authorizeApiRequest } from '$lib/server/api-access';
+import { getUserByApiToken, readBearerToken } from '$lib/server/api-tokens';
 import { countUsers, getUserFromSession, readSessionToken } from '$lib/server/auth';
 import { DOMAIN_COOKIE } from '$lib/server/constants';
 import { listAddressesForUser, listDomains } from '$lib/server/domains';
 
-const PUBLIC_PREFIXES = ['/login', '/setup', '/api/auth', '/api/setup', '/api/webhooks'];
+const PUBLIC_PREFIXES = [
+	'/login',
+	'/setup',
+	'/api/auth',
+	'/api/setup',
+	'/api/webhooks',
+	'/install.sh'
+];
 
 function isPublicPath(pathname: string): boolean {
 	return PUBLIC_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
 }
 
+function jsonError(error: string, status: number): Response {
+	return new Response(JSON.stringify({ error }), {
+		status,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
 	const db = event.platform?.env.DB;
 	event.locals.user = null;
+	event.locals.authMethod = null;
+	event.locals.apiScopes = [];
+	event.locals.apiTokenId = null;
 	event.locals.domains = [];
 	event.locals.addresses = [];
 	event.locals.activeDomainId = null;
 
-	if (db) {
-		const token = readSessionToken(event.cookies);
-		event.locals.user = await getUserFromSession(db, token);
-	}
-
 	const { pathname } = event.url;
+
+	if (db) {
+		const session = readSessionToken(event.cookies);
+		event.locals.user = await getUserFromSession(db, session);
+		if (event.locals.user) {
+			event.locals.authMethod = 'session';
+		} else if (pathname.startsWith('/api/')) {
+			const bearer = readBearerToken(event.request);
+			if (bearer) {
+				const auth = await getUserByApiToken(db, bearer);
+				if (auth) {
+					event.locals.user = auth.user;
+					event.locals.authMethod = 'api_token';
+					event.locals.apiScopes = auth.scopes;
+					event.locals.apiTokenId = auth.tokenId;
+				}
+			}
+		}
+	}
 
 	// Webhooks authenticate with a signature, not a session.
 	if (pathname.startsWith('/api/webhooks/')) {
@@ -37,28 +70,42 @@ export const handle: Handle = async ({ event, resolve }) => {
 		event.locals.domains = domains;
 		event.locals.addresses = addresses;
 
-		// Only honour a domain filter that is still connected.
-		const selected = event.cookies.get(DOMAIN_COOKIE);
+		// Scripts pass `?domain=`; the dashboard uses a cookie.
+		const requested = pathname.startsWith('/api/')
+			? event.url.searchParams.get('domain')
+			: event.cookies.get(DOMAIN_COOKIE);
 		event.locals.activeDomainId =
-			selected && domains.some((domain) => domain.id === selected) ? selected : null;
+			requested && domains.some((domain) => domain.id === requested) ? requested : null;
 	}
 
 	if (pathname.startsWith('/api/')) {
 		if (isPublicPath(pathname)) {
 			return resolve(event);
 		}
-		if (!event.locals.user) {
-			return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-				status: 401,
-				headers: { 'Content-Type': 'application/json' }
-			});
+		if (!event.locals.user || !event.locals.authMethod) {
+			return jsonError('Unauthorized', 401);
 		}
+
+		const access = authorizeApiRequest({
+			pathname,
+			method: event.request.method,
+			authMethod: event.locals.authMethod,
+			scopes: event.locals.apiScopes
+		});
+		if (!access.ok) {
+			return jsonError(access.error, access.status);
+		}
+
 		return resolve(event);
 	}
 
 	const needsSetup = db ? (await countUsers(db)) === 0 : false;
 
-	if (needsSetup && pathname !== '/setup') {
+	if (
+		needsSetup &&
+		pathname !== '/setup' &&
+		pathname !== '/install.sh'
+	) {
 		throw redirect(303, '/setup');
 	}
 
@@ -89,8 +136,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	// Nothing works until a provider domain is connected and the user owns an
 	// address on it, so send them through onboarding first.
-	const needsOnboarding =
-		event.locals.domains.length === 0 || event.locals.addresses.length === 0;
+	const needsOnboarding = event.locals.domains.length === 0 || event.locals.addresses.length === 0;
 
 	if (needsOnboarding && pathname !== '/onboarding') {
 		throw redirect(303, '/onboarding');

--- a/src/lib/components/Check.svelte
+++ b/src/lib/components/Check.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	import Icon from './Icon.svelte';
+
+	let {
+		checked = false,
+		indeterminate = false,
+		disabled = false,
+		label,
+		caption = '',
+		onchange
+	}: {
+		checked?: boolean;
+		indeterminate?: boolean;
+		disabled?: boolean;
+		label: string;
+		caption?: string;
+		onchange?: (next: boolean) => void;
+	} = $props();
+
+	const icon = $derived(
+		indeterminate
+			? 'checkbox-indeterminate-line'
+			: checked
+				? 'checkbox-fill'
+				: 'checkbox-blank-line'
+	);
+</script>
+
+<button
+	type="button"
+	role="checkbox"
+	aria-checked={indeterminate ? 'mixed' : checked}
+	aria-label={label}
+	class="check"
+	class:on={checked && !indeterminate}
+	class:mixed={indeterminate}
+	class:labeled={Boolean(caption)}
+	{disabled}
+	onclick={() => onchange?.(!checked)}
+>
+	<Icon name={icon} size={18} />
+	{#if caption}<span>{caption}</span>{/if}
+</button>
+
+<style>
+	.check {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		width: 1.25rem;
+		height: 1.25rem;
+		padding: 0;
+		border: none;
+		color: var(--color-muted);
+		background: transparent;
+		cursor: pointer;
+		transition: color 0.15s;
+	}
+
+	.check:hover:not(:disabled) {
+		color: var(--color-text);
+	}
+
+	.check:focus-visible {
+		outline: none;
+		border-radius: 0.25rem;
+		box-shadow: 0 0 0 3px var(--color-focus-halo);
+	}
+
+	.check.on,
+	.check.mixed {
+		color: var(--color-accent);
+	}
+
+	.check:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	.check.labeled {
+		width: auto;
+		height: auto;
+		gap: 0.4rem;
+		padding: 0.375rem 0.625rem;
+		border-radius: 0.5rem;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+	}
+
+	.check.labeled:hover:not(:disabled) {
+		background: var(--color-surface-muted);
+	}
+
+	.check.labeled.on,
+	.check.labeled.mixed {
+		color: var(--color-text);
+		box-shadow: inset 0 0 0 1.5px var(--color-accent);
+	}
+
+	.check.labeled.on :global(i),
+	.check.labeled.mixed :global(i) {
+		color: var(--color-accent);
+	}
+
+	.check.labeled:focus-visible {
+		box-shadow: inset 0 0 0 1.5px var(--color-accent), 0 0 0 3px var(--color-focus-halo);
+	}
+</style>

--- a/src/lib/components/MailboxView.svelte
+++ b/src/lib/components/MailboxView.svelte
@@ -2,6 +2,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page as currentPage } from '$app/stores';
 	import Icon from './Icon.svelte';
+	import Check from './Check.svelte';
 	import EmptyState from './EmptyState.svelte';
 	import DeliveryStatus from './DeliveryStatus.svelte';
 	import { formatRelativeDate } from '$lib/utils/date';
@@ -151,13 +152,11 @@
 	<header class="toolbar">
 		<div class="toolbar-left">
 			<div class="select-all">
-				<input
-					type="checkbox"
-					class="checkbox"
-					aria-label="Select all messages"
+				<Check
+					label="Select all messages"
 					checked={allSelected}
 					indeterminate={someSelected && !allSelected}
-					onchange={(event) => selectAll(event.currentTarget.checked)}
+					onchange={selectAll}
 				/>
 				<button
 					type="button"
@@ -351,7 +350,7 @@
 							onclick={() => apply({ unread: filters.unreadOnly ? null : '1' })}
 						>
 							<Icon
-								name={filters.unreadOnly ? 'checkbox-line' : 'checkbox-blank-line'}
+								name={filters.unreadOnly ? 'checkbox-fill' : 'checkbox-blank-line'}
 								size={15}
 							/>
 							Unread only
@@ -362,7 +361,7 @@
 							onclick={() => apply({ starred: filters.starredOnly ? null : '1' })}
 						>
 							<Icon
-								name={filters.starredOnly ? 'checkbox-line' : 'checkbox-blank-line'}
+								name={filters.starredOnly ? 'checkbox-fill' : 'checkbox-blank-line'}
 								size={15}
 							/>
 							Starred only
@@ -373,7 +372,7 @@
 							onclick={() => apply({ attachments: filters.attachmentsOnly ? null : '1' })}
 						>
 							<Icon
-								name={filters.attachmentsOnly ? 'checkbox-line' : 'checkbox-blank-line'}
+								name={filters.attachmentsOnly ? 'checkbox-fill' : 'checkbox-blank-line'}
 								size={15}
 							/>
 							Has attachments
@@ -436,10 +435,8 @@
 						class:unread={!thread.is_read}
 						class:checked={selected.includes(thread.latest_id)}
 					>
-						<input
-							type="checkbox"
-							class="checkbox"
-							aria-label="Select conversation with {people(thread)}"
+						<Check
+							label={`Select conversation with ${people(thread)}`}
 							checked={selected.includes(thread.latest_id)}
 							onchange={() => toggle(thread.latest_id)}
 						/>
@@ -602,15 +599,6 @@
 
 	.caret:hover {
 		color: var(--color-text);
-	}
-
-	.checkbox {
-		width: 1rem;
-		height: 1rem;
-		flex-shrink: 0;
-		border-radius: 0.25rem;
-		accent-color: var(--color-accent);
-		cursor: pointer;
 	}
 
 	.tool-btn {

--- a/src/lib/server/api-access.test.ts
+++ b/src/lib/server/api-access.test.ts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { authorizeApiRequest, authorizeMailAction } from './api-access';
+import { parseScopes } from './api-tokens';
+
+describe('API key access', () => {
+	test('sessions are unrestricted', () => {
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/apikeys',
+				method: 'POST',
+				authMethod: 'session',
+				scopes: []
+			}),
+			{ ok: true }
+		);
+	});
+
+	test('a read key cannot send or manage keys', () => {
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/mail',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}).ok,
+			false
+		);
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/apikeys',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}).ok,
+			false
+		);
+	});
+
+	test('a read key can list and open threads', () => {
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/mail',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/mail/abc',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}),
+			{ ok: true }
+		);
+	});
+
+	test('admin routes stay off mail keys', () => {
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/admin/users',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}).ok,
+			false
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/admin/users',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['admin']
+			}),
+			{ ok: true }
+		);
+	});
+
+	test('parseScopes rejects admin unless allowed', () => {
+		assert.equal(parseScopes(['mail:read', 'admin'], false), null);
+		assert.deepEqual(parseScopes(['mail:read', 'admin'], true), ['mail:read', 'admin']);
+		assert.equal(parseScopes(['mail:write'], true), null);
+	});
+
+	test('POST /api/mail/actions is allowed for read or send keys', () => {
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/mail/actions',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/mail/actions',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:send']
+			}),
+			{ ok: true }
+		);
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/mail/actions',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['admin']
+			}).ok,
+			false
+		);
+	});
+
+	test('creating an address stays admin-only for API keys', () => {
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/addresses',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:send']
+			}).ok,
+			false
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/addresses',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['admin']
+			}),
+			{ ok: true }
+		);
+	});
+
+	test('mailbox flag actions need mail:read; destructive actions need both scopes', () => {
+		assert.deepEqual(
+			authorizeMailAction({ action: 'star', authMethod: 'session', scopes: [] }),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({ action: 'empty-trash', authMethod: 'session', scopes: [] }),
+			{ ok: true }
+		);
+
+		assert.deepEqual(
+			authorizeMailAction({ action: 'read', authMethod: 'api_token', scopes: ['mail:read'] }),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({ action: 'unread', authMethod: 'api_token', scopes: ['mail:read'] }),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({ action: 'star', authMethod: 'api_token', scopes: ['mail:read'] }),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({ action: 'unstar', authMethod: 'api_token', scopes: ['mail:read'] }),
+			{ ok: true }
+		);
+
+		assert.equal(
+			authorizeMailAction({ action: 'star', authMethod: 'api_token', scopes: ['mail:send'] }).ok,
+			false
+		);
+		assert.equal(
+			authorizeMailAction({ action: 'trash', authMethod: 'api_token', scopes: ['mail:read'] }).ok,
+			false
+		);
+		assert.equal(
+			authorizeMailAction({ action: 'delete', authMethod: 'api_token', scopes: ['mail:send'] }).ok,
+			false
+		);
+		assert.equal(
+			authorizeMailAction({
+				action: 'empty-trash',
+				authMethod: 'api_token',
+				scopes: ['mail:send']
+			}).ok,
+			false
+		);
+		assert.equal(
+			authorizeMailAction({
+				action: 'read-all',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}).ok,
+			false
+		);
+
+		assert.deepEqual(
+			authorizeMailAction({
+				action: 'trash',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({
+				action: 'restore',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({
+				action: 'delete',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({
+				action: 'read-all',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeMailAction({
+				action: 'empty-trash',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}),
+			{ ok: true }
+		);
+	});
+});

--- a/src/lib/server/api-access.ts
+++ b/src/lib/server/api-access.ts
@@ -1,0 +1,238 @@
+import { API_SCOPES, type ApiScope } from './api-tokens';
+
+export type { ApiScope };
+export type AuthMethod = 'session' | 'api_token';
+
+export type ApiAuthDecision = { ok: true } | { ok: false; status: number; error: string };
+
+type RouteRule = {
+	method: string;
+	match: (pathname: string) => boolean;
+	scopes: readonly ApiScope[];
+};
+
+function isPrefix(pathname: string, prefix: string): boolean {
+	return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+const BEARER_ROUTES: RouteRule[] = [
+	{
+		method: 'GET',
+		match: (pathname) => pathname === '/api/auth/me',
+		scopes: API_SCOPES
+	},
+	{
+		method: 'GET',
+		match: (pathname) => pathname === '/api/mail',
+		scopes: ['mail:read']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => pathname === '/api/mail',
+		scopes: ['mail:send']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => pathname === '/api/mail/actions',
+		scopes: ['mail:read', 'mail:send']
+	},
+	{
+		method: 'GET',
+		match: (pathname) => /^\/api\/mail\/[^/]+\/attachments\/[^/]+$/.test(pathname),
+		scopes: ['mail:read']
+	},
+	{
+		method: 'GET',
+		match: (pathname) => /^\/api\/mail\/[^/]+$/.test(pathname),
+		scopes: ['mail:read']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => /^\/api\/mail\/[^/]+$/.test(pathname),
+		scopes: ['mail:send']
+	},
+	{
+		method: 'PATCH',
+		match: (pathname) => /^\/api\/mail\/[^/]+$/.test(pathname),
+		scopes: ['mail:send']
+	},
+	{
+		method: 'DELETE',
+		match: (pathname) => /^\/api\/mail\/[^/]+$/.test(pathname),
+		scopes: ['mail:send']
+	},
+	{
+		method: 'GET',
+		match: (pathname) => pathname === '/api/addresses',
+		scopes: ['mail:read', 'mail:send', 'admin']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => pathname === '/api/addresses',
+		scopes: ['admin']
+	},
+	{
+		method: 'PATCH',
+		match: (pathname) => /^\/api\/addresses\/[^/]+$/.test(pathname),
+		scopes: ['admin']
+	},
+	{
+		method: 'DELETE',
+		match: (pathname) => /^\/api\/addresses\/[^/]+$/.test(pathname),
+		scopes: ['admin']
+	},
+	{
+		method: 'GET',
+		match: (pathname) => isPrefix(pathname, '/api/admin'),
+		scopes: ['admin']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => isPrefix(pathname, '/api/admin'),
+		scopes: ['admin']
+	},
+	{
+		method: 'PATCH',
+		match: (pathname) => isPrefix(pathname, '/api/admin'),
+		scopes: ['admin']
+	},
+	{
+		method: 'DELETE',
+		match: (pathname) => isPrefix(pathname, '/api/admin'),
+		scopes: ['admin']
+	},
+	{
+		method: 'GET',
+		match: (pathname) => isPrefix(pathname, '/api/domains'),
+		scopes: ['admin']
+	},
+	{
+		method: 'POST',
+		match: (pathname) => isPrefix(pathname, '/api/domains'),
+		scopes: ['admin']
+	},
+	{
+		method: 'PATCH',
+		match: (pathname) => isPrefix(pathname, '/api/domains'),
+		scopes: ['admin']
+	},
+	{
+		method: 'DELETE',
+		match: (pathname) => isPrefix(pathname, '/api/domains'),
+		scopes: ['admin']
+	}
+];
+
+/** Bulk mailbox actions. Per-action scopes are enforced in `authorizeMailAction`. */
+export const MAIL_ACTIONS = [
+	'read',
+	'unread',
+	'star',
+	'unstar',
+	'trash',
+	'restore',
+	'delete',
+	'read-all',
+	'empty-trash'
+] as const;
+
+export type MailAction = (typeof MAIL_ACTIONS)[number];
+
+export function isMailAction(value: unknown): value is MailAction {
+	return typeof value === 'string' && (MAIL_ACTIONS as readonly string[]).includes(value);
+}
+
+function hasScope(granted: readonly ApiScope[], needed: readonly ApiScope[]): boolean {
+	return needed.some((scope) => granted.includes(scope));
+}
+
+function hasAllScopes(granted: readonly ApiScope[], needed: readonly ApiScope[]): boolean {
+	return needed.every((scope) => granted.includes(scope));
+}
+
+/**
+ * Session cookies may run any mailbox action. API keys: flag changes need
+ * `mail:read`; destructive / whole-mailbox actions need both `mail:read` and
+ * `mail:send` so a send-only cron key cannot wipe the mailbox.
+ */
+export function authorizeMailAction(input: {
+	action: MailAction;
+	authMethod: AuthMethod;
+	scopes: readonly ApiScope[];
+}): ApiAuthDecision {
+	if (input.authMethod === 'session') {
+		return { ok: true };
+	}
+
+	switch (input.action) {
+		case 'read':
+		case 'unread':
+		case 'star':
+		case 'unstar':
+			if (!input.scopes.includes('mail:read')) {
+				return { ok: false, status: 403, error: 'This API key needs mail:read.' };
+			}
+			return { ok: true };
+		case 'trash':
+		case 'restore':
+		case 'delete':
+		case 'read-all':
+		case 'empty-trash':
+			if (!hasAllScopes(input.scopes, ['mail:read', 'mail:send'])) {
+				return {
+					ok: false,
+					status: 403,
+					error: 'This API key needs mail:read and mail:send.'
+				};
+			}
+			return { ok: true };
+		default: {
+			const _never: never = input.action;
+			return _never;
+		}
+	}
+}
+
+/**
+ * Session cookies keep full access. Bearer tokens are limited to an explicit
+ * allowlist so a leaked "read" key cannot send mail, mint more keys, or hit
+ * admin routes.
+ */
+export function authorizeApiRequest(input: {
+	pathname: string;
+	method: string;
+	authMethod: AuthMethod;
+	scopes: readonly ApiScope[];
+}): ApiAuthDecision {
+	if (input.authMethod === 'session') {
+		return { ok: true };
+	}
+
+	if (isPrefix(input.pathname, '/api/apikeys')) {
+		return {
+			ok: false,
+			status: 403,
+			error: 'API keys cannot manage API keys. Sign in with a browser session.'
+		};
+	}
+
+	const method = input.method.toUpperCase();
+	const rule = BEARER_ROUTES.find((entry) => entry.method === method && entry.match(input.pathname));
+	if (!rule) {
+		return {
+			ok: false,
+			status: 403,
+			error: 'This API key cannot access that endpoint.'
+		};
+	}
+
+	if (!hasScope(input.scopes, rule.scopes)) {
+		return {
+			ok: false,
+			status: 403,
+			error: `This API key needs ${rule.scopes.join(' or ')}.`
+		};
+	}
+
+	return { ok: true };
+}

--- a/src/lib/server/api-tokens.test.ts
+++ b/src/lib/server/api-tokens.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { D1Database } from '@cloudflare/workers-types';
+import { getUserByApiToken, previewFor, readBearerToken } from './api-tokens';
+
+describe('API token preview', () => {
+	test('skips the shared prefix so keys are distinguishable', () => {
+		assert.equal(previewFor('qm_live_abcdEFGHxxxxxxxxwXYZ'), 'abcd…wXYZ');
+	});
+
+	test('still works if the prefix is missing', () => {
+		assert.equal(previewFor('abcdEFGHxxxxxxxxwXYZ'), 'abcd…wXYZ');
+	});
+});
+
+describe('API token parsing', () => {
+	const unusedDb = {
+		prepare() {
+			throw new Error('must not hash or query an implausible token');
+		}
+	} as unknown as D1Database;
+
+	test('readBearerToken extracts a Bearer value and rejects oversized tokens', () => {
+		const token = 'qm_live_abcdefghijklmnopqrstuvwxyz012345';
+		const request = new Request('https://mail.example.com', {
+			headers: { authorization: `Bearer ${token}` }
+		});
+		assert.equal(readBearerToken(request), token);
+
+		const oversized = new Request('https://mail.example.com', {
+			headers: { authorization: `Bearer ${'x'.repeat(300)}` }
+		});
+		assert.equal(readBearerToken(oversized), null);
+		assert.equal(readBearerToken(new Request('https://mail.example.com')), null);
+	});
+
+	test('getUserByApiToken rejects missing prefix and oversized tokens before hashing', async () => {
+		assert.equal(await getUserByApiToken(unusedDb, 'not-a-quickmail-token'), null);
+		assert.equal(await getUserByApiToken(unusedDb, 'qm_live_'), null);
+		assert.equal(await getUserByApiToken(unusedDb, `qm_live_${'x'.repeat(300)}`), null);
+	});
+});

--- a/src/lib/server/api-tokens.ts
+++ b/src/lib/server/api-tokens.ts
@@ -1,0 +1,222 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { hashToken } from './crypto';
+import type { ApiTokenSummary, User } from '$lib/types';
+
+/** Scopes a token can carry. Enforced in `authorizeApiRequest`. */
+export const API_SCOPES = ['mail:send', 'mail:read', 'admin'] as const;
+export type ApiScope = (typeof API_SCOPES)[number];
+
+type TokenRow = {
+	id: string;
+	user_id: string;
+	name: string;
+	token_preview: string;
+	scopes: string;
+	created_at: string;
+	last_used_at: string | null;
+};
+
+/** A freshly minted token: the raw value (shown once) plus its stored summary. */
+export type CreatedApiToken = {
+	token: string;
+	summary: ApiTokenSummary;
+};
+
+export type ApiTokenAuth = {
+	user: User;
+	tokenId: string;
+	scopes: ApiScope[];
+};
+
+const TOKEN_PREFIX = 'qm_live_';
+const MAX_TOKEN_LENGTH = 256;
+const LAST_USED_THROTTLE_MS = 5 * 60 * 1000;
+
+function isPlausibleApiToken(token: string): boolean {
+	return (
+		token.startsWith(TOKEN_PREFIX) &&
+		token.length > TOKEN_PREFIX.length &&
+		token.length <= MAX_TOKEN_LENGTH
+	);
+}
+
+export function isApiScope(value: unknown): value is ApiScope {
+	return typeof value === 'string' && (API_SCOPES as readonly string[]).includes(value);
+}
+
+export function isValidScope(scopes: unknown): scopes is ApiScope[] {
+	return parseScopes(scopes, true) !== null;
+}
+
+/** Deduped, known scopes. `admin` is rejected unless the owner is an admin. */
+export function parseScopes(input: unknown, allowAdmin: boolean): ApiScope[] | null {
+	if (!Array.isArray(input) || input.length === 0) return null;
+
+	const scopes: ApiScope[] = [];
+	for (const item of input) {
+		if (!isApiScope(item)) return null;
+		if (item === 'admin' && !allowAdmin) return null;
+		if (!scopes.includes(item)) scopes.push(item);
+	}
+
+	return scopes;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+	let binary = '';
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** `qm_live_<32 random bytes, base64url>` — recognizable and collision-resistant. */
+function generateToken(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(32));
+	return `${TOKEN_PREFIX}${toBase64Url(bytes)}`;
+}
+
+/** Preview the random part, not the shared `qm_live_` prefix. */
+export function previewFor(token: string): string {
+	const random = token.startsWith(TOKEN_PREFIX) ? token.slice(TOKEN_PREFIX.length) : token;
+	if (random.length < 8) return random;
+	return `${random.slice(0, 4)}…${random.slice(-4)}`;
+}
+
+function parseStoredScopes(value: string): ApiScope[] {
+	return value
+		.split(',')
+		.map((scope) => scope.trim())
+		.filter(isApiScope);
+}
+
+function mapRow(row: TokenRow): ApiTokenSummary {
+	return {
+		id: row.id,
+		name: row.name,
+		preview: row.token_preview,
+		scopes: parseStoredScopes(row.scopes),
+		created_at: row.created_at,
+		last_used_at: row.last_used_at
+	};
+}
+
+export async function createApiToken(
+	db: D1Database,
+	userId: string,
+	options: { name?: string; scopes?: ApiScope[] } = {}
+): Promise<CreatedApiToken> {
+	const token = generateToken();
+	const hash = await hashToken(token);
+	const id = crypto.randomUUID();
+	const scopes: ApiScope[] = options.scopes?.length ? options.scopes : ['mail:send'];
+	const name = (options.name ?? '').trim().slice(0, 60) || 'Default';
+	const createdAt = new Date().toISOString();
+
+	await db
+		.prepare(
+			`INSERT INTO api_tokens (id, user_id, name, token_hash, token_preview, scopes, created_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`
+		)
+		.bind(id, userId, name, hash, previewFor(token), scopes.join(','), createdAt)
+		.run();
+
+	return {
+		token,
+		summary: {
+			id,
+			name,
+			preview: previewFor(token),
+			scopes,
+			created_at: createdAt,
+			last_used_at: null
+		}
+	};
+}
+
+export async function listApiTokens(db: D1Database, userId: string): Promise<ApiTokenSummary[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT id, user_id, name, token_preview, scopes, created_at, last_used_at
+			 FROM api_tokens WHERE user_id = ? ORDER BY created_at DESC`
+		)
+		.bind(userId)
+		.all<TokenRow>();
+
+	return results.map(mapRow);
+}
+
+export async function revokeApiToken(
+	db: D1Database,
+	userId: string,
+	tokenId: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM api_tokens WHERE id = ? AND user_id = ?')
+		.bind(tokenId, userId)
+		.run();
+
+	return (result.meta.changes ?? 0) > 0;
+}
+
+type TokenUserRow = {
+	id: string;
+	email: string;
+	name: string;
+	is_admin: number;
+	created_at: string;
+	token_id: string;
+	scopes: string;
+	last_used_at: string | null;
+};
+
+/**
+ * Resolve a bearer token to its owning user. Returns null when the token is
+ * unknown or already revoked.
+ */
+export async function getUserByApiToken(db: D1Database, token: string): Promise<ApiTokenAuth | null> {
+	if (!isPlausibleApiToken(token)) return null;
+
+	const hash = await hashToken(token);
+	const row = await db
+		.prepare(
+			`SELECT u.id, u.email, u.name, u.is_admin, u.created_at,
+			        t.id AS token_id, t.scopes, t.last_used_at
+			 FROM api_tokens t
+			 JOIN users u ON u.id = t.user_id
+			 WHERE t.token_hash = ?`
+		)
+		.bind(hash)
+		.first<TokenUserRow>();
+
+	if (!row) return null;
+
+	const lastUsed = row.last_used_at ? Date.parse(row.last_used_at) : 0;
+	if (!lastUsed || Date.now() - lastUsed >= LAST_USED_THROTTLE_MS) {
+		await db
+			.prepare('UPDATE api_tokens SET last_used_at = ? WHERE id = ?')
+			.bind(new Date().toISOString(), row.token_id)
+			.run();
+	}
+
+	return {
+		user: {
+			id: row.id,
+			email: row.email,
+			name: row.name,
+			is_admin: row.is_admin === 1,
+			created_at: row.created_at
+		},
+		tokenId: row.token_id,
+		scopes: parseStoredScopes(row.scopes)
+	};
+}
+
+/** Read a `Bearer <token>` value off the Authorization header, if present. */
+export function readBearerToken(request: Request): string | null {
+	const header = request.headers.get('authorization');
+	if (!header) return null;
+	const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+	if (!match) return null;
+	const token = match[1];
+	if (token.length > MAX_TOKEN_LENGTH) return null;
+	return token;
+}

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -126,6 +126,52 @@ export async function logout(db: D1Database, token: string): Promise<void> {
 	await db.prepare('DELETE FROM sessions WHERE token_hash = ?').bind(token_hash).run();
 }
 
+export async function setUserPassword(
+	db: D1Database,
+	userId: string,
+	password: string
+): Promise<void> {
+	if (password.length < 8) {
+		throw new Error('Password must be at least 8 characters');
+	}
+
+	const password_hash = await hashPassword(password);
+	const result = await db
+		.prepare('UPDATE users SET password_hash = ? WHERE id = ?')
+		.bind(password_hash, userId)
+		.run();
+
+	if ((result.meta.changes ?? 0) === 0) {
+		throw new Error('User not found');
+	}
+
+	// Password rotation must cut off every login path, including long-lived keys.
+	await db.batch([
+		db.prepare('DELETE FROM sessions WHERE user_id = ?').bind(userId),
+		db.prepare('DELETE FROM api_tokens WHERE user_id = ?').bind(userId)
+	]);
+}
+
+export async function deleteUser(db: D1Database, actor: User, targetId: string): Promise<void> {
+	if (actor.id === targetId) {
+		throw new Error('You cannot delete your own account');
+	}
+
+	const target = await getUserById(db, targetId);
+	if (!target) {
+		throw new Error('User not found');
+	}
+
+	if (target.is_admin) {
+		const admins = (await listUsers(db)).filter((user) => user.is_admin);
+		if (admins.length <= 1) {
+			throw new Error('Keep at least one admin');
+		}
+	}
+
+	await db.prepare('DELETE FROM users WHERE id = ?').bind(targetId).run();
+}
+
 export async function getUserFromSession(db: D1Database, token: string | undefined): Promise<User | null> {
 	if (!token) return null;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,17 @@ export type User = {
 	created_at: string;
 };
 
+export type ApiScope = 'mail:send' | 'mail:read' | 'admin';
+
+export type ApiTokenSummary = {
+	id: string;
+	name: string;
+	preview: string;
+	scopes: ApiScope[];
+	created_at: string;
+	last_used_at: string | null;
+};
+
 export type DeliveryStatus =
 	| 'queued'
 	| 'sent'

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -121,12 +121,7 @@
 
 	<section class="surface-lg admin-card">
 		<h2><Icon name="global-line" size={18} /> Domains</h2>
-		<p class="card-hint">
-			Connected domains send and receive through {data.providerKind === 'cloudflare'
-				? 'Cloudflare Email'
-				: 'Resend'}. Catch-all decides who gets mail addressed to an unknown mailbox on that
-			domain.
-		</p>
+		<p class="card-hint">Catch-all gets unmatched mail.</p>
 
 		<ul class="domain-list">
 			{#each data.domains as domain (domain.id)}
@@ -186,17 +181,17 @@
 					{#if !domain.receiving_enabled}
 						<p class="hint">
 							<Icon name="information-line" size={13} />
-							Inbound is off for this domain — enable receiving
+							Inbound is off
 							{data.providerKind === 'cloudflare'
-								? "and point Email Routing's catch-all at this Worker"
-								: 'and add the MX record at the provider'}
-							to get mail.
+								? '— point Email Routing’s catch-all at this Worker'
+								: '— add the MX record'}
+							to receive.
 						</p>
 					{/if}
 					{#if domain.catchall_user_id}
 						<p class="hint">
 							<Icon name="user-received-line" size={13} />
-							Unmatched mail goes to {userLabel(domain.catchall_user_id)}.
+							Goes to {userLabel(domain.catchall_user_id)}.
 						</p>
 					{/if}
 				</li>
@@ -235,9 +230,7 @@
 	<div class="admin-grid">
 		<section class="surface-lg admin-card">
 			<h2><Icon name="user-add-line" size={18} /> New user</h2>
-			<p class="card-hint">
-				Their address is also their login — they can sign in and use it straight away.
-			</p>
+			<p class="card-hint">Address is their login.</p>
 			<form class="mt-4 space-y-3" onsubmit={createUser}>
 				<input type="text" bind:value={name} required placeholder="Display name" class="admin-input" />
 				<AddressField
@@ -291,9 +284,7 @@
 	{#if data.unrouted.length > 0}
 		<section class="surface-lg admin-card">
 			<h2><Icon name="question-mark" size={18} /> Unrouted mail</h2>
-			<p class="card-hint">
-				Received on a connected domain but no address matched and no catch-all was set.
-			</p>
+			<p class="card-hint">No matching address or catch-all.</p>
 			<ul class="user-list">
 				{#each data.unrouted as item (item.id)}
 					<li class="user-row">

--- a/src/routes/api/addresses/+server.ts
+++ b/src/routes/api/addresses/+server.ts
@@ -7,7 +7,10 @@ export const GET: RequestHandler = async ({ locals, platform, url }) => {
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
-	const all = url.searchParams.get('all') === '1' && locals.user.is_admin;
+	const all =
+		url.searchParams.get('all') === '1' &&
+		locals.user.is_admin &&
+		(locals.authMethod === 'session' || locals.apiScopes.includes('admin'));
 	const addresses = all
 		? await listAllAddresses(db)
 		: await listAddressesForUser(db, locals.user.id);

--- a/src/routes/api/admin/unrouted/+server.ts
+++ b/src/routes/api/admin/unrouted/+server.ts
@@ -1,0 +1,14 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { listUnroutedEmails } from '$lib/server/domains';
+
+export const GET: RequestHandler = async ({ locals, platform, url }) => {
+	if (!locals.user?.is_admin) {
+		return json({ error: 'Forbidden' }, { status: 403 });
+	}
+
+	const db = platform?.env.DB;
+	if (!db) return json({ error: 'Database unavailable' }, { status: 503 });
+
+	const limit = Math.min(100, Math.max(1, Number(url.searchParams.get('limit')) || 50));
+	return json({ unrouted: await listUnroutedEmails(db, limit) });
+};

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -1,0 +1,45 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { deleteUser, setUserPassword } from '$lib/server/auth';
+
+export const PATCH: RequestHandler = async ({ params, request, locals, platform }) => {
+	if (!locals.user?.is_admin) {
+		return json({ error: 'Forbidden' }, { status: 403 });
+	}
+
+	const db = platform?.env.DB;
+	if (!db) return json({ error: 'Database unavailable' }, { status: 503 });
+
+	const body = (await request.json()) as { password?: string };
+	if (!body.password) {
+		return json({ error: 'Password is required' }, { status: 400 });
+	}
+
+	try {
+		await setUserPassword(db, params.id!, body.password);
+		return json({ ok: true });
+	} catch (error) {
+		return json(
+			{ error: error instanceof Error ? error.message : 'Failed to reset password' },
+			{ status: 400 }
+		);
+	}
+};
+
+export const DELETE: RequestHandler = async ({ params, locals, platform }) => {
+	if (!locals.user?.is_admin) {
+		return json({ error: 'Forbidden' }, { status: 403 });
+	}
+
+	const db = platform?.env.DB;
+	if (!db) return json({ error: 'Database unavailable' }, { status: 503 });
+
+	try {
+		await deleteUser(db, locals.user, params.id!);
+		return json({ ok: true });
+	} catch (error) {
+		return json(
+			{ error: error instanceof Error ? error.message : 'Failed to delete user' },
+			{ status: 400 }
+		);
+	}
+};

--- a/src/routes/api/apikeys/+server.ts
+++ b/src/routes/api/apikeys/+server.ts
@@ -1,0 +1,44 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { createApiToken, listApiTokens, parseScopes, type ApiScope } from '$lib/server/api-tokens';
+
+export const GET: RequestHandler = async ({ locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+	return json({ tokens: await listApiTokens(db, locals.user.id) });
+};
+
+type CreateTokenBody = {
+	name?: string;
+	scopes?: ApiScope[];
+};
+
+export const POST: RequestHandler = async ({ request, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const body = (await request.json().catch(() => null)) as CreateTokenBody | null;
+	const scopes = body?.scopes ?? [];
+	const parsed = scopes.length === 0 ? null : parseScopes(scopes, locals.user.is_admin);
+	if (body && !parsed) {
+		return json(
+			{
+				error: locals.user.is_admin
+					? 'Scopes must be a subset of mail:send, mail:read, admin'
+					: 'Scopes must be a subset of mail:send, mail:read'
+			},
+			{ status: 400 }
+		);
+	}
+
+	const created = await createApiToken(db, locals.user.id, {
+		name: body?.name,
+		scopes: parsed ?? undefined
+	});
+
+	// The raw token is only ever returned here — the table stores just its hash.
+	return json({ ok: true, token: created.token, tokenMeta: created.summary }, { status: 201 });
+};

--- a/src/routes/api/apikeys/[id]/+server.ts
+++ b/src/routes/api/apikeys/[id]/+server.ts
@@ -1,0 +1,16 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { listApiTokens, revokeApiToken } from '$lib/server/api-tokens';
+
+export const DELETE: RequestHandler = async ({ locals, platform, params }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const removed = await revokeApiToken(db, locals.user.id, params.id!);
+	if (!removed) {
+		return json({ error: 'Token not found' }, { status: 404 });
+	}
+
+	return json({ ok: true, tokens: await listApiTokens(db, locals.user.id) });
+};

--- a/src/routes/api/mail/+server.ts
+++ b/src/routes/api/mail/+server.ts
@@ -4,9 +4,9 @@ import {
 	getEmailProvider,
 	statusForProviderError
 } from '$lib/server/context';
-import { deleteDraft, listEmails } from '$lib/server/mail-store';
+import { deleteDraft, listMailbox } from '$lib/server/mail-store';
 import { sendAndStore } from '$lib/server/outbox';
-import type { OutboundAttachmentInput } from '$lib/types';
+import type { MailboxView, OutboundAttachmentInput } from '$lib/types';
 
 type SendMailBody = {
 	/** Set when the composer was editing a draft — it is removed once sent. */
@@ -21,19 +21,48 @@ type SendMailBody = {
 	attachments?: OutboundAttachmentInput[];
 };
 
+function mailboxView(url: URL): MailboxView {
+	const view = url.searchParams.get('view');
+	switch (view) {
+		case 'inbox':
+		case 'starred':
+		case 'drafts':
+		case 'sent':
+		case 'trash':
+			return view;
+		default:
+			break;
+	}
+
+	// PR #9 documented `?direction=` on the flat list; keep that working.
+	const direction = url.searchParams.get('direction');
+	switch (direction) {
+		case 'outbound':
+			return 'sent';
+		case 'inbound':
+			return 'inbox';
+		default:
+			return 'inbox';
+	}
+}
+
 export const GET: RequestHandler = async ({ locals, platform, url }) => {
 	const db = platform?.env.DB;
 	if (!db || !locals.user) {
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
-	const direction = url.searchParams.get('direction');
-	const emails = await listEmails(db, locals.user.id, {
-		direction: direction === 'inbound' || direction === 'outbound' ? direction : undefined,
-		domainId: locals.activeDomainId
+	const mailbox = await listMailbox(db, locals.user.id, {
+		view: mailboxView(url),
+		domainId: locals.activeDomainId,
+		q: url.searchParams.get('q'),
+		unreadOnly: url.searchParams.get('unread') === '1',
+		starredOnly: url.searchParams.get('starred') === '1',
+		attachmentsOnly: url.searchParams.get('attachments') === '1',
+		page: Number(url.searchParams.get('page')) || 1
 	});
 
-	return json({ emails });
+	return json(mailbox);
 };
 
 export const POST: RequestHandler = async ({ request, locals, platform }) => {

--- a/src/routes/api/mail/actions/+server.ts
+++ b/src/routes/api/mail/actions/+server.ts
@@ -1,4 +1,5 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
+import { authorizeMailAction, isMailAction, type MailAction } from '$lib/server/api-access';
 import {
 	deleteEmailsPermanently,
 	emptyTrash,
@@ -8,26 +9,11 @@ import {
 	getMailboxCounts
 } from '$lib/server/mail-store';
 
-/** Bulk actions from the list toolbar. */
-const ACTIONS = [
-	'read',
-	'unread',
-	'star',
-	'unstar',
-	'trash',
-	'restore',
-	'delete',
-	'read-all',
-	'empty-trash'
-] as const;
-
 /** Actions that operate on the whole mailbox rather than a selection. */
-const WHOLE_MAILBOX: Action[] = ['read-all', 'empty-trash'];
-
-type Action = (typeof ACTIONS)[number];
+const WHOLE_MAILBOX: MailAction[] = ['read-all', 'empty-trash'];
 
 type ActionBody = {
-	action?: Action;
+	action?: MailAction;
 	ids?: string[];
 };
 
@@ -40,8 +26,19 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 	const body = (await request.json()) as ActionBody;
 	const action = body.action;
 
-	if (!action || !ACTIONS.includes(action)) {
+	if (!isMailAction(action)) {
 		return json({ error: 'Unknown action' }, { status: 400 });
+	}
+
+	if (locals.authMethod === 'api_token') {
+		const access = authorizeMailAction({
+			action,
+			authMethod: 'api_token',
+			scopes: locals.apiScopes
+		});
+		if (!access.ok) {
+			return json({ error: access.error }, { status: access.status });
+		}
 	}
 
 	const selected = (body.ids ?? []).filter((id) => typeof id === 'string' && id.length > 0);
@@ -88,6 +85,10 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 		case 'empty-trash':
 			affected = await emptyTrash(db, platform?.env.ATTACHMENTS, locals.user.id);
 			break;
+		default: {
+			const _never: never = action;
+			return _never;
+		}
 	}
 
 	const counts = await getMailboxCounts(db, locals.user.id, locals.activeDomainId);

--- a/src/routes/install.sh/+server.ts
+++ b/src/routes/install.sh/+server.ts
@@ -1,0 +1,45 @@
+import type { RequestHandler } from '@sveltejs/kit';
+
+const GITHUB_REPO = 'DivinPrince/quickmail';
+/** Public installer lives on main; set QUICKMAIL_REF in the script to use another ref. */
+const GITHUB_REF = 'main';
+
+function isSafeOrigin(origin: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(origin);
+	} catch {
+		return false;
+	}
+	if (parsed.origin !== origin) return false;
+	if (parsed.protocol === 'https:') return true;
+	return (
+		parsed.protocol === 'http:' &&
+		(parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')
+	);
+}
+
+function shellSingleQuote(value: string): string {
+	return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export const GET: RequestHandler = ({ url }) => {
+	const origin = isSafeOrigin(url.origin) ? url.origin : '';
+	const installUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${GITHUB_REF}/scripts/install.sh`;
+	const exportLine = origin
+		? `export QUICKMAIL_URL="\${QUICKMAIL_URL:-${shellSingleQuote(origin)}}"\n`
+		: '';
+
+	const body = `#!/usr/bin/env bash
+set -euo pipefail
+${exportLine}curl -fsSL ${shellSingleQuote(installUrl)} | bash
+`;
+
+	return new Response(body, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8',
+			'Cache-Control': 'no-store',
+			'Content-Disposition': 'inline; filename="install.sh"'
+		}
+	});
+};

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,15 +1,17 @@
 import type { PageServerLoad } from './$types';
+import { listApiTokens } from '$lib/server/api-tokens';
 import { getEmailSignature } from '$lib/server/email-signature';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
-	const signature =
-		locals.user && platform?.env.DB
-			? await getEmailSignature(platform.env.DB, locals.user.id)
-			: '';
+	const db = platform?.env.DB;
+	const signature = locals.user && db ? await getEmailSignature(db, locals.user.id) : '';
+	const apiTokens = locals.user && db ? await listApiTokens(db, locals.user.id) : [];
 
 	return {
 		domains: locals.domains,
 		addresses: locals.addresses,
-		signature
+		signature,
+		apiTokens,
+		isAdmin: locals.user?.is_admin ?? false
 	};
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { untrack } from 'svelte';
 	import Icon from '$lib/components/Icon.svelte';
+	import Check from '$lib/components/Check.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
 	import {
 		readThemePreference,
@@ -9,7 +10,7 @@
 		type ThemePreference
 	} from '$lib/theme';
 	import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
-	import type { MailAddress } from '$lib/types';
+	import type { ApiTokenSummary, MailAddress } from '$lib/types';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -65,6 +66,116 @@
 	let domainId = $state('');
 	let error = $state('');
 	let busy = $state(false);
+
+	let keyName = $state('');
+	let sendScope = $state(true);
+	let readScope = $state(true);
+	let adminScope = $state(false);
+	let tokens = $state<ApiTokenSummary[]>([]);
+	let hydrated = $state(false);
+	$effect(() => {
+		if (!hydrated) {
+			tokens = data.apiTokens;
+			hydrated = true;
+		}
+	});
+	let keyBusy = $state(false);
+	let keyError = $state('');
+	let creating = $state(false);
+	let revealed = $state<{ summary: ApiTokenSummary; token: string } | null>(null);
+	let copied = $state(false);
+	let installCopied = $state(false);
+	const installCommand =
+		'curl -fsSL https://raw.githubusercontent.com/DivinPrince/quickmail/main/scripts/install.sh | sh';
+
+	const canCreateKey = $derived(
+		Boolean(keyName.trim()) && (sendScope || readScope || (data.isAdmin && adminScope))
+	);
+
+	function openCreate() {
+		keyName = '';
+		sendScope = true;
+		readScope = true;
+		adminScope = false;
+		keyError = '';
+		revealed = null;
+		copied = false;
+		creating = true;
+	}
+
+	function closeCreate() {
+		creating = false;
+		revealed = null;
+		copied = false;
+		keyError = '';
+	}
+
+	async function createKey(event?: SubmitEvent) {
+		if (event) event.preventDefault();
+		keyBusy = true;
+		keyError = '';
+		try {
+			const scopes = [];
+			if (sendScope) scopes.push('mail:send');
+			if (readScope) scopes.push('mail:read');
+			if (data.isAdmin && adminScope) scopes.push('admin');
+
+			const res = await fetch('/api/apikeys', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: keyName, scopes })
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				keyError = body.error ?? 'Could not create the API key';
+				return;
+			}
+			tokens = [body.tokenMeta, ...tokens.filter((token) => token.id !== body.tokenMeta.id)];
+			revealed = { summary: body.tokenMeta, token: body.token };
+			copied = false;
+			keyName = '';
+		} catch {
+			keyError = 'Network error';
+		} finally {
+			keyBusy = false;
+		}
+	}
+
+	async function copyKey() {
+		if (!revealed) return;
+		try {
+			await navigator.clipboard.writeText(revealed.token);
+			copied = true;
+			setTimeout(() => (copied = false), 1600);
+		} catch {
+			/* clipboard unavailable — the box is still selectable */
+		}
+	}
+
+	async function copyInstall() {
+		try {
+			await navigator.clipboard.writeText(installCommand);
+			installCopied = true;
+			setTimeout(() => (installCopied = false), 1600);
+		} catch {
+			/* clipboard unavailable — the command is still selectable */
+		}
+	}
+
+	async function revokeKey(id: string) {
+		if (!confirm('Revoke this key?')) return;
+		const res = await fetch(`/api/apikeys/${id}`, { method: 'DELETE' });
+		const body = await res.json();
+		if (!res.ok) {
+			keyError = body.error ?? 'Could not revoke that key';
+			return;
+		}
+		tokens = body.tokens;
+	}
+
+	function formatDate(value: string): string {
+		return new Date(value).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+	}
 
 	$effect(() => {
 		if (!domainId && data.domains[0]) {
@@ -129,7 +240,6 @@
 
 	<section class="surface-lg card">
 		<h2><Icon name="contrast-2-line" size={18} /> Appearance</h2>
-		<p class="card-hint">Choose how Mail looks. System follows your device setting.</p>
 
 		<div class="theme-options" role="radiogroup" aria-label="Theme">
 			{#each THEME_OPTIONS as option (option.value)}
@@ -159,18 +269,14 @@
 	</section>
 
 	<section class="surface-lg card">
-		<h2><Icon name="pencil-line" size={18} /> Email signature</h2>
-		<p class="card-hint">
-			Add a short sign-off to new messages and replies, for example “Best, Emmanuel.”
-		</p>
+		<h2><Icon name="pencil-line" size={18} /> Signature</h2>
 
 		<form class="signature-form" onsubmit={saveSignature}>
-			<label for="email-signature" class="field-title">Signature text</label>
 			<textarea
 				id="email-signature"
 				bind:value={signature}
 				maxlength={MAX_EMAIL_SIGNATURE_LENGTH}
-				rows="5"
+				rows="3"
 				placeholder={'Best,\nEmmanuel'}
 				class="signature-input"
 			></textarea>
@@ -178,21 +284,17 @@
 			<div class="signature-actions">
 				<span class="character-count">{signature.length}/{MAX_EMAIL_SIGNATURE_LENGTH}</span>
 				<button type="submit" class="btn-primary" disabled={signatureBusy}>
-					{signatureBusy ? 'Saving…' : 'Save signature'}
+					{signatureBusy ? 'Saving…' : 'Save'}
 				</button>
 			</div>
 
 			{#if signatureError}<p class="error">{signatureError}</p>{/if}
-			{#if signatureSaved}<p class="saved">Signature saved.</p>{/if}
+			{#if signatureSaved}<p class="saved">Saved</p>{/if}
 		</form>
 	</section>
 
 	<section class="surface-lg card">
-		<h2><Icon name="at-line" size={18} /> Your addresses</h2>
-		<p class="card-hint">
-			Mail sent to any of these lands in your inbox. The default is what new messages are sent
-			from.
-		</p>
+		<h2><Icon name="at-line" size={18} /> Addresses</h2>
 
 		<ul class="address-list">
 			{#each addresses as address (address.id)}
@@ -242,8 +344,7 @@
 		{#if selectedDomain && !selectedDomain.receiving_enabled}
 			<p class="hint">
 				<Icon name="information-line" size={14} />
-				Receiving isn't enabled on {selectedDomain.name} — this address can send but won't
-				receive.
+				{selectedDomain.name} can send, but inbound is off.
 			</p>
 		{/if}
 
@@ -265,7 +366,134 @@
 			{/each}
 		</ul>
 	</section>
+
+	<section class="surface-lg card">
+		<div class="card-head">
+			<h2><Icon name="key-2-line" size={18} /> API keys</h2>
+			<button type="button" class="btn-primary" onclick={openCreate}>
+				<Icon name="add-line" size={15} />
+				New
+			</button>
+		</div>
+
+		{#if tokens.length}
+			<ul class="key-list">
+				{#each tokens as token (token.id)}
+					<li class="key-row">
+						<div class="min-w-0 flex-1">
+							<p class="key-name">{token.name}</p>
+							<p class="key-meta">
+								<code>{token.preview}</code>
+								<span class="caps">
+									{#each token.scopes as scope (scope)}<span class="chip">{scope}</span>{/each}
+								</span>
+							</p>
+						</div>
+						<span class="key-created">{formatDate(token.created_at)}</span>
+						<button
+							type="button"
+							class="icon-btn"
+							aria-label="Revoke {token.name}"
+							onclick={() => revokeKey(token.id)}
+						>
+							<Icon name="delete-bin-line" size={15} />
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p class="empty">No keys</p>
+		{/if}
+
+		{#if keyError && !creating}<p class="error">{keyError}</p>{/if}
+
+		<div class="install-row">
+			<code>{installCommand}</code>
+			<button type="button" class="icon-btn" aria-label="Copy install command" onclick={copyInstall}>
+				<Icon name={installCopied ? 'check-line' : 'file-copy-line'} size={15} />
+			</button>
+		</div>
+	</section>
 </div>
+
+{#if creating}
+	<svelte:window
+		onkeydown={(event) => {
+			if (event.key === 'Escape' && !revealed) closeCreate();
+		}}
+	/>
+	<div
+		class="modal-backdrop"
+		role="presentation"
+		onclick={(event) => {
+			if (event.target === event.currentTarget && !revealed) closeCreate();
+		}}
+	>
+		<div
+			class="key-modal"
+			role="dialog"
+			aria-modal="true"
+			aria-label={revealed ? 'Copy API key' : 'New API key'}
+			tabindex="-1"
+		>
+			<div class="modal-head">
+				<h3>
+					<Icon name="key-2-line" size={16} />
+					{revealed ? 'Copy this key' : 'New API key'}
+				</h3>
+				<button type="button" class="icon-btn" aria-label="Close" onclick={closeCreate}>
+					<Icon name="close-line" size={16} />
+				</button>
+			</div>
+
+			{#if revealed}
+				<p class="modal-note">Shown once. Copy it now.</p>
+				<pre class="token-box">{revealed.token}</pre>
+				<div class="modal-actions">
+					<button type="button" class="btn-primary" onclick={copyKey}>
+						<Icon name={copied ? 'check-line' : 'file-copy-line'} size={15} />
+						{copied ? 'Copied' : 'Copy'}
+					</button>
+					<button type="button" class="btn-ghost" onclick={closeCreate}>Done</button>
+				</div>
+			{:else}
+				<form class="key-form" onsubmit={createKey}>
+					<label class="sr-only" for="apikey-name">Key name</label>
+					<input
+						id="apikey-name"
+						class="text-input"
+						placeholder="Name"
+						value={keyName}
+						autofocus
+						oninput={(event) => (keyName = event.currentTarget.value)}
+					/>
+
+					<div class="scope-row">
+						<Check label="Send mail" caption="send" checked={sendScope} onchange={(next) => (sendScope = next)} />
+						<Check label="Read mail" caption="read" checked={readScope} onchange={(next) => (readScope = next)} />
+						{#if data.isAdmin}
+							<Check
+								label="Admin"
+								caption="admin"
+								checked={adminScope}
+								onchange={(next) => (adminScope = next)}
+							/>
+						{/if}
+					</div>
+
+					{#if keyError}<p class="error">{keyError}</p>{/if}
+
+					<div class="modal-actions">
+						<button type="button" class="btn-ghost" onclick={closeCreate}>Cancel</button>
+						<button type="submit" class="btn-primary" disabled={keyBusy || !canCreateKey}>
+							{keyBusy ? 'Creating…' : 'Create'}
+						</button>
+					</div>
+				</form>
+			{/if}
+		</div>
+	</div>
+{/if}
 
 <style>
 	.settings-page {
@@ -283,6 +511,13 @@
 		padding: 1.5rem;
 	}
 
+	.card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
 	.card h2 {
 		display: flex;
 		align-items: center;
@@ -291,27 +526,12 @@
 		font-weight: 600;
 	}
 
-	.card-hint {
-		margin-top: 0.375rem;
-		font-size: 0.8125rem;
-		line-height: 1.5;
-		color: var(--color-muted);
-	}
-
 	.signature-form {
 		margin-top: 1rem;
 	}
 
-	.field-title {
-		display: block;
-		font-size: 0.8125rem;
-		font-weight: 500;
-		color: var(--color-text-secondary);
-	}
-
 	.signature-input {
 		width: 100%;
-		margin-top: 0.5rem;
 		padding: 0.75rem 0.875rem;
 		resize: vertical;
 		border-radius: 0.75rem;
@@ -566,5 +786,181 @@
 		margin-top: 0.75rem;
 		font-size: 0.8125rem;
 		color: var(--color-danger);
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.empty {
+		margin-top: 1rem;
+		font-size: 0.8125rem;
+		color: var(--color-muted);
+	}
+
+	.key-form {
+		display: flex;
+		flex-direction: column;
+		gap: 0.875rem;
+		margin-top: 1rem;
+	}
+
+	.text-input {
+		width: 100%;
+		padding: 0.625rem 0.75rem;
+		border-radius: 0.625rem;
+		font-size: 0.875rem;
+		color: var(--color-text);
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		transition: box-shadow 0.15s;
+	}
+
+	.text-input::placeholder {
+		color: var(--color-muted);
+	}
+
+	.text-input:focus {
+		outline: none;
+		box-shadow: inset 0 0 0 1px var(--color-focus-line), 0 0 0 3px var(--color-focus-halo);
+	}
+
+	.scope-row {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.375rem;
+	}
+
+	.key-list {
+		margin-top: 1rem;
+	}
+
+	.key-row {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		padding: 0.75rem 0;
+	}
+
+	.key-row + .key-row {
+		box-shadow: inset 0 1px 0 var(--color-line);
+	}
+
+	.key-name {
+		font-size: 0.875rem;
+		font-weight: 500;
+	}
+
+	.key-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.1875rem;
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.key-meta code {
+		font-size: 0.75rem;
+	}
+
+	.key-created {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 40;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		background: var(--color-scrim);
+	}
+
+	.key-modal {
+		width: 100%;
+		max-width: 26rem;
+		padding: 1.25rem 1.375rem 1.375rem;
+		border-radius: 1.25rem;
+		background: var(--color-surface);
+		box-shadow: var(--shadow-md);
+	}
+
+	.modal-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.modal-head h3 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.modal-note {
+		margin-top: 0.5rem;
+		font-size: 0.8125rem;
+		color: var(--color-muted);
+	}
+
+	.token-box {
+		overflow-x: auto;
+		margin-top: 0.875rem;
+		padding: 0.75rem;
+		border-radius: 0.625rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		word-break: break-all;
+		white-space: pre-wrap;
+		color: var(--color-text);
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.5rem;
+		margin-top: 0.25rem;
+	}
+
+	.key-form .modal-actions {
+		margin-top: 0.25rem;
+	}
+
+	.install-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 1rem;
+		padding: 0.625rem 0.75rem;
+		border-radius: 0.625rem;
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+	}
+
+	.install-row code {
+		flex: 1;
+		min-width: 0;
+		overflow-x: auto;
+		font-size: 0.75rem;
+		white-space: nowrap;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Users can mint scoped API keys in Settings and use them as bearer tokens so scripts do not need a browser session.
- A GitHub-installed `quickmail` CLI and MCP server talk to those keys; the public install command stays `curl -fsSL https://raw.githubusercontent.com/DivinPrince/quickmail/main/scripts/install.sh | sh`.
- Keys are hashed, cannot mint other keys, and `mail:read` / `mail:send` / `admin` are enforced so a leaked send-only key cannot read mail or hit admin routes.

## Test plan
- [ ] Apply `migrations/0009_api_tokens.sql`, create a key in Settings, copy it once, then revoke it
- [ ] `curl -fsSL https://raw.githubusercontent.com/DivinPrince/quickmail/main/scripts/install.sh | sh` then `quickmail login --url <instance> --token <key>`
- [ ] `quickmail inbox` / `send` with `mail:read` and `mail:send`; confirm a read-only key cannot send
- [ ] Admin-scoped `quickmail users list` / `unrouted`; a mail-only key gets 403
- [ ] `bunx quickmail mcp` (or `bun run quickmail -- mcp`) from the repo; curl install still skips MCP
- [ ] Mailbox and Settings use the custom checkbox, not native ones
- [ ] `bun test src/lib/email-signature.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts cli/client.test.ts` and `bash -n scripts/install.sh`


Made with [Cursor](https://cursor.com)