### PR TITLE
Add per-address From names and reply from the received mailbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/lib/server/domains.ts
+++ b/src/lib/server/domains.ts
@@ -242,6 +242,29 @@ export async function createAddress(
 	return created;
 }
 
+export async function updateAddress(
+	db: D1Database,
+	userId: string,
+	addressId: string,
+	patch: { label?: string | null }
+): Promise<MailAddress> {
+	const current = await getAddressForUser(db, userId, addressId);
+	if (!current) {
+		throw new Error('Address not found');
+	}
+
+	const label = patch.label !== undefined ? patch.label?.trim() || null : current.label;
+
+	await db
+		.prepare('UPDATE addresses SET label = ? WHERE id = ? AND user_id = ?')
+		.bind(label, addressId, userId)
+		.run();
+
+	const saved = await getAddressForUser(db, userId, addressId);
+	if (!saved) throw new Error('Failed to update address');
+	return saved;
+}
+
 export async function setDefaultAddress(
 	db: D1Database,
 	userId: string,

--- a/src/lib/server/outbox.test.ts
+++ b/src/lib/server/outbox.test.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { D1Database } from '@cloudflare/workers-types';
+import type { User } from '$lib/types';
+import { resolveReplyFromAddress } from './outbox';
+
+const user: User = {
+	id: 'user-1',
+	email: 'ada@example.com',
+	name: 'Ada',
+	is_admin: false,
+	created_at: '2026-01-01T00:00:00.000Z'
+};
+
+type AddressRow = {
+	id: string;
+	user_id: string;
+	domain_id: string;
+	domain_name: string;
+	address: string;
+	label: string | null;
+	is_default: number;
+	created_at: string;
+};
+
+type DomainRow = {
+	id: string;
+	name: string;
+	status: string;
+	region: string | null;
+	sending_enabled: number;
+	receiving_enabled: number;
+	catchall_user_id: string | null;
+	created_at: string;
+	synced_at: string | null;
+};
+
+function mockDb(input: { addresses: AddressRow[]; domains: DomainRow[] }): D1Database {
+	return {
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					const statement = {
+						async all() {
+							if (sql.includes('FROM addresses')) {
+								const userId = args[0];
+								return {
+									results: input.addresses.filter((row) => row.user_id === userId)
+								};
+							}
+							return { results: [] };
+						},
+						async first() {
+							if (sql.includes('FROM domains')) {
+								const name = String(args[0] ?? '').toLowerCase();
+								return input.domains.find((row) => row.name === name) ?? null;
+							}
+							return null;
+						}
+					};
+					return statement;
+				}
+			};
+		}
+	} as unknown as D1Database;
+}
+
+const defaultAddress: AddressRow = {
+	id: 'addr-default',
+	user_id: user.id,
+	domain_id: 'dom-1',
+	domain_name: 'example.com',
+	address: 'ada@example.com',
+	label: 'Office',
+	is_default: 1,
+	created_at: user.created_at
+};
+
+const inbound = {
+	direction: 'inbound' as const,
+	to_addr: 'Ada <hello@example.com>',
+	from_addr: 'Sam <sam@other.test>'
+};
+
+describe('resolveReplyFromAddress', () => {
+	test('uses the saved mailbox and its From name', async () => {
+		const hello: AddressRow = {
+			...defaultAddress,
+			id: 'addr-hello',
+			address: 'hello@example.com',
+			label: 'Support',
+			is_default: 0
+		};
+		const identity = await resolveReplyFromAddress(
+			mockDb({ addresses: [defaultAddress, hello], domains: [] }),
+			user,
+			inbound
+		);
+		assert.equal(identity?.address, 'hello@example.com');
+		assert.equal(identity?.label, 'Support');
+	});
+
+	test('sends catch-all replies from the received mailbox', async () => {
+		const identity = await resolveReplyFromAddress(
+			mockDb({
+				addresses: [
+					{
+						...defaultAddress,
+						domain_id: 'dom-other',
+						domain_name: 'other.test',
+						address: 'ada@other.test'
+					}
+				],
+				domains: [
+					{
+						id: 'dom-1',
+						name: 'example.com',
+						status: 'verified',
+						region: null,
+						sending_enabled: 1,
+						receiving_enabled: 1,
+						catchall_user_id: user.id,
+						created_at: user.created_at,
+						synced_at: null
+					}
+				]
+			}),
+			user,
+			inbound
+		);
+		assert.equal(identity?.address, 'hello@example.com');
+		assert.equal(identity?.label, null);
+	});
+
+	test('sends from the received mailbox when the user already has an address on that domain', async () => {
+		const identity = await resolveReplyFromAddress(
+			mockDb({
+				addresses: [defaultAddress],
+				domains: [
+					{
+						id: 'dom-1',
+						name: 'example.com',
+						status: 'verified',
+						region: null,
+						sending_enabled: 1,
+						receiving_enabled: 1,
+						catchall_user_id: null,
+						created_at: user.created_at,
+						synced_at: null
+					}
+				]
+			}),
+			user,
+			inbound
+		);
+		assert.equal(identity?.address, 'hello@example.com');
+	});
+
+	test('falls back to the default address when the mailbox cannot send', async () => {
+		const identity = await resolveReplyFromAddress(
+			mockDb({
+				addresses: [defaultAddress],
+				domains: [
+					{
+						id: 'dom-1',
+						name: 'example.com',
+						status: 'verified',
+						region: null,
+						sending_enabled: 1,
+						receiving_enabled: 1,
+						catchall_user_id: 'someone-else',
+						created_at: user.created_at,
+						synced_at: null
+					}
+				]
+			}),
+			user,
+			{
+				direction: 'inbound',
+				to_addr: 'unknown@other.test',
+				from_addr: 'sam@other.test'
+			}
+		);
+		assert.equal(identity?.address, 'ada@example.com');
+		assert.equal(identity?.label, 'Office');
+	});
+
+	test('returns null when the user has no sending identity', async () => {
+		const identity = await resolveReplyFromAddress(
+			mockDb({ addresses: [], domains: [] }),
+			user,
+			inbound
+		);
+		assert.equal(identity, null);
+	});
+});

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -3,7 +3,13 @@ import type { MailAddress, OutboundAttachmentInput, User } from '$lib/types';
 import { appendEmailSignature } from '$lib/email-signature';
 import { base64ByteLength, insertAttachments } from './attachments';
 import { MAX_TOTAL_ATTACHMENT_BYTES } from './constants';
-import { getAddressForUser, getDefaultAddress } from './domains';
+import {
+	getAddressForUser,
+	getDefaultAddress,
+	getDomainByName,
+	listAddressesForUser
+} from './domains';
+import { parseEmailAddress } from './email-address';
 import { getEmailSignature } from './email-signature';
 import { stripHtml } from './html';
 import { insertEmail } from './mail-store';
@@ -12,6 +18,8 @@ import { escapeHtml, parseRecipients, sendOutboundEmail } from './send-mail';
 
 export type ComposeInput = {
 	fromAddressId?: string | null;
+	/** Pre-resolved identity — used by replies so we can send from the received mailbox. */
+	fromAddress?: MailAddress | null;
 	to: string;
 	cc?: string | null;
 	bcc?: string | null;
@@ -44,6 +52,47 @@ export async function resolveFromAddress(
 	return address;
 }
 
+/**
+ * Replies come from the mailbox that received the original, not the default
+ * sending identity. Catch-all mail uses that exact recipient if the user owns
+ * the domain, even when the local-part is not a saved address.
+ */
+export async function resolveReplyFromAddress(
+	db: D1Database,
+	user: User,
+	original: { direction: 'inbound' | 'outbound'; to_addr: string; from_addr: string }
+): Promise<MailAddress> {
+	const mailbox = parseEmailAddress(
+		original.direction === 'inbound' ? original.to_addr : original.from_addr
+	);
+
+	const owned = await listAddressesForUser(db, user.id);
+	const exact = owned.find((address) => address.address.toLowerCase() === mailbox);
+	if (exact) return exact;
+
+	const domainName = mailbox.split('@')[1];
+	const domain = domainName ? await getDomainByName(db, domainName) : null;
+	const canSendOnDomain =
+		domain &&
+		(domain.catchall_user_id === user.id ||
+			owned.some((address) => address.domain_id === domain.id));
+
+	if (domain && canSendOnDomain && mailbox.includes('@')) {
+		return {
+			id: `reply:${mailbox}`,
+			user_id: user.id,
+			domain_id: domain.id,
+			domain_name: domain.name,
+			address: mailbox,
+			label: null,
+			is_default: false,
+			created_at: new Date().toISOString()
+		};
+	}
+
+	return resolveFromAddress(db, user);
+}
+
 /** Send through the configured provider, then record it in the Sent folder. */
 export async function sendAndStore(
 	env: { DB: D1Database; ATTACHMENTS: R2Bucket },
@@ -52,7 +101,7 @@ export async function sendAndStore(
 	input: ComposeInput
 ): Promise<{ emailId: string; providerId: string; from: MailAddress }> {
 	// resolveFromAddress scopes the lookup to this user, so ownership is implied.
-	const from = await resolveFromAddress(env.DB, user, input.fromAddressId);
+	const from = input.fromAddress ?? (await resolveFromAddress(env.DB, user, input.fromAddressId));
 
 	const bodyHtml = input.html?.trim() || null;
 	const bodyText = input.text?.trim() || (bodyHtml ? stripHtml(bodyHtml) : '');
@@ -79,7 +128,7 @@ export async function sendAndStore(
 
 	const { providerId } = await sendOutboundEmail(provider, {
 		from,
-		senderName: user.name,
+		senderName: from.label?.trim() || user.name,
 		to: input.to,
 		cc: input.cc ?? undefined,
 		bcc: input.bcc ?? undefined,

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -56,12 +56,15 @@ export async function resolveFromAddress(
  * Replies come from the mailbox that received the original, not the default
  * sending identity. Catch-all mail uses that exact recipient if the user owns
  * the domain, even when the local-part is not a saved address.
+ *
+ * Returns null when the user has no sending identity, so the thread page can
+ * still load.
  */
 export async function resolveReplyFromAddress(
 	db: D1Database,
 	user: User,
 	original: { direction: 'inbound' | 'outbound'; to_addr: string; from_addr: string }
-): Promise<MailAddress> {
+): Promise<MailAddress | null> {
 	const mailbox = parseEmailAddress(
 		original.direction === 'inbound' ? original.to_addr : original.from_addr
 	);
@@ -90,7 +93,7 @@ export async function resolveReplyFromAddress(
 		};
 	}
 
-	return resolveFromAddress(db, user);
+	return getDefaultAddress(db, user.id);
 }
 
 /** Send through the configured provider, then record it in the Sent folder. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,7 @@ export type MailAddress = {
 	domain_id: string;
 	domain_name: string;
 	address: string;
+	/** From display name on outbound mail. Falls back to the account name. */
 	label: string | null;
 	is_default: boolean;
 	created_at: string;

--- a/src/routes/api/addresses/[id]/+server.ts
+++ b/src/routes/api/addresses/[id]/+server.ts
@@ -1,5 +1,10 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
-import { deleteAddress, listAddressesForUser, setDefaultAddress } from '$lib/server/domains';
+import {
+	deleteAddress,
+	listAddressesForUser,
+	setDefaultAddress,
+	updateAddress
+} from '$lib/server/domains';
 
 export const PATCH: RequestHandler = async ({ params, request, locals, platform }) => {
 	const db = platform?.env.DB;
@@ -7,9 +12,20 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
-	const body = (await request.json()) as { isDefault?: boolean };
+	const body = (await request.json()) as { isDefault?: boolean; label?: string | null };
 	if (body.isDefault) {
 		await setDefaultAddress(db, locals.user.id, params.id!);
+	}
+
+	if (body.label !== undefined) {
+		try {
+			await updateAddress(db, locals.user.id, params.id!, { label: body.label });
+		} catch (error) {
+			return json(
+				{ error: error instanceof Error ? error.message : 'Could not update address' },
+				{ status: 400 }
+			);
+		}
 	}
 
 	return json({ addresses: await listAddressesForUser(db, locals.user.id) });

--- a/src/routes/api/mail/[id]/+server.ts
+++ b/src/routes/api/mail/[id]/+server.ts
@@ -12,7 +12,7 @@ import {
 	markThreadRead,
 	setEmailFlags
 } from '$lib/server/mail-store';
-import { sendAndStore } from '$lib/server/outbox';
+import { resolveReplyFromAddress, sendAndStore } from '$lib/server/outbox';
 import { buildReferences, displaySubject } from '$lib/server/threads';
 import type { OutboundAttachmentInput } from '$lib/types';
 
@@ -113,15 +113,11 @@ export const POST: RequestHandler = async ({ params, request, locals, platform }
 	// Replying to our own message continues the conversation with its recipient.
 	const to = original.direction === 'inbound' ? original.from_addr : original.to_addr;
 
-	// Reply from the address the message was sent to, so threads stay coherent.
-	const preferredAddress =
-		original.direction === 'inbound'
-			? locals.addresses.find(
-					(address) => address.address.toLowerCase() === original.to_addr.toLowerCase()
-				)
-			: locals.addresses.find(
-					(address) => address.address.toLowerCase() === original.from_addr.toLowerCase()
-				);
+	// Reply from the mailbox that received the original. Catch-all mail uses
+	// that exact recipient when the user can send on the domain.
+	const fromAddress = body.fromAddressId
+		? undefined
+		: await resolveReplyFromAddress(db, locals.user, original);
 
 	try {
 		const provider = getEmailProvider(platform);
@@ -130,7 +126,8 @@ export const POST: RequestHandler = async ({ params, request, locals, platform }
 			provider,
 			locals.user,
 			{
-				fromAddressId: body.fromAddressId ?? preferredAddress?.id,
+				fromAddressId: body.fromAddressId,
+				fromAddress,
 				to,
 				subject,
 				text: body.text,

--- a/src/routes/compose/+page.svelte
+++ b/src/routes/compose/+page.svelte
@@ -167,11 +167,17 @@
 					aria-label="Send from"
 				>
 					{#each addresses as address (address.id)}
-						<option value={address.id}>{address.address}</option>
+						<option value={address.id}>
+							{address.label ? `${address.label} · ${address.address}` : address.address}
+						</option>
 					{/each}
 				</select>
 			{:else}
-				<span class="field-static">{addresses[0]?.address ?? '—'}</span>
+				<span class="field-static">
+					{addresses[0]?.label
+						? `${addresses[0].label} · ${addresses[0].address}`
+						: (addresses[0]?.address ?? '—')}
+				</span>
 			{/if}
 		</div>
 

--- a/src/routes/mail/[id]/+page.server.ts
+++ b/src/routes/mail/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { parseEmailAddress } from '$lib/server/email-address';
 import { getEmailForUser, listThreadMessages, markThreadRead } from '$lib/server/mail-store';
+import { resolveReplyFromAddress } from '$lib/server/outbox';
 import { displaySubject } from '$lib/server/threads';
 
 export const load: PageServerLoad = async ({ params, locals, platform }) => {
@@ -19,12 +19,7 @@ export const load: PageServerLoad = async ({ params, locals, platform }) => {
 	const messages = await listThreadMessages(platform.env.DB, locals.user.id, email);
 
 	const latest = messages[messages.length - 1] ?? email;
-	const replyFrom = parseEmailAddress(
-		latest.direction === 'inbound' ? latest.to_addr : latest.from_addr
-	);
-	const replyFromName =
-		locals.addresses.find((address) => address.address.toLowerCase() === replyFrom)?.label ??
-		null;
+	const replyIdentity = await resolveReplyFromAddress(platform.env.DB, locals.user, latest);
 
 	return {
 		threadId: email.thread_id ?? email.id,
@@ -32,8 +27,8 @@ export const load: PageServerLoad = async ({ params, locals, platform }) => {
 		focusId: email.id,
 		trashed: Boolean(email.deleted_at),
 		subject: displaySubject(messages[0]?.subject ?? email.subject),
-		replyFrom,
-		replyFromName,
+		replyFrom: replyIdentity?.address ?? null,
+		replyFromName: replyIdentity?.label?.trim() || null,
 		messages: messages.map((message) => ({ ...message, is_read: true }))
 	};
 };

--- a/src/routes/mail/[id]/+page.server.ts
+++ b/src/routes/mail/[id]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
+import { parseEmailAddress } from '$lib/server/email-address';
 import { getEmailForUser, listThreadMessages, markThreadRead } from '$lib/server/mail-store';
 import { displaySubject } from '$lib/server/threads';
 
@@ -17,12 +18,22 @@ export const load: PageServerLoad = async ({ params, locals, platform }) => {
 	await markThreadRead(platform.env.DB, locals.user.id, email);
 	const messages = await listThreadMessages(platform.env.DB, locals.user.id, email);
 
+	const latest = messages[messages.length - 1] ?? email;
+	const replyFrom = parseEmailAddress(
+		latest.direction === 'inbound' ? latest.to_addr : latest.from_addr
+	);
+	const replyFromName =
+		locals.addresses.find((address) => address.address.toLowerCase() === replyFrom)?.label ??
+		null;
+
 	return {
 		threadId: email.thread_id ?? email.id,
 		/** The message that was linked to — expanded first when the page opens. */
 		focusId: email.id,
 		trashed: Boolean(email.deleted_at),
 		subject: displaySubject(messages[0]?.subject ?? email.subject),
+		replyFrom,
+		replyFromName,
 		messages: messages.map((message) => ({ ...message, is_read: true }))
 	};
 };

--- a/src/routes/mail/[id]/+page.svelte
+++ b/src/routes/mail/[id]/+page.svelte
@@ -205,12 +205,14 @@
 						{latest?.direction === 'inbound' ? latest.from_addr : latest?.to_addr}
 					</strong>
 				</p>
-				<p class="reply-from">
-					From
-					<strong>
-						{#if data.replyFromName}{data.replyFromName} · {/if}{data.replyFrom}
-					</strong>
-				</p>
+				{#if data.replyFrom}
+					<p class="reply-from">
+						From
+						<strong>
+							{#if data.replyFromName}{data.replyFromName} · {/if}{data.replyFrom}
+						</strong>
+					</p>
+				{/if}
 
 				<RichTextEditor bind:html={replyHtml} embedded minHeight={160} placeholder="Reply…" />
 

--- a/src/routes/mail/[id]/+page.svelte
+++ b/src/routes/mail/[id]/+page.svelte
@@ -205,6 +205,12 @@
 						{latest?.direction === 'inbound' ? latest.from_addr : latest?.to_addr}
 					</strong>
 				</p>
+				<p class="reply-from">
+					From
+					<strong>
+						{#if data.replyFromName}{data.replyFromName} · {/if}{data.replyFrom}
+					</strong>
+				</p>
 
 				<RichTextEditor bind:html={replyHtml} embedded minHeight={160} placeholder="Reply…" />
 
@@ -300,13 +306,19 @@
 		box-shadow: inset 0 1px 0 var(--color-line);
 	}
 
-	.reply-to {
-		margin-bottom: 0.625rem;
+	.reply-to,
+	.reply-from {
+		margin: 0;
 		font-size: 0.8125rem;
 		color: var(--color-muted);
 	}
 
-	.reply-to strong {
+	.reply-from {
+		margin: 0.25rem 0 0.625rem;
+	}
+
+	.reply-to strong,
+	.reply-from strong {
 		font-weight: 500;
 		color: var(--color-text-secondary);
 	}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -64,9 +64,11 @@
 	const addresses = $derived(edited ?? data.addresses);
 
 	let localPart = $state('');
+	let displayName = $state('');
 	let domainId = $state('');
 	let error = $state('');
 	let busy = $state(false);
+	let savingId = $state('');
 
 	let keyName = $state('');
 	let sendScope = $state(true);
@@ -199,7 +201,7 @@
 			const res = await fetch('/api/addresses', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ domainId, localPart })
+				body: JSON.stringify({ domainId, localPart, label: displayName.trim() || null })
 			});
 			const body = await res.json();
 			if (!res.ok) {
@@ -208,10 +210,36 @@
 			}
 			edited = [...addresses, body.address];
 			localPart = '';
+			displayName = '';
 		} catch {
 			error = 'Network error';
 		} finally {
 			busy = false;
+		}
+	}
+
+	async function saveLabel(id: string, label: string) {
+		const current = addresses.find((address) => address.id === id);
+		if (!current || (current.label ?? '') === label.trim()) return;
+
+		savingId = id;
+		error = '';
+		try {
+			const res = await fetch(`/api/addresses/${id}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ label: label.trim() || null })
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				error = body.error ?? 'Could not save that name';
+				return;
+			}
+			edited = body.addresses;
+		} catch {
+			error = 'Network error';
+		} finally {
+			savingId = '';
 		}
 	}
 
@@ -304,13 +332,24 @@
 
 	<section class="surface-lg card">
 		<h2><Icon name="at-line" size={18} /> Addresses</h2>
+		<p class="card-hint">
+			The From name is what recipients see. Leave it blank to use your account name.
+		</p>
 
 		<ul class="address-list">
 			{#each addresses as address (address.id)}
 				<li class="address-row">
 					<div class="min-w-0 flex-1">
-						<p class="address-value">{address.address}</p>
-						<p class="address-domain">{address.domain_name}</p>
+						<input
+							type="text"
+							class="name-input"
+							value={address.label ?? ''}
+							placeholder="From name"
+							aria-label="From name for {address.address}"
+							disabled={savingId === address.id}
+							onchange={(event) => saveLabel(address.id, event.currentTarget.value)}
+						/>
+						<p class="address-domain">{address.address}</p>
 					</div>
 
 					{#if address.is_default}
@@ -337,12 +376,21 @@
 
 		<form class="add-form" onsubmit={addAddress}>
 			<div class="add-field">
+				<label class="field-title" for="new-display-name">From name</label>
+				<input
+					id="new-display-name"
+					type="text"
+					bind:value={displayName}
+					placeholder="Support"
+					class="name-add-input"
+					autocomplete="off"
+				/>
 				<AddressField
 					bind:localPart
 					bind:domainId
 					domains={data.domains}
 					placeholder="another"
-					label="Add an address"
+					label="Address"
 				/>
 			</div>
 			<button type="submit" class="btn-primary" disabled={busy || !localPart.trim()}>
@@ -530,6 +578,13 @@
 		font-weight: 600;
 	}
 
+	.card-hint {
+		margin-top: 0.375rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		color: var(--color-muted);
+	}
+
 	.signature-form {
 		margin-top: 1rem;
 	}
@@ -697,17 +752,46 @@
 		box-shadow: inset 0 1px 0 var(--color-line);
 	}
 
-	.address-value {
+	.name-input {
+		width: 100%;
 		font-size: 0.875rem;
 		font-weight: 500;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		color: var(--color-text);
+		background: transparent;
+		outline: none;
+	}
+
+	.name-input::placeholder {
+		color: var(--color-muted);
+		font-weight: 400;
 	}
 
 	.address-domain {
+		margin-top: 0.125rem;
 		font-size: 0.75rem;
 		color: var(--color-muted);
+	}
+
+	.field-title {
+		display: block;
+		font-size: 0.8125rem;
+		color: var(--color-text-secondary);
+	}
+
+	.name-add-input {
+		width: 100%;
+		margin: 0.5rem 0 0.875rem;
+		padding: 0.625rem 0.875rem;
+		border-radius: 0.625rem;
+		font-size: 0.9375rem;
+		color: var(--color-text);
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		outline: none;
+	}
+
+	.name-add-input:focus {
+		box-shadow: inset 0 0 0 1px var(--color-focus-line), 0 0 0 3px var(--color-focus-halo);
 	}
 
 	.badge {


### PR DESCRIPTION
## Summary

Each saved address already has a `label`. This uses it as the From display name on outbound mail, with the account name as the fallback when a mailbox has no label.

Replies currently fall back to the default sending address when the original mailbox is not a saved address (typical for catch-all). They now send from the address the mail actually arrived at, as long as the user can send on that domain.

## What changed

* Outbound mail sends `label` as the From name, or the account name if the label is empty.
* Settings Addresses: a From name field on add, and an inline name on each existing row.
* Compose shows `Name · address` in the From dropdown.
* `PATCH /api/addresses/:id` accepts `label`. No migration — the column is already there.
* Replies use the received mailbox. Catch-all mail uses that exact recipient when the user owns catch-all or already has an address on the domain. An explicit `fromAddressId` (CLI / API) still wins.
* The thread composer shows that identity next to **Replying to**, using the same muted type as that line.

## Behaviour

* Blank From name → account name.
* One name per saved address, not one name for the whole account.
* Mail to a saved address → reply from that address and its From name.
* Catch-all mail to an unsaved local-part → reply from that exact address (account name if it has no label).
* If the user cannot send on that domain, the default From is unchanged.
* New compose still uses the default address unless the user picks another.

## Validation

* `bun run check` — 0 errors and one existing autofocus warning
* `bun test` — 28 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add and edit optional “From” names for email addresses in Settings.
  - Display sender names alongside email addresses when composing and replying.
  - Automatically select the appropriate sending address for replies, including catch-all addresses.
  - Show the selected sender identity in the reply composer.
- **Bug Fixes**
  - Improved reply sending to preserve the correct sender address and display name.
  - Added validation and error handling when updating address names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->