### PR TITLE
Fix settings window listener placement

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -110,6 +110,10 @@
 		keyError = '';
 	}
 
+	function handleWindowKeydown(event: KeyboardEvent) {
+		if (creating && event.key === 'Escape' && !revealed) closeCreate();
+	}
+
 	async function createKey(event?: SubmitEvent) {
 		if (event) event.preventDefault();
 		keyBusy = true;
@@ -234,6 +238,8 @@
 <svelte:head>
 	<title>Settings — Mail</title>
 </svelte:head>
+
+<svelte:window onkeydown={handleWindowKeydown} />
 
 <div class="settings-page">
 	<h1>Settings</h1>
@@ -417,11 +423,6 @@
 </div>
 
 {#if creating}
-	<svelte:window
-		onkeydown={(event) => {
-			if (event.key === 'Escape' && !revealed) closeCreate();
-		}}
-	/>
 	<div
 		class="modal-backdrop"
 		role="presentation"


### PR DESCRIPTION
## Summary

- move the settings page `<svelte:window>` listener to the component top level
- guard Escape handling so it only closes an open, unrevealed API-key modal
- restore successful production builds during setup and deployment

## Verification

- `bun run build`
- `bun run check` — 0 errors; one pre-existing `autofocus` accessibility warning
- `bun test` — 18 passed

Fixes #13
