### PR TITLE
Add desktop notifications for new mail

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -17,3 +17,10 @@ RESEND_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # --- Cloudflare Email (EMAIL_PROVIDER=cloudflare) ---
 # Comma-separated domains already onboarded in Email Service / Email Routing.
 # CLOUDFLARE_MAIL_DOMAINS=example.com,mail.example.com
+
+# --- Desktop notifications (optional) ---
+# Generate once with: bunx web-push generate-vapid-keys
+# Production values should be added with `wrangler secret put`, not committed.
+# VAPID_PUBLIC_KEY=REPLACE_WITH_YOUR_VAPID_PUBLIC_KEY
+# VAPID_PRIVATE_KEY=REPLACE_WITH_YOUR_VAPID_PRIVATE_KEY
+# VAPID_SUBJECT=mailto:admin@example.com

--- a/README.md
+++ b/README.md
@@ -254,6 +254,29 @@ No Resend key or webhook is used on this track. `vite dev` never runs the
 Send yourself a message from another account. It should land within a few
 seconds (Resend webhook or Cloudflare Routing → Worker).
 
+### Desktop notifications (optional)
+
+QuickMail can use Web Push to notify signed-in users when new mail arrives,
+even when no QuickMail tab is open. Generate one VAPID key pair for the
+deployment:
+
+```bash
+bunx web-push generate-vapid-keys
+bunx wrangler secret put VAPID_PUBLIC_KEY
+bunx wrangler secret put VAPID_PRIVATE_KEY
+bunx wrangler secret put VAPID_SUBJECT   # e.g. mailto:admin@example.com
+bun run db:migrate:remote
+bun run deploy
+```
+
+For local development, put the same three values in `.dev.vars` and run the
+local migrations. Users can then opt in under **Settings → Desktop
+notifications**. Permission is requested only after they press **Enable**.
+Subscriptions are stored per user and browser in D1; expired browser endpoints
+are removed after the push service reports them as gone. Keep the private key
+secret, and avoid changing the pair after users subscribe or they will need to
+enable notifications again.
+
 ---
 
 # Development

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "postal-mime": "^3.0.0",
         "remixicon": "^4.9.1",
+        "web-push": "^3.6.7",
         "zod": "^3.25.0",
       },
       "devDependencies": {
@@ -18,6 +19,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^24.10.1",
+        "@types/web-push": "^3.6.4",
         "svelte": "^5.55.2",
         "svelte-check": "^4.4.6",
         "tailwindcss": "^4.2.2",
@@ -272,9 +274,13 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -282,11 +288,17 @@
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
+    "asn1.js": ["asn1.js@5.4.1", "", { "dependencies": { "bn.js": "^4.0.0", "inherits": "^2.0.1", "minimalistic-assert": "^1.0.0", "safer-buffer": "^2.1.0" } }, "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
+
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -321,6 +333,8 @@
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
@@ -386,6 +400,10 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
+    "http_ece": ["http_ece@1.2.0", "", {}, "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -407,6 +425,10 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -449,6 +471,10 @@
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "miniflare": ["miniflare@5.20260815.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260815.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ=="],
+
+    "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -509,6 +535,8 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -577,6 +605,8 @@
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "web-push": ["web-push@3.6.7", "", { "dependencies": { "asn1.js": "^5.3.0", "http_ece": "1.2.0", "https-proxy-agent": "^7.0.0", "jws": "^4.0.0", "minimist": "^1.2.5" }, "bin": { "web-push": "src/cli.js" } }, "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/migrations/0010_push_subscriptions.sql
+++ b/migrations/0010_push_subscriptions.sql
@@ -1,0 +1,16 @@
+-- Browser Web Push subscriptions. One user can enable notifications on
+-- several browsers/devices; deleting the user removes every subscription.
+
+CREATE TABLE push_subscriptions (
+	id              TEXT PRIMARY KEY,
+	user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	endpoint        TEXT NOT NULL UNIQUE,
+	p256dh           TEXT NOT NULL,
+	auth             TEXT NOT NULL,
+	expiration_time  INTEGER,
+	user_agent       TEXT,
+	created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+	updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX idx_push_subscriptions_user ON push_subscriptions(user_id);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",
@@ -31,6 +31,7 @@
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/node": "^24.10.1",
+		"@types/web-push": "^3.6.4",
 		"svelte": "^5.55.2",
 		"svelte-check": "^4.4.6",
 		"tailwindcss": "^4.2.2",
@@ -42,6 +43,7 @@
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"postal-mime": "^3.0.0",
 		"remixicon": "^4.9.1",
+		"web-push": "^3.6.7",
 		"zod": "^3.25.0"
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,4 @@
-import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { D1Database, ExecutionContext, R2Bucket } from '@cloudflare/workers-types';
 import type { ApiScope, AuthMethod } from '$lib/server/api-access';
 import type { CloudflareSendEmailBinding } from '$lib/server/providers/cloudflare-provider';
 import type { Domain, MailAddress, User } from '$lib/types';
@@ -6,6 +6,7 @@ import type { Domain, MailAddress, User } from '$lib/types';
 declare global {
 	namespace App {
 		interface Platform {
+			ctx: ExecutionContext;
 			env: {
 				DB: D1Database;
 				ATTACHMENTS: R2Bucket;
@@ -19,6 +20,12 @@ declare global {
 				RESEND_API_KEY: string;
 				/** Signing secret from the Resend webhook (whsec_…). */
 				RESEND_WEBHOOK_SECRET: string;
+				/** Web Push application server public key. */
+				VAPID_PUBLIC_KEY?: string;
+				/** Web Push application server private key. */
+				VAPID_PRIVATE_KEY?: string;
+				/** A mailto: or https: contact URI for Web Push. */
+				VAPID_SUBJECT?: string;
 			};
 		}
 		interface Locals {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -11,6 +11,9 @@ declare global {
 		CLOUDFLARE_MAIL_DOMAINS?: string;
 		RESEND_API_KEY: string;
 		RESEND_WEBHOOK_SECRET: string;
+		VAPID_PUBLIC_KEY?: string;
+		VAPID_PRIVATE_KEY?: string;
+		VAPID_SUBJECT?: string;
 	}
 }
 

--- a/src/lib/components/DesktopNotifications.svelte
+++ b/src/lib/components/DesktopNotifications.svelte
@@ -1,0 +1,256 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import {
+		deletePushSubscription,
+		getPushSubscription,
+		isPushSubscriptionRegistered,
+		savePushSubscription,
+		subscribeToPush,
+		subscriptionUsesPublicKey,
+		supportsWebPush
+	} from '$lib/push-client';
+
+	let {
+		configured,
+		publicKey
+	}: {
+		configured: boolean;
+		publicKey: string | null;
+	} = $props();
+
+	type PushState =
+		| 'loading'
+		| 'unsupported'
+		| 'unconfigured'
+		| 'denied'
+		| 'disabled'
+		| 'enabled'
+		| 'error';
+
+	let pushState = $state<PushState>('loading');
+	let pushBusy = $state(false);
+	let pushError = $state('');
+	const pushStatusLabel = $derived(
+		({
+			loading: 'Checking',
+			unsupported: 'Unsupported',
+			unconfigured: 'Setup required',
+			denied: 'Blocked',
+			disabled: 'Off',
+			enabled: 'On',
+			error: 'Error'
+		} satisfies Record<PushState, string>)[pushState]
+	);
+
+	function pushErrorMessage(error: unknown): string {
+		return error instanceof Error ? error.message : 'Could not update desktop notifications';
+	}
+
+	async function refreshPushState() {
+		pushError = '';
+		if (!configured || !publicKey) {
+			pushState = 'unconfigured';
+			return;
+		}
+		if (!supportsWebPush()) {
+			pushState = 'unsupported';
+			return;
+		}
+		if (Notification.permission === 'denied') {
+			pushState = 'denied';
+			return;
+		}
+
+		try {
+			const subscription = await getPushSubscription();
+			if (
+				subscription &&
+				Notification.permission === 'granted' &&
+				subscriptionUsesPublicKey(subscription, publicKey) &&
+				(await isPushSubscriptionRegistered(subscription))
+			) {
+				pushState = 'enabled';
+			} else {
+				pushState = 'disabled';
+			}
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		}
+	}
+
+	$effect(() => {
+		void refreshPushState();
+	});
+
+	async function enableDesktopNotifications() {
+		if (!publicKey || !supportsWebPush()) return;
+		pushBusy = true;
+		pushError = '';
+		try {
+			const permission = await Notification.requestPermission();
+			if (permission !== 'granted') {
+				pushState = permission === 'denied' ? 'denied' : 'disabled';
+				pushError =
+					permission === 'denied'
+						? 'Notifications are blocked in this browser. Allow them in site settings.'
+						: 'Notification permission was not granted.';
+				return;
+			}
+
+			const subscription = await subscribeToPush(publicKey);
+			await savePushSubscription(subscription);
+			pushState = 'enabled';
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		} finally {
+			pushBusy = false;
+		}
+	}
+
+	async function disableDesktopNotifications() {
+		pushBusy = true;
+		pushError = '';
+		try {
+			const subscription = await getPushSubscription();
+			if (subscription) {
+				await deletePushSubscription(subscription);
+				const removed = await subscription.unsubscribe();
+				if (!removed) throw new Error('The browser could not remove its push subscription');
+			}
+			pushState = 'disabled';
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		} finally {
+			pushBusy = false;
+		}
+	}
+</script>
+
+<section class="surface-lg card">
+	<div class="card-head">
+		<div>
+			<h2><Icon name="notification-3-line" size={18} /> Desktop notifications</h2>
+			<p class="section-description">Get an alert when new mail arrives, even after closing this tab.</p>
+		</div>
+		<span class="badge" class:notification-on={pushState === 'enabled'}>{pushStatusLabel}</span>
+	</div>
+
+	{#if pushState === 'unconfigured'}
+		<p class="hint">
+			<Icon name="information-line" size={14} />
+			The server needs VAPID keys before desktop notifications can be enabled.
+		</p>
+	{:else if pushState === 'unsupported'}
+		<p class="hint">
+			<Icon name="information-line" size={14} />
+			This browser does not support Web Push notifications.
+		</p>
+	{:else if pushState === 'denied'}
+		<p class="hint">
+			<Icon name="information-line" size={14} />
+			Notifications are blocked. Allow them for this site in your browser settings.
+		</p>
+	{:else}
+		<div class="notification-controls">
+			<p class="hint notification-hint">
+				{pushState === 'enabled'
+					? 'This browser will receive notifications for your account.'
+					: 'Permission is requested only when you enable notifications.'}
+			</p>
+			{#if pushState === 'enabled'}
+				<button
+					type="button"
+					class="btn-ghost"
+					disabled={pushBusy}
+					onclick={disableDesktopNotifications}
+				>
+					{pushBusy ? 'Disabling…' : 'Disable'}
+				</button>
+			{:else}
+				<button
+					type="button"
+					class="btn-primary"
+					disabled={pushBusy || pushState === 'loading'}
+					onclick={enableDesktopNotifications}
+				>
+					{pushBusy ? 'Enabling…' : pushState === 'loading' ? 'Checking…' : 'Enable'}
+				</button>
+			{/if}
+		</div>
+	{/if}
+
+	{#if pushError}<p class="error" aria-live="polite">{pushError}</p>{/if}
+</section>
+
+<style>
+	.card {
+		margin-top: 1.5rem;
+		padding: 1.5rem;
+	}
+
+	.card-head {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.card h2 {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.9375rem;
+		font-weight: 600;
+	}
+
+	.section-description {
+		margin-top: 0.375rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		color: var(--color-muted);
+	}
+
+	.badge {
+		padding: 0.125rem 0.5rem;
+		border-radius: 9999px;
+		font-size: 0.6875rem;
+		font-weight: 500;
+		background: var(--color-surface-muted);
+	}
+
+	.notification-on {
+		color: var(--tone-good-fg);
+		background: var(--tone-good-bg);
+	}
+
+	.notification-controls {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-top: 1rem;
+	}
+
+	.hint {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.375rem;
+		margin-top: 0.75rem;
+		font-size: 0.75rem;
+		line-height: 1.5;
+		color: var(--color-muted);
+	}
+
+	.notification-hint {
+		margin-top: 0;
+	}
+
+	.error {
+		margin-top: 0.75rem;
+		font-size: 0.8125rem;
+		color: var(--color-danger);
+	}
+</style>

--- a/src/lib/push-client.test.ts
+++ b/src/lib/push-client.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	applicationServerKeyMatches,
+	base64UrlToApplicationServerKey,
+	subscriptionUsesPublicKey
+} from './push-client';
+
+test('converts URL-safe VAPID keys to bytes', () => {
+	const bytes = new Uint8Array(base64UrlToApplicationServerKey('AQID-v8'));
+	assert.deepEqual([...bytes], [1, 2, 3, 250, 255]);
+});
+
+test('detects subscriptions created with another VAPID key', () => {
+	const current = base64UrlToApplicationServerKey('AQID-v8');
+	assert.equal(applicationServerKeyMatches(current, 'AQID-v8'), true);
+	assert.equal(applicationServerKeyMatches(current, 'AQID-v4'), false);
+	assert.equal(applicationServerKeyMatches(null, 'AQID-v8'), false);
+
+	const subscription = {
+		options: { applicationServerKey: current }
+	} as Pick<PushSubscription, 'options'> as PushSubscription;
+	assert.equal(subscriptionUsesPublicKey(subscription, 'AQID-v8'), true);
+});

--- a/src/lib/push-client.ts
+++ b/src/lib/push-client.ts
@@ -35,18 +35,68 @@ export function subscriptionUsesPublicKey(
 	return applicationServerKeyMatches(subscription.options.applicationServerKey, publicKey);
 }
 
-export async function getPushSubscription(): Promise<PushSubscription | null> {
-	const registration = await navigator.serviceWorker.ready;
-	return registration.pushManager.getSubscription();
-}
+const SERVICE_WORKER_URL = '/service-worker.js';
+const WORKER_ACTIVATE_TIMEOUT_MS = 10_000;
 
-async function getExistingPushSubscription(): Promise<PushSubscription | null> {
+export async function getPushSubscription(): Promise<PushSubscription | null> {
 	const registration = await navigator.serviceWorker.getRegistration();
 	return registration?.pushManager.getSubscription() ?? null;
 }
 
+function waitUntilActive(registration: ServiceWorkerRegistration): Promise<ServiceWorkerRegistration> {
+	if (registration.active) return Promise.resolve(registration);
+
+	return new Promise((resolve, reject) => {
+		const pending = registration.installing ?? registration.waiting;
+		const timer = setTimeout(() => {
+			reject(new Error('The notification service worker did not activate'));
+		}, WORKER_ACTIVATE_TIMEOUT_MS);
+
+		let settled = false;
+		const finish = (error?: Error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			if (error) reject(error);
+			else resolve(registration);
+		};
+
+		if (!pending) {
+			const onFound = () => {
+				const installing = registration.installing;
+				if (!installing) return;
+				installing.addEventListener('statechange', () => {
+					if (registration.active) finish();
+				});
+			};
+			registration.addEventListener('updatefound', onFound, { once: true });
+			return;
+		}
+
+		const onState = () => {
+			if (pending.state === 'activated' || registration.active) {
+				pending.removeEventListener('statechange', onState);
+				finish();
+				return;
+			}
+			if (pending.state === 'redundant') {
+				pending.removeEventListener('statechange', onState);
+				finish(new Error('The notification service worker was replaced before it activated'));
+			}
+		};
+		pending.addEventListener('statechange', onState);
+		onState();
+	});
+}
+
+async function ensurePushRegistration(): Promise<ServiceWorkerRegistration> {
+	const registration = await navigator.serviceWorker.register(SERVICE_WORKER_URL);
+	if (registration.active) return registration;
+	return waitUntilActive(registration);
+}
+
 export async function subscribeToPush(publicKey: string): Promise<PushSubscription> {
-	const registration = await navigator.serviceWorker.ready;
+	const registration = await ensurePushRegistration();
 	const existing = await registration.pushManager.getSubscription();
 	if (existing && subscriptionUsesPublicKey(existing, publicKey)) return existing;
 	if (existing) {
@@ -99,7 +149,7 @@ export async function isPushSubscriptionRegistered(
 /** Remove the current browser from the authenticated account before logout. */
 export async function disablePushForCurrentAccount(): Promise<void> {
 	if (!supportsWebPush()) return;
-	const subscription = await getExistingPushSubscription();
+	const subscription = await getPushSubscription();
 	if (!subscription) return;
 
 	let serverError: unknown;
@@ -122,7 +172,7 @@ export async function disablePushForCurrentAccount(): Promise<void> {
  */
 export async function discardPushSubscriptionFromAnotherAccount(): Promise<void> {
 	if (!supportsWebPush()) return;
-	const subscription = await getExistingPushSubscription();
+	const subscription = await getPushSubscription();
 	if (!subscription || (await isPushSubscriptionRegistered(subscription))) return;
 	await subscription.unsubscribe();
 }

--- a/src/lib/push-client.ts
+++ b/src/lib/push-client.ts
@@ -1,0 +1,128 @@
+export function supportsWebPush(): boolean {
+	return (
+		typeof window !== 'undefined' &&
+		'Notification' in window &&
+		'serviceWorker' in navigator &&
+		'PushManager' in window
+	);
+}
+
+export function base64UrlToApplicationServerKey(value: string): ArrayBuffer {
+	const padding = '='.repeat((4 - (value.length % 4)) % 4);
+	const base64 = (value + padding).replaceAll('-', '+').replaceAll('_', '/');
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes.buffer;
+}
+
+export function applicationServerKeyMatches(
+	current: ArrayBuffer | null,
+	publicKey: string
+): boolean {
+	if (!current) return false;
+	const expected = new Uint8Array(base64UrlToApplicationServerKey(publicKey));
+	const actual = new Uint8Array(current);
+	return actual.byteLength === expected.byteLength && actual.every((byte, index) => byte === expected[index]);
+}
+
+export function subscriptionUsesPublicKey(
+	subscription: PushSubscription,
+	publicKey: string
+): boolean {
+	return applicationServerKeyMatches(subscription.options.applicationServerKey, publicKey);
+}
+
+export async function getPushSubscription(): Promise<PushSubscription | null> {
+	const registration = await navigator.serviceWorker.ready;
+	return registration.pushManager.getSubscription();
+}
+
+async function getExistingPushSubscription(): Promise<PushSubscription | null> {
+	const registration = await navigator.serviceWorker.getRegistration();
+	return registration?.pushManager.getSubscription() ?? null;
+}
+
+export async function subscribeToPush(publicKey: string): Promise<PushSubscription> {
+	const registration = await navigator.serviceWorker.ready;
+	const existing = await registration.pushManager.getSubscription();
+	if (existing && subscriptionUsesPublicKey(existing, publicKey)) return existing;
+	if (existing) {
+		// A subscription is tied to the VAPID public key used to create it. Remove a
+		// stale one so key rotation can recover through the normal Enable action.
+		await deletePushSubscription(existing).catch(() => undefined);
+		const removed = await existing.unsubscribe();
+		if (!removed) throw new Error('The browser could not replace its old push subscription');
+	}
+
+	return registration.pushManager.subscribe({
+		userVisibleOnly: true,
+		applicationServerKey: base64UrlToApplicationServerKey(publicKey)
+	});
+}
+
+async function readError(response: Response): Promise<string> {
+	const body = (await response.json().catch(() => null)) as { error?: unknown } | null;
+	return typeof body?.error === 'string' ? body.error : `Request failed (${response.status})`;
+}
+
+export async function savePushSubscription(subscription: PushSubscription): Promise<void> {
+	const response = await fetch('/api/push/subscriptions', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(subscription.toJSON())
+	});
+	if (!response.ok) throw new Error(await readError(response));
+}
+
+export async function deletePushSubscription(subscription: PushSubscription): Promise<void> {
+	const response = await fetch('/api/push/subscriptions', {
+		method: 'DELETE',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ endpoint: subscription.endpoint })
+	});
+	if (!response.ok) throw new Error(await readError(response));
+}
+
+export async function isPushSubscriptionRegistered(
+	subscription: PushSubscription
+): Promise<boolean> {
+	const endpoint = encodeURIComponent(subscription.endpoint);
+	const response = await fetch(`/api/push/subscriptions?endpoint=${endpoint}`);
+	if (!response.ok) throw new Error(await readError(response));
+	const body = (await response.json()) as { registered?: unknown };
+	return body.registered === true;
+}
+
+/** Remove the current browser from the authenticated account before logout. */
+export async function disablePushForCurrentAccount(): Promise<void> {
+	if (!supportsWebPush()) return;
+	const subscription = await getExistingPushSubscription();
+	if (!subscription) return;
+
+	let serverError: unknown;
+	try {
+		await deletePushSubscription(subscription);
+	} catch (error) {
+		serverError = error;
+	}
+
+	const removed = await subscription.unsubscribe();
+	if (!removed && !serverError) {
+		throw new Error('The browser could not remove its push subscription');
+	}
+	if (serverError) throw serverError;
+}
+
+/**
+ * After login, retain a native subscription only when the new account owns it.
+ * This prevents a shared browser from continuing to receive another user's mail.
+ */
+export async function discardPushSubscriptionFromAnotherAccount(): Promise<void> {
+	if (!supportsWebPush()) return;
+	const subscription = await getExistingPushSubscription();
+	if (!subscription || (await isPushSubscriptionRegistered(subscription))) return;
+	await subscription.unsubscribe();
+}

--- a/src/lib/server/api-access.test.ts
+++ b/src/lib/server/api-access.test.ts
@@ -35,6 +35,24 @@ describe('API key access', () => {
 			}).ok,
 			false
 		);
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/push/subscriptions',
+				method: 'POST',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}).ok,
+			false
+		);
+		assert.equal(
+			authorizeApiRequest({
+				pathname: '/api/push/subscriptions',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['mail:read', 'mail:send']
+			}).ok,
+			false
+		);
 	});
 
 	test('a read key can list and open threads', () => {

--- a/src/lib/server/cloudflare-inbound.ts
+++ b/src/lib/server/cloudflare-inbound.ts
@@ -1,10 +1,11 @@
-import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { R2Bucket } from '@cloudflare/workers-types';
 import PostalMime, { type Address, type Attachment } from 'postal-mime';
 import { insertAttachmentBytes } from './attachments';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENTS_PER_EMAIL } from './constants';
 import { recordUnroutedEmail, resolveInboundRoute } from './domains';
 import { collectInboundRecipients, parseEmailAddress } from './email-address';
 import { emailExistsByProviderId, insertEmail } from './mail-store';
+import { scheduleNewMailNotification, type PushNotificationEnv } from './push-notifications';
 import { normalizeMessageId } from './send-mail';
 
 export type CloudflareInboundMessage = {
@@ -15,8 +16,7 @@ export type CloudflareInboundMessage = {
 	setReject(reason: string): void;
 };
 
-export type CloudflareInboundEnv = {
-	DB: D1Database;
+export type CloudflareInboundEnv = PushNotificationEnv & {
 	ATTACHMENTS: R2Bucket;
 };
 
@@ -87,6 +87,12 @@ export async function handleCloudflareInbound(
 	});
 
 	await storeInboundAttachments(env, emailId, parsed.attachments);
+	await scheduleNewMailNotification(env, {
+		emailId,
+		userId: route.userId,
+		from,
+		subject
+	});
 }
 
 async function storeInboundAttachments(

--- a/src/lib/server/inbound.ts
+++ b/src/lib/server/inbound.ts
@@ -5,6 +5,7 @@ import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENTS_PER_EMAIL, MAX_BODY_BYTES } from 
 import { collectInboundRecipients, parseEmailAddress } from './email-address';
 import { recordUnroutedEmail, resolveInboundRoute } from './domains';
 import { emailExistsByProviderId, insertEmail, updateEmailStatusByProviderId } from './mail-store';
+import { scheduleNewMailNotification, type PushNotificationEnv } from './push-notifications';
 import type { ResendClient } from './resend';
 
 export type ResendWebhookEvent = {
@@ -18,7 +19,7 @@ export type WebhookOutcome = {
 	note: string;
 };
 
-type InboundEnv = { DB: D1Database; ATTACHMENTS: R2Bucket };
+type InboundEnv = PushNotificationEnv & { ATTACHMENTS: R2Bucket };
 
 /** Resend delivery events → the status we display on a sent message. */
 const STATUS_BY_EVENT: Record<string, DeliveryStatus> = {
@@ -132,6 +133,12 @@ async function handleInboundEmail(
 	});
 
 	await storeInboundAttachments(env, client, providerId, emailId);
+	await scheduleNewMailNotification(env, {
+		emailId,
+		userId: route.userId,
+		from,
+		subject
+	});
 
 	return {
 		handled: true,

--- a/src/lib/server/push-notifications.test.ts
+++ b/src/lib/server/push-notifications.test.ts
@@ -3,10 +3,12 @@ import { describe, test } from 'node:test';
 import type { D1Database } from '@cloudflare/workers-types';
 import webpush from 'web-push';
 import {
+	MAX_SUBSCRIPTIONS_PER_USER,
 	buildNewMailPayload,
 	parsePushSubscription,
 	pushErrorStatus,
 	readVapidConfiguration,
+	savePushSubscription,
 	scheduleNewMailNotification
 } from './push-notifications';
 
@@ -17,7 +19,7 @@ const validSubscription = {
 	expirationTime: null,
 	keys: {
 		p256dh: vapidKeys.publicKey,
-		auth: 'tBHItJI5svbpez7KI4CCXg'
+		auth: 'AAAAAAAAAAAAAAAAAAAAAA'
 	}
 };
 
@@ -134,4 +136,120 @@ describe('new-mail push payloads', () => {
 		assert.equal(pushErrorStatus({ statusCode: 410 }), 410);
 		assert.equal(pushErrorStatus(new Error('network error')), null);
 	});
+});
+
+type StoredPushRow = {
+	id: string;
+	user_id: string;
+	endpoint: string;
+	updated_at: string;
+	rowid: number;
+};
+
+function createMemoryPushDb() {
+	const rows: StoredPushRow[] = [];
+	let nextRowid = 1;
+	let clock = 0;
+
+	function prepare(sql: string) {
+		let bound: unknown[] = [];
+		const statement = {
+			bind(...args: unknown[]) {
+				bound = args;
+				return statement;
+			},
+			async run() {
+				if (sql.includes('INSERT INTO push_subscriptions')) {
+					const [id, userId, endpoint] = bound;
+					const existing = rows.find((row) => row.endpoint === String(endpoint));
+					clock += 1;
+					const updated_at = String(clock).padStart(4, '0');
+					if (existing) {
+						existing.user_id = String(userId);
+						existing.updated_at = updated_at;
+					} else {
+						rows.push({
+							id: String(id),
+							user_id: String(userId),
+							endpoint: String(endpoint),
+							updated_at,
+							rowid: nextRowid
+						});
+						nextRowid += 1;
+					}
+					return { meta: { changes: 1 } };
+				}
+				if (sql.includes('DELETE FROM push_subscriptions') && sql.includes('WHERE id = ?')) {
+					const index = rows.findIndex((row) => row.id === String(bound[0]));
+					if (index >= 0) rows.splice(index, 1);
+					return { meta: { changes: index >= 0 ? 1 : 0 } };
+				}
+				throw new Error(`Unexpected SQL: ${sql}`);
+			},
+			async all() {
+				if (!sql.includes('SELECT id FROM push_subscriptions')) {
+					throw new Error(`Unexpected SQL: ${sql}`);
+				}
+				const userId = String(bound[0]);
+				const keepEndpoint = String(bound[1]);
+				const list = rows
+					.filter((row) => row.user_id === userId)
+					.sort((left, right) => {
+						const keep =
+							Number(right.endpoint === keepEndpoint) - Number(left.endpoint === keepEndpoint);
+						if (keep !== 0) return keep;
+						if (left.updated_at !== right.updated_at) {
+							return left.updated_at < right.updated_at ? 1 : -1;
+						}
+						return right.rowid - left.rowid;
+					});
+				return { results: list.map((row) => ({ id: row.id })) };
+			}
+		};
+		return statement;
+	}
+
+	return {
+		db: {
+			prepare,
+			async batch(statements: Array<{ run: () => Promise<unknown> }>) {
+				for (const statement of statements) await statement.run();
+			}
+		} as unknown as D1Database,
+		rows
+	};
+}
+
+test('caps a user at ten subscriptions and keeps the newest endpoint', async () => {
+	const { db, rows } = createMemoryPushDb();
+	const keys = { p256dh: vapidKeys.publicKey, auth: 'AAAAAAAAAAAAAAAAAAAAAA' };
+
+	for (let index = 0; index < MAX_SUBSCRIPTIONS_PER_USER; index += 1) {
+		await savePushSubscription(db, 'user-1', {
+			endpoint: `https://push.example.com/subscriptions/device-${index}`,
+			expirationTime: null,
+			keys
+		});
+	}
+
+	await savePushSubscription(db, 'user-2', {
+		endpoint: 'https://push.example.com/subscriptions/other-user',
+		expirationTime: null,
+		keys
+	});
+
+	await savePushSubscription(db, 'user-1', {
+		endpoint: 'https://push.example.com/subscriptions/device-newest',
+		expirationTime: null,
+		keys
+	});
+
+	const userRows = rows.filter((row) => row.user_id === 'user-1');
+	assert.equal(userRows.length, MAX_SUBSCRIPTIONS_PER_USER);
+	assert.ok(userRows.some((row) => row.endpoint.endsWith('/device-newest')));
+	assert.equal(
+		userRows.some((row) => row.endpoint.endsWith('/device-0')),
+		false
+	);
+	assert.ok(rows.some((row) => row.user_id === 'user-2'));
 });

--- a/src/lib/server/push-notifications.test.ts
+++ b/src/lib/server/push-notifications.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { D1Database } from '@cloudflare/workers-types';
+import webpush from 'web-push';
+import {
+	buildNewMailPayload,
+	parsePushSubscription,
+	pushErrorStatus,
+	readVapidConfiguration,
+	scheduleNewMailNotification
+} from './push-notifications';
+
+const vapidKeys = webpush.generateVAPIDKeys();
+
+const validSubscription = {
+	endpoint: 'https://push.example.com/subscriptions/device-1',
+	expirationTime: null,
+	keys: {
+		p256dh: vapidKeys.publicKey,
+		auth: 'tBHItJI5svbpez7KI4CCXg'
+	}
+};
+
+describe('push subscription parsing', () => {
+	test('accepts browser subscription JSON', () => {
+		assert.deepEqual(parsePushSubscription(validSubscription), validSubscription);
+	});
+
+	test('rejects insecure endpoints and malformed keys', () => {
+		assert.equal(
+			parsePushSubscription({ ...validSubscription, endpoint: 'http://push.example.com/device' }),
+			null
+		);
+		assert.equal(
+			parsePushSubscription({
+				...validSubscription,
+				keys: { ...validSubscription.keys, auth: 'not base64!' }
+			}),
+			null
+		);
+		assert.equal(parsePushSubscription({ endpoint: validSubscription.endpoint }), null);
+		assert.equal(
+			parsePushSubscription({
+				...validSubscription,
+				keys: { ...validSubscription.keys, p256dh: validSubscription.keys.p256dh.slice(1) }
+			}),
+			null
+		);
+	});
+});
+
+describe('VAPID configuration', () => {
+	test('requires all keys and a contact URI', () => {
+		assert.deepEqual(
+			readVapidConfiguration({
+				VAPID_PUBLIC_KEY: vapidKeys.publicKey,
+				VAPID_PRIVATE_KEY: vapidKeys.privateKey,
+				VAPID_SUBJECT: 'mailto:admin@example.com'
+			}),
+			{ ...vapidKeys, subject: 'mailto:admin@example.com' }
+		);
+		assert.equal(
+			readVapidConfiguration({
+				VAPID_PUBLIC_KEY: vapidKeys.publicKey,
+				VAPID_PRIVATE_KEY: vapidKeys.privateKey,
+				VAPID_SUBJECT: 'admin@example.com'
+			}),
+			null
+		);
+		assert.equal(
+			readVapidConfiguration({
+				VAPID_PUBLIC_KEY: vapidKeys.publicKey,
+				VAPID_PRIVATE_KEY: vapidKeys.privateKey,
+				VAPID_SUBJECT: 'mailto:'
+			}),
+			null
+		);
+	});
+
+	test('rejects placeholders and mismatched key pairs', () => {
+		assert.equal(
+			readVapidConfiguration({
+				VAPID_PUBLIC_KEY: 'REPLACE_WITH_YOUR_VAPID_PUBLIC_KEY',
+				VAPID_PRIVATE_KEY: 'REPLACE_WITH_YOUR_VAPID_PRIVATE_KEY',
+				VAPID_SUBJECT: 'mailto:admin@example.com'
+			}),
+			null
+		);
+
+		const otherKeys = webpush.generateVAPIDKeys();
+		assert.equal(
+			readVapidConfiguration({
+				VAPID_PUBLIC_KEY: vapidKeys.publicKey,
+				VAPID_PRIVATE_KEY: otherKeys.privateKey,
+				VAPID_SUBJECT: 'https://example.com/push-contact'
+			}),
+			null
+		);
+	});
+});
+
+test('push delivery is handed to the runtime background scheduler', async () => {
+	let scheduled: Promise<void> | null = null;
+	await scheduleNewMailNotification(
+		{
+			DB: {} as D1Database,
+			waitUntil: (promise) => (scheduled = promise)
+		},
+		{ emailId: 'mail-1', userId: 'user-1', from: 'sender@example.com', subject: 'Hello' }
+	);
+	assert.ok(scheduled);
+	await scheduled;
+});
+
+describe('new-mail push payloads', () => {
+	test('contain no message body and link to the stored email', () => {
+		const payload = buildNewMailPayload({
+			emailId: 'mail/id',
+			userId: 'user-1',
+			from: 'Ada <ada@example.com>',
+			subject: 'Project update'
+		});
+
+		assert.deepEqual(payload, {
+			title: 'Project update',
+			body: 'From Ada <ada@example.com>',
+			tag: 'quickmail-mail/id',
+			url: '/mail/mail%2Fid'
+		});
+		assert.equal(JSON.stringify(payload).includes('message body'), false);
+	});
+
+	test('recognizes expired subscription responses', () => {
+		assert.equal(pushErrorStatus({ statusCode: 410 }), 410);
+		assert.equal(pushErrorStatus(new Error('network error')), null);
+	});
+});

--- a/src/lib/server/push-notifications.ts
+++ b/src/lib/server/push-notifications.ts
@@ -5,7 +5,7 @@ import webpush from 'web-push';
 const MAX_ENDPOINT_LENGTH = 2048;
 const MAX_KEY_LENGTH = 512;
 const MAX_USER_AGENT_LENGTH = 512;
-const MAX_SUBSCRIPTIONS_PER_USER = 10;
+export const MAX_SUBSCRIPTIONS_PER_USER = 10;
 const PUSH_REQUEST_TIMEOUT_MS = 10_000;
 const BASE64URL = /^[A-Za-z0-9_-]+={0,2}$/;
 
@@ -195,18 +195,29 @@ export async function savePushSubscription(
 		)
 		.run();
 
-	await db
+	await capUserSubscriptions(db, userId, subscription.endpoint);
+}
+
+async function capUserSubscriptions(
+	db: D1Database,
+	userId: string,
+	keepEndpoint: string
+): Promise<void> {
+	const { results } = await db
 		.prepare(
-			`DELETE FROM push_subscriptions
-			 WHERE user_id = ? AND id NOT IN (
-				 SELECT id FROM push_subscriptions
-				 WHERE user_id = ?
-				 ORDER BY (endpoint = ?) DESC, updated_at DESC, rowid DESC
-				 LIMIT ?
-			 )`
+			`SELECT id FROM push_subscriptions
+			 WHERE user_id = ?
+			 ORDER BY (endpoint = ?) DESC, updated_at DESC, rowid DESC`
 		)
-		.bind(userId, userId, subscription.endpoint, MAX_SUBSCRIPTIONS_PER_USER)
-		.run();
+		.bind(userId, keepEndpoint)
+		.all<{ id: string }>();
+
+	const extraIds = results.slice(MAX_SUBSCRIPTIONS_PER_USER).map((row) => row.id);
+	if (extraIds.length === 0) return;
+
+	await db.batch(
+		extraIds.map((id) => db.prepare('DELETE FROM push_subscriptions WHERE id = ?').bind(id))
+	);
 }
 
 export async function hasPushSubscription(

--- a/src/lib/server/push-notifications.ts
+++ b/src/lib/server/push-notifications.ts
@@ -1,0 +1,353 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import { createECDH } from 'node:crypto';
+import webpush from 'web-push';
+
+const MAX_ENDPOINT_LENGTH = 2048;
+const MAX_KEY_LENGTH = 512;
+const MAX_USER_AGENT_LENGTH = 512;
+const MAX_SUBSCRIPTIONS_PER_USER = 10;
+const PUSH_REQUEST_TIMEOUT_MS = 10_000;
+const BASE64URL = /^[A-Za-z0-9_-]+={0,2}$/;
+
+export type PushSubscriptionInput = {
+	endpoint: string;
+	expirationTime: number | null;
+	keys: {
+		p256dh: string;
+		auth: string;
+	};
+};
+
+export type PushNotificationEnv = {
+	DB: D1Database;
+	VAPID_PUBLIC_KEY?: string;
+	VAPID_PRIVATE_KEY?: string;
+	VAPID_SUBJECT?: string;
+	waitUntil?: (promise: Promise<void>) => void;
+};
+
+type StoredPushSubscription = {
+	endpoint: string;
+	p256dh: string;
+	auth: string;
+	expiration_time: number | null;
+};
+
+export type NewMailNotificationInput = {
+	emailId: string;
+	userId: string;
+	from: string;
+	subject: string;
+};
+
+export type NewMailPushPayload = {
+	title: string;
+	body: string;
+	tag: string;
+	url: string;
+};
+
+type VapidConfiguration = {
+	publicKey: string;
+	privateKey: string;
+	subject: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function decodeBase64Url(value: unknown): Uint8Array | null {
+	if (
+		typeof value !== 'string' ||
+		value.length === 0 ||
+		value.length > MAX_KEY_LENGTH ||
+		!BASE64URL.test(value)
+	) {
+		return null;
+	}
+
+	const unpadded = value.replace(/=+$/, '');
+	if (unpadded.length % 4 === 1) return null;
+	const base64 = unpadded.replaceAll('-', '+').replaceAll('_', '/');
+	const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+
+	try {
+		const binary = atob(padded);
+		return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+	} catch {
+		return null;
+	}
+}
+
+function validPublicKey(value: unknown): value is string {
+	const decoded = decodeBase64Url(value);
+	return decoded?.byteLength === 65 && decoded[0] === 0x04;
+}
+
+function validAuthSecret(value: unknown): value is string {
+	return decodeBase64Url(value)?.byteLength === 16;
+}
+
+function validVapidKeyPair(publicKey: string, privateKey: string): boolean {
+	const publicBytes = decodeBase64Url(publicKey);
+	const privateBytes = decodeBase64Url(privateKey);
+	if (publicBytes?.byteLength !== 65 || publicBytes[0] !== 0x04 || privateBytes?.byteLength !== 32) {
+		return false;
+	}
+
+	try {
+		const ecdh = createECDH('prime256v1');
+		ecdh.setPrivateKey(privateBytes);
+		const derivedPublicKey = ecdh.getPublicKey();
+		return (
+			derivedPublicKey.byteLength === publicBytes.byteLength &&
+			derivedPublicKey.every((byte, index) => byte === publicBytes[index])
+		);
+	} catch {
+		return false;
+	}
+}
+
+function validEndpoint(value: unknown): value is string {
+	if (typeof value !== 'string') return false;
+	const endpoint = value.trim();
+	if (!endpoint || endpoint.length > MAX_ENDPOINT_LENGTH) return false;
+
+	try {
+		const url = new URL(endpoint);
+		return url.protocol === 'https:' && !url.username && !url.password;
+	} catch {
+		return false;
+	}
+}
+
+/** Treat browser subscription JSON as untrusted input before storing it. */
+export function parsePushSubscription(value: unknown): PushSubscriptionInput | null {
+	if (!isRecord(value) || typeof value.endpoint !== 'string' || !isRecord(value.keys)) {
+		return null;
+	}
+
+	if (!validEndpoint(value.endpoint)) return null;
+	const endpoint = value.endpoint.trim();
+
+	if (!validPublicKey(value.keys.p256dh) || !validAuthSecret(value.keys.auth)) return null;
+
+	const expirationTime = value.expirationTime ?? null;
+	if (
+		expirationTime !== null &&
+		(typeof expirationTime !== 'number' || !Number.isFinite(expirationTime) || expirationTime < 0)
+	) {
+		return null;
+	}
+
+	return {
+		endpoint,
+		expirationTime,
+		keys: { p256dh: value.keys.p256dh, auth: value.keys.auth }
+	};
+}
+
+export function readVapidConfiguration(
+	env: Pick<PushNotificationEnv, 'VAPID_PUBLIC_KEY' | 'VAPID_PRIVATE_KEY' | 'VAPID_SUBJECT'>
+): VapidConfiguration | null {
+	const publicKey = env.VAPID_PUBLIC_KEY?.trim();
+	const privateKey = env.VAPID_PRIVATE_KEY?.trim();
+	const subject = env.VAPID_SUBJECT?.trim();
+	if (!publicKey || !privateKey || !subject || !validVapidKeyPair(publicKey, privateKey)) return null;
+	try {
+		const subjectUrl = new URL(subject);
+		if (subjectUrl.protocol !== 'mailto:' && subjectUrl.protocol !== 'https:') return null;
+		if (subjectUrl.protocol === 'mailto:' && !subjectUrl.pathname.trim()) return null;
+	} catch {
+		return null;
+	}
+	return { publicKey, privateKey, subject };
+}
+
+export async function savePushSubscription(
+	db: D1Database,
+	userId: string,
+	subscription: PushSubscriptionInput,
+	userAgent?: string | null
+): Promise<void> {
+	await db
+		.prepare(
+			`INSERT INTO push_subscriptions (
+				id, user_id, endpoint, p256dh, auth, expiration_time, user_agent
+			) VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(endpoint) DO UPDATE SET
+				user_id = excluded.user_id,
+				p256dh = excluded.p256dh,
+				auth = excluded.auth,
+				expiration_time = excluded.expiration_time,
+				user_agent = excluded.user_agent,
+				updated_at = datetime('now')`
+		)
+		.bind(
+			crypto.randomUUID(),
+			userId,
+			subscription.endpoint,
+			subscription.keys.p256dh,
+			subscription.keys.auth,
+			subscription.expirationTime,
+			userAgent?.slice(0, MAX_USER_AGENT_LENGTH) ?? null
+		)
+		.run();
+
+	await db
+		.prepare(
+			`DELETE FROM push_subscriptions
+			 WHERE user_id = ? AND id NOT IN (
+				 SELECT id FROM push_subscriptions
+				 WHERE user_id = ?
+				 ORDER BY (endpoint = ?) DESC, updated_at DESC, rowid DESC
+				 LIMIT ?
+			 )`
+		)
+		.bind(userId, userId, subscription.endpoint, MAX_SUBSCRIPTIONS_PER_USER)
+		.run();
+}
+
+export async function hasPushSubscription(
+	db: D1Database,
+	userId: string,
+	endpoint: string
+): Promise<boolean> {
+	if (!validEndpoint(endpoint)) return false;
+	const row = await db
+		.prepare('SELECT 1 AS registered FROM push_subscriptions WHERE user_id = ? AND endpoint = ?')
+		.bind(userId, endpoint.trim())
+		.first<{ registered: number }>();
+	return row?.registered === 1;
+}
+
+export async function removePushSubscription(
+	db: D1Database,
+	userId: string,
+	endpoint: string
+): Promise<boolean> {
+	const result = await db
+		.prepare('DELETE FROM push_subscriptions WHERE user_id = ? AND endpoint = ?')
+		.bind(userId, endpoint)
+		.run();
+	return (result.meta?.changes ?? 0) > 0;
+}
+
+async function listPushSubscriptions(
+	db: D1Database,
+	userId: string
+): Promise<StoredPushSubscription[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT endpoint, p256dh, auth, expiration_time
+			 FROM push_subscriptions WHERE user_id = ?
+			 ORDER BY updated_at DESC, rowid DESC
+			 LIMIT ?`
+		)
+		.bind(userId, MAX_SUBSCRIPTIONS_PER_USER)
+		.all<StoredPushSubscription>();
+	return results;
+}
+
+async function removeDeadSubscriptions(db: D1Database, endpoints: string[]): Promise<void> {
+	if (endpoints.length === 0) return;
+	await db.batch(
+		endpoints.map((endpoint) =>
+			db.prepare('DELETE FROM push_subscriptions WHERE endpoint = ?').bind(endpoint)
+		)
+	);
+}
+
+function truncate(value: string, max: number): string {
+	const normalized = value.trim().replace(/\s+/g, ' ');
+	return normalized.length <= max ? normalized : `${normalized.slice(0, max - 1)}…`;
+}
+
+export function buildNewMailPayload(input: NewMailNotificationInput): NewMailPushPayload {
+	return {
+		title: truncate(input.subject || '(no subject)', 120) || '(no subject)',
+		body: `From ${truncate(input.from || 'Unknown sender', 160) || 'Unknown sender'}`,
+		tag: `quickmail-${input.emailId}`,
+		url: `/mail/${encodeURIComponent(input.emailId)}`
+	};
+}
+
+export function pushErrorStatus(error: unknown): number | null {
+	if (!isRecord(error) || typeof error.statusCode !== 'number') return null;
+	return error.statusCode;
+}
+
+/**
+ * Notify every browser registered to the recipient. Push failures never undo a
+ * successfully stored email; expired endpoints are removed automatically.
+ */
+export async function notifyNewMail(
+	env: PushNotificationEnv,
+	input: NewMailNotificationInput
+): Promise<void> {
+	try {
+		await deliverNewMailNotification(env, input);
+	} catch (error) {
+		console.error(
+			'Failed to deliver new-mail push notifications',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+	}
+}
+
+/** Schedule best-effort delivery without holding up inbound-provider acknowledgement. */
+export async function scheduleNewMailNotification(
+	env: PushNotificationEnv,
+	input: NewMailNotificationInput
+): Promise<void> {
+	const task = notifyNewMail(env, input);
+	if (env.waitUntil) {
+		env.waitUntil(task);
+		return;
+	}
+	await task;
+}
+
+async function deliverNewMailNotification(
+	env: PushNotificationEnv,
+	input: NewMailNotificationInput
+): Promise<void> {
+	const vapid = readVapidConfiguration(env);
+	if (!vapid) return;
+
+	const subscriptions = await listPushSubscriptions(env.DB, input.userId);
+	if (subscriptions.length === 0) return;
+
+	webpush.setVapidDetails(vapid.subject, vapid.publicKey, vapid.privateKey);
+	const payload = JSON.stringify(buildNewMailPayload(input));
+	const deadEndpoints: string[] = [];
+
+	await Promise.all(
+		subscriptions.map(async (subscription) => {
+			try {
+				await webpush.sendNotification(
+					{
+						endpoint: subscription.endpoint,
+						expirationTime: subscription.expiration_time,
+						keys: { p256dh: subscription.p256dh, auth: subscription.auth }
+					},
+					payload,
+						{ TTL: 300, urgency: 'high', timeout: PUSH_REQUEST_TIMEOUT_MS }
+				);
+			} catch (error) {
+				const status = pushErrorStatus(error);
+				if (status === 404 || status === 410) {
+					deadEndpoints.push(subscription.endpoint);
+				} else {
+					console.error(
+						'Failed to send new-mail push notification',
+						status ?? (error instanceof Error ? error.message : 'Unknown error')
+					);
+				}
+			}
+		})
+	);
+
+	await removeDeadSubscriptions(env.DB, deadEndpoints);
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Topbar from '$lib/components/Topbar.svelte';
+	import { disablePushForCurrentAccount } from '$lib/push-client';
 	import { watchSystemTheme } from '$lib/theme';
 	import type { LayoutData } from './$types';
 
@@ -36,8 +37,14 @@
 	});
 
 	async function logout() {
-		await fetch('/api/auth/login', { method: 'DELETE' });
-		window.location.href = '/login';
+		try {
+			await disablePushForCurrentAccount();
+		} catch (error) {
+			console.warn('Could not fully remove the push subscription during logout', error);
+		} finally {
+			await fetch('/api/auth/login', { method: 'DELETE' });
+			window.location.href = '/login';
+		}
 	}
 </script>
 

--- a/src/routes/api/push/subscriptions/+server.ts
+++ b/src/routes/api/push/subscriptions/+server.ts
@@ -1,0 +1,66 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import {
+	hasPushSubscription,
+	parsePushSubscription,
+	removePushSubscription,
+	savePushSubscription
+} from '$lib/server/push-notifications';
+
+function rejectCrossOrigin(request: Request, url: URL): Response | null {
+	const origin = request.headers.get('origin');
+	if (origin && origin !== url.origin) {
+		return json({ error: 'Cross-origin request rejected' }, { status: 403 });
+	}
+	return null;
+}
+
+export const GET: RequestHandler = async ({ url, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user || locals.authMethod !== 'session') {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const endpoint = url.searchParams.get('endpoint');
+	if (!endpoint) return json({ error: 'Push endpoint is required' }, { status: 400 });
+	return json({ registered: await hasPushSubscription(db, locals.user.id, endpoint) });
+};
+
+export const POST: RequestHandler = async ({ request, url, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user || locals.authMethod !== 'session') {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+	const crossOrigin = rejectCrossOrigin(request, url);
+	if (crossOrigin) return crossOrigin;
+
+	const body = await request.json().catch(() => null);
+	const subscription = parsePushSubscription(body);
+	if (!subscription) {
+		return json({ error: 'Invalid push subscription' }, { status: 400 });
+	}
+
+	await savePushSubscription(
+		db,
+		locals.user.id,
+		subscription,
+		request.headers.get('user-agent')
+	);
+	return json({ ok: true }, { status: 201 });
+};
+
+export const DELETE: RequestHandler = async ({ request, url, locals, platform }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user || locals.authMethod !== 'session') {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+	const crossOrigin = rejectCrossOrigin(request, url);
+	if (crossOrigin) return crossOrigin;
+
+	const body = (await request.json().catch(() => null)) as { endpoint?: unknown } | null;
+	if (typeof body?.endpoint !== 'string' || !body.endpoint.trim()) {
+		return json({ error: 'Push endpoint is required' }, { status: 400 });
+	}
+
+	await removePushSubscription(db, locals.user.id, body.endpoint.trim());
+	return json({ ok: true });
+};

--- a/src/routes/api/webhooks/resend/+server.ts
+++ b/src/routes/api/webhooks/resend/+server.ts
@@ -52,7 +52,18 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 
 	try {
 		const client = getResendClient(platform);
-		const outcome = await handleResendWebhook(event, { DB: db, ATTACHMENTS: bucket }, client);
+		const outcome = await handleResendWebhook(
+			event,
+			{
+				DB: db,
+				ATTACHMENTS: bucket,
+				VAPID_PUBLIC_KEY: platform?.env.VAPID_PUBLIC_KEY,
+				VAPID_PRIVATE_KEY: platform?.env.VAPID_PRIVATE_KEY,
+				VAPID_SUBJECT: platform?.env.VAPID_SUBJECT,
+				waitUntil: platform?.ctx ? (promise) => platform.ctx.waitUntil(promise) : undefined
+			},
+			client
+		);
 		return json({ ok: true, ...outcome });
 	} catch (error) {
 		// Release the claim so Resend's retry can succeed.

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Logo from '$lib/components/Logo.svelte';
+	import { discardPushSubscriptionFromAnotherAccount } from '$lib/push-client';
 
 	let email = $state('');
 	let password = $state('');
@@ -21,6 +22,11 @@
 			if (!res.ok) {
 				error = data.error ?? 'Login failed';
 				return;
+			}
+			try {
+				await discardPushSubscriptionFromAnotherAccount();
+			} catch (pushError) {
+				console.warn('Could not reconcile the existing push subscription after login', pushError);
 			}
 			window.location.href = '/inbox';
 		} catch {

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,17 +1,23 @@
 import type { PageServerLoad } from './$types';
 import { listApiTokens } from '$lib/server/api-tokens';
 import { getEmailSignature } from '$lib/server/email-signature';
+import { readVapidConfiguration } from '$lib/server/push-notifications';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
 	const db = platform?.env.DB;
 	const signature = locals.user && db ? await getEmailSignature(db, locals.user.id) : '';
 	const apiTokens = locals.user && db ? await listApiTokens(db, locals.user.id) : [];
+	const vapid = platform?.env ? readVapidConfiguration(platform.env) : null;
 
 	return {
 		domains: locals.domains,
 		addresses: locals.addresses,
 		signature,
 		apiTokens,
+		push: {
+			configured: Boolean(vapid),
+			publicKey: vapid?.publicKey ?? null
+		},
 		isAdmin: locals.user?.is_admin ?? false
 	};
 };

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,6 +3,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import Check from '$lib/components/Check.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
+	import DesktopNotifications from '$lib/components/DesktopNotifications.svelte';
 	import {
 		readThemePreference,
 		setThemePreference,
@@ -10,15 +11,6 @@
 		type ThemePreference
 	} from '$lib/theme';
 	import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
-	import {
-		deletePushSubscription,
-		getPushSubscription,
-		isPushSubscriptionRegistered,
-		savePushSubscription,
-		subscribeToPush,
-		subscriptionUsesPublicKey,
-		supportsWebPush
-	} from '$lib/push-client';
 	import type { ApiTokenSummary, MailAddress } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -33,116 +25,6 @@
 	function chooseTheme(next: ThemePreference) {
 		theme = next;
 		setThemePreference(next);
-	}
-
-	type PushState =
-		| 'loading'
-		| 'unsupported'
-		| 'unconfigured'
-		| 'denied'
-		| 'disabled'
-		| 'enabled'
-		| 'error';
-
-	let pushState = $state<PushState>('loading');
-	let pushBusy = $state(false);
-	let pushError = $state('');
-	const pushStatusLabel = $derived(
-		({
-			loading: 'Checking',
-			unsupported: 'Unsupported',
-			unconfigured: 'Setup required',
-			denied: 'Blocked',
-			disabled: 'Off',
-			enabled: 'On',
-			error: 'Error'
-		} satisfies Record<PushState, string>)[pushState]
-	);
-
-	function pushErrorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : 'Could not update desktop notifications';
-	}
-
-	async function refreshPushState() {
-		pushError = '';
-		if (!data.push.configured || !data.push.publicKey) {
-			pushState = 'unconfigured';
-			return;
-		}
-		if (!supportsWebPush()) {
-			pushState = 'unsupported';
-			return;
-		}
-		if (Notification.permission === 'denied') {
-			pushState = 'denied';
-			return;
-		}
-
-		try {
-			const subscription = await getPushSubscription();
-			if (
-				subscription &&
-				Notification.permission === 'granted' &&
-				subscriptionUsesPublicKey(subscription, data.push.publicKey) &&
-				(await isPushSubscriptionRegistered(subscription))
-			) {
-				pushState = 'enabled';
-			} else {
-				pushState = 'disabled';
-			}
-		} catch (error) {
-			pushState = 'error';
-			pushError = pushErrorMessage(error);
-		}
-	}
-
-	$effect(() => {
-		void refreshPushState();
-	});
-
-	async function enableDesktopNotifications() {
-		if (!data.push.publicKey || !supportsWebPush()) return;
-		pushBusy = true;
-		pushError = '';
-		try {
-			const permission = await Notification.requestPermission();
-			if (permission !== 'granted') {
-				pushState = permission === 'denied' ? 'denied' : 'disabled';
-				pushError =
-					permission === 'denied'
-						? 'Notifications are blocked in this browser. Allow them in site settings.'
-						: 'Notification permission was not granted.';
-				return;
-			}
-
-			const subscription = await subscribeToPush(data.push.publicKey);
-			await savePushSubscription(subscription);
-			pushState = 'enabled';
-		} catch (error) {
-			pushState = 'error';
-			pushError = pushErrorMessage(error);
-		} finally {
-			pushBusy = false;
-		}
-	}
-
-	async function disableDesktopNotifications() {
-		pushBusy = true;
-		pushError = '';
-		try {
-			const subscription = await getPushSubscription();
-			if (subscription) {
-				await deletePushSubscription(subscription);
-				const removed = await subscription.unsubscribe();
-				if (!removed) throw new Error('The browser could not remove its push subscription');
-			}
-			pushState = 'disabled';
-		} catch (error) {
-			pushState = 'error';
-			pushError = pushErrorMessage(error);
-		} finally {
-			pushBusy = false;
-		}
 	}
 
 	let signature = $state(untrack(() => data.signature));
@@ -393,61 +275,7 @@
 		</div>
 	</section>
 
-	<section class="surface-lg card">
-		<div class="card-head notification-head">
-			<div>
-				<h2><Icon name="notification-3-line" size={18} /> Desktop notifications</h2>
-				<p class="section-description">Get an alert when new mail arrives, even after closing this tab.</p>
-			</div>
-			<span class="badge" class:notification-on={pushState === 'enabled'}>{pushStatusLabel}</span>
-		</div>
-
-		{#if pushState === 'unconfigured'}
-			<p class="hint">
-				<Icon name="information-line" size={14} />
-				The server needs VAPID keys before desktop notifications can be enabled.
-			</p>
-		{:else if pushState === 'unsupported'}
-			<p class="hint">
-				<Icon name="information-line" size={14} />
-				This browser does not support Web Push notifications.
-			</p>
-		{:else if pushState === 'denied'}
-			<p class="hint">
-				<Icon name="information-line" size={14} />
-				Notifications are blocked. Allow them for this site in your browser settings.
-			</p>
-		{:else}
-			<div class="notification-controls">
-				<p class="hint notification-hint">
-					{pushState === 'enabled'
-						? 'This browser will receive notifications for your account.'
-						: 'Permission is requested only when you enable notifications.'}
-				</p>
-				{#if pushState === 'enabled'}
-					<button
-						type="button"
-						class="btn-ghost"
-						disabled={pushBusy}
-						onclick={disableDesktopNotifications}
-					>
-						{pushBusy ? 'Disabling…' : 'Disable'}
-					</button>
-				{:else}
-					<button
-						type="button"
-						class="btn-primary"
-						disabled={pushBusy || pushState === 'loading'}
-						onclick={enableDesktopNotifications}
-					>
-						{pushBusy ? 'Enabling…' : pushState === 'loading' ? 'Checking…' : 'Enable'}
-					</button>
-				{/if}
-			</div>
-		{/if}
-
-		{#if pushError}<p class="error" aria-live="polite">{pushError}</p>{/if}
-	</section>
+	<DesktopNotifications configured={data.push.configured} publicKey={data.push.publicKey} />
 
 	<section class="surface-lg card">
 		<h2><Icon name="pencil-line" size={18} /> Signature</h2>
@@ -692,34 +520,6 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 0.75rem;
-	}
-
-	.notification-head {
-		align-items: flex-start;
-	}
-
-	.section-description {
-		margin-top: 0.375rem;
-		font-size: 0.8125rem;
-		line-height: 1.5;
-		color: var(--color-muted);
-	}
-
-	.notification-on {
-		color: var(--tone-good-fg);
-		background: var(--tone-good-bg);
-	}
-
-	.notification-controls {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 1rem;
-		margin-top: 1rem;
-	}
-
-	.notification-hint {
-		margin-top: 0;
 	}
 
 	.card h2 {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -10,6 +10,15 @@
 		type ThemePreference
 	} from '$lib/theme';
 	import { MAX_EMAIL_SIGNATURE_LENGTH } from '$lib/email-signature';
+	import {
+		deletePushSubscription,
+		getPushSubscription,
+		isPushSubscriptionRegistered,
+		savePushSubscription,
+		subscribeToPush,
+		subscriptionUsesPublicKey,
+		supportsWebPush
+	} from '$lib/push-client';
 	import type { ApiTokenSummary, MailAddress } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -24,6 +33,116 @@
 	function chooseTheme(next: ThemePreference) {
 		theme = next;
 		setThemePreference(next);
+	}
+
+	type PushState =
+		| 'loading'
+		| 'unsupported'
+		| 'unconfigured'
+		| 'denied'
+		| 'disabled'
+		| 'enabled'
+		| 'error';
+
+	let pushState = $state<PushState>('loading');
+	let pushBusy = $state(false);
+	let pushError = $state('');
+	const pushStatusLabel = $derived(
+		({
+			loading: 'Checking',
+			unsupported: 'Unsupported',
+			unconfigured: 'Setup required',
+			denied: 'Blocked',
+			disabled: 'Off',
+			enabled: 'On',
+			error: 'Error'
+		} satisfies Record<PushState, string>)[pushState]
+	);
+
+	function pushErrorMessage(error: unknown): string {
+		return error instanceof Error ? error.message : 'Could not update desktop notifications';
+	}
+
+	async function refreshPushState() {
+		pushError = '';
+		if (!data.push.configured || !data.push.publicKey) {
+			pushState = 'unconfigured';
+			return;
+		}
+		if (!supportsWebPush()) {
+			pushState = 'unsupported';
+			return;
+		}
+		if (Notification.permission === 'denied') {
+			pushState = 'denied';
+			return;
+		}
+
+		try {
+			const subscription = await getPushSubscription();
+			if (
+				subscription &&
+				Notification.permission === 'granted' &&
+				subscriptionUsesPublicKey(subscription, data.push.publicKey) &&
+				(await isPushSubscriptionRegistered(subscription))
+			) {
+				pushState = 'enabled';
+			} else {
+				pushState = 'disabled';
+			}
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		}
+	}
+
+	$effect(() => {
+		void refreshPushState();
+	});
+
+	async function enableDesktopNotifications() {
+		if (!data.push.publicKey || !supportsWebPush()) return;
+		pushBusy = true;
+		pushError = '';
+		try {
+			const permission = await Notification.requestPermission();
+			if (permission !== 'granted') {
+				pushState = permission === 'denied' ? 'denied' : 'disabled';
+				pushError =
+					permission === 'denied'
+						? 'Notifications are blocked in this browser. Allow them in site settings.'
+						: 'Notification permission was not granted.';
+				return;
+			}
+
+			const subscription = await subscribeToPush(data.push.publicKey);
+			await savePushSubscription(subscription);
+			pushState = 'enabled';
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		} finally {
+			pushBusy = false;
+		}
+	}
+
+	async function disableDesktopNotifications() {
+		pushBusy = true;
+		pushError = '';
+		try {
+			const subscription = await getPushSubscription();
+			if (subscription) {
+				await deletePushSubscription(subscription);
+				const removed = await subscription.unsubscribe();
+				if (!removed) throw new Error('The browser could not remove its push subscription');
+			}
+			pushState = 'disabled';
+		} catch (error) {
+			pushState = 'error';
+			pushError = pushErrorMessage(error);
+		} finally {
+			pushBusy = false;
+		}
 	}
 
 	let signature = $state(untrack(() => data.signature));
@@ -275,6 +394,62 @@
 	</section>
 
 	<section class="surface-lg card">
+		<div class="card-head notification-head">
+			<div>
+				<h2><Icon name="notification-3-line" size={18} /> Desktop notifications</h2>
+				<p class="section-description">Get an alert when new mail arrives, even after closing this tab.</p>
+			</div>
+			<span class="badge" class:notification-on={pushState === 'enabled'}>{pushStatusLabel}</span>
+		</div>
+
+		{#if pushState === 'unconfigured'}
+			<p class="hint">
+				<Icon name="information-line" size={14} />
+				The server needs VAPID keys before desktop notifications can be enabled.
+			</p>
+		{:else if pushState === 'unsupported'}
+			<p class="hint">
+				<Icon name="information-line" size={14} />
+				This browser does not support Web Push notifications.
+			</p>
+		{:else if pushState === 'denied'}
+			<p class="hint">
+				<Icon name="information-line" size={14} />
+				Notifications are blocked. Allow them for this site in your browser settings.
+			</p>
+		{:else}
+			<div class="notification-controls">
+				<p class="hint notification-hint">
+					{pushState === 'enabled'
+						? 'This browser will receive notifications for your account.'
+						: 'Permission is requested only when you enable notifications.'}
+				</p>
+				{#if pushState === 'enabled'}
+					<button
+						type="button"
+						class="btn-ghost"
+						disabled={pushBusy}
+						onclick={disableDesktopNotifications}
+					>
+						{pushBusy ? 'Disabling…' : 'Disable'}
+					</button>
+				{:else}
+					<button
+						type="button"
+						class="btn-primary"
+						disabled={pushBusy || pushState === 'loading'}
+						onclick={enableDesktopNotifications}
+					>
+						{pushBusy ? 'Enabling…' : pushState === 'loading' ? 'Checking…' : 'Enable'}
+					</button>
+				{/if}
+			</div>
+		{/if}
+
+		{#if pushError}<p class="error" aria-live="polite">{pushError}</p>{/if}
+	</section>
+
+	<section class="surface-lg card">
 		<h2><Icon name="pencil-line" size={18} /> Signature</h2>
 
 		<form class="signature-form" onsubmit={saveSignature}>
@@ -517,6 +692,34 @@
 		align-items: center;
 		justify-content: space-between;
 		gap: 0.75rem;
+	}
+
+	.notification-head {
+		align-items: flex-start;
+	}
+
+	.section-description {
+		margin-top: 0.375rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		color: var(--color-muted);
+	}
+
+	.notification-on {
+		color: var(--tone-good-fg);
+		background: var(--tone-good-bg);
+	}
+
+	.notification-controls {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-top: 1rem;
+	}
+
+	.notification-hint {
+		margin-top: 0;
 	}
 
 	.card h2 {

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -13,6 +13,14 @@ type PushPayload = {
 
 const worker = globalThis as unknown as ServiceWorkerGlobalScope;
 
+worker.addEventListener('install', () => {
+	void worker.skipWaiting();
+});
+
+worker.addEventListener('activate', (event) => {
+	event.waitUntil(worker.clients.claim());
+});
+
 function stringValue(value: unknown, fallback: string): string {
 	return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
@@ -79,9 +87,14 @@ worker.addEventListener('notificationclick', (event: NotificationEvent) => {
 			for (const client of windows) {
 				const windowClient = client as WindowClient;
 				if (new URL(windowClient.url).origin !== worker.location.origin) continue;
-				await windowClient.navigate(destination.href);
-				await windowClient.focus();
-				return;
+				try {
+					await windowClient.navigate(destination.href);
+					await windowClient.focus();
+					return;
+				} catch {
+					await worker.clients.openWindow(destination.href);
+					return;
+				}
 			}
 			await worker.clients.openWindow(destination.href);
 		})()

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,89 @@
+/// <reference no-default-lib="true" />
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
+export {};
+
+type PushPayload = {
+	title?: unknown;
+	body?: unknown;
+	tag?: unknown;
+	url?: unknown;
+};
+
+const worker = globalThis as unknown as ServiceWorkerGlobalScope;
+
+function stringValue(value: unknown, fallback: string): string {
+	return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function readPushPayload(event: PushEvent): PushPayload {
+	if (!event.data) return {};
+	try {
+		const value = event.data.json();
+		return typeof value === 'object' && value !== null ? (value as PushPayload) : {};
+	} catch {
+		return {};
+	}
+}
+
+async function currentAccountOwnsSubscription(): Promise<boolean> {
+	try {
+		const subscription = await worker.registration.pushManager.getSubscription();
+		if (!subscription) return false;
+		const endpoint = encodeURIComponent(subscription.endpoint);
+		const response = await fetch(`/api/push/subscriptions?endpoint=${endpoint}`, {
+			cache: 'no-store',
+			credentials: 'same-origin'
+		});
+		if (!response.ok) return false;
+		const body = (await response.json()) as { registered?: unknown };
+		return body.registered === true;
+	} catch {
+		// Prefer dropping an alert over exposing one account's mail on another
+		// account's session when ownership cannot be verified.
+		return false;
+	}
+}
+
+worker.addEventListener('push', (event: PushEvent) => {
+	const payload = readPushPayload(event);
+	const url = stringValue(payload.url, '/inbox');
+
+	event.waitUntil(
+		(async () => {
+			if (!(await currentAccountOwnsSubscription())) return;
+			await worker.registration.showNotification(stringValue(payload.title, 'New message'), {
+				body: stringValue(payload.body, 'You received a new email.'),
+				icon: '/favicon.svg',
+				badge: '/favicon.svg',
+				tag: stringValue(payload.tag, 'quickmail-new-message'),
+				data: { url }
+			});
+		})()
+	);
+});
+
+worker.addEventListener('notificationclick', (event: NotificationEvent) => {
+	event.notification.close();
+	const requested = stringValue((event.notification.data as { url?: unknown } | null)?.url, '/inbox');
+	const requestedDestination = new URL(requested, worker.location.origin);
+	const destination =
+		requestedDestination.origin === worker.location.origin
+			? requestedDestination
+			: new URL('/inbox', worker.location.origin);
+
+	event.waitUntil(
+		(async () => {
+			const windows = await worker.clients.matchAll({ type: 'window', includeUncontrolled: true });
+			for (const client of windows) {
+				const windowClient = client as WindowClient;
+				if (new URL(windowClient.url).origin !== worker.location.origin) continue;
+				await windowClient.navigate(destination.href);
+				await windowClient.focus();
+				return;
+			}
+			await worker.clients.openWindow(destination.href);
+		})()
+	);
+});

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,7 +26,7 @@ export default {
 		return svelteApp.fetch(request, env, ctx);
 	},
 
-	async email(message: CloudflareInboundMessage, env: Env) {
+	async email(message: CloudflareInboundMessage, env: Env, ctx: ExecutionContext) {
 		if (env.EMAIL_PROVIDER?.trim().toLowerCase() !== 'cloudflare') {
 			message.setReject('Cloudflare email provider is not enabled');
 			return;
@@ -34,7 +34,11 @@ export default {
 
 		const inboundEnv: CloudflareInboundEnv = {
 			DB: env.DB,
-			ATTACHMENTS: env.ATTACHMENTS
+			ATTACHMENTS: env.ATTACHMENTS,
+			VAPID_PUBLIC_KEY: env.VAPID_PUBLIC_KEY,
+			VAPID_PRIVATE_KEY: env.VAPID_PRIVATE_KEY,
+			VAPID_SUBJECT: env.VAPID_SUBJECT,
+			waitUntil: (promise) => ctx.waitUntil(promise)
 		};
 
 		await handleCloudflareInbound(message, inboundEnv);

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Mail">
+	<rect width="64" height="64" rx="16.5" fill="#90ac9a" />
+	<g
+		transform="translate(9.7 9.7) scale(1.858)"
+		fill="none"
+		stroke="#363636"
+		stroke-width="2.3"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	>
+		<path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
+		<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+		<path d="m16 19 2 2 4-4" />
+	</g>
+</svg>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,7 +3,7 @@
 	"name": "quickmail",
 	"main": ".svelte-kit/cloudflare/_worker.js",
 	"compatibility_date": "2025-06-01",
-	"compatibility_flags": ["nodejs_compat"],
+	"compatibility_flags": ["nodejs_compat", "enable_nodejs_http_modules"],
 	"workers_dev": true,
 
 	// Your Cloudflare account is picked up from `wrangler login`. If you belong


### PR DESCRIPTION
Closes #15

Depends on #14. This branch includes the settings listener fix because the desktop notification controls live on the same page.

## What changed

- Adds opt-in Web Push controls under Settings.
- Stores per-user browser subscriptions in D1 and removes dead endpoints.
- Sends sender and subject alerts for Cloudflare Email and Resend inbound mail.
- Runs push requests through the Worker execution context so provider acknowledgement does not wait on push services.
- Checks the active session before the service worker shows an alert on shared browsers.
- Validates VAPID key lengths and confirms that the public and private keys match.
- Replaces subscriptions after VAPID key rotation.
- Documents local and Wrangler VAPID setup.

## Verification

- `bun test`, 27 passed
- `bun run check`, 0 errors and one existing autofocus warning
- `bun run build`
- `wrangler deploy --dry-run`
- All ten migrations applied from an empty local D1 database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional desktop Web Push notifications for new incoming mail.
  * Added notification controls and status messaging in Settings.
  * Added secure subscription management, including enable, disable, account switching, and logout cleanup.
  * Added automatic removal of expired notification endpoints.
* **Documentation**
  * Added setup guidance for VAPID keys, secrets, migrations, deployment, local development, and key rotation.
* **Bug Fixes**
  * Isolated notification delivery failures so they do not interrupt email processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->