### PR TITLE
Support Cloudflare Access in CLI and MCP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Typecheck
         run: bun run check
 
+      - name: Test
+        run: bun run test
+
       - name: Build
         run: bun run build

--- a/README.md
+++ b/README.md
@@ -235,6 +235,35 @@ quickmail inbox
 quickmail send --to someone@example.com --subject "Hi" --body "Hello"
 ```
 
+If the instance is protected by Cloudflare Access, provide a service-token pair
+in addition to the QuickMail API key:
+
+```bash
+quickmail login \
+  --url https://mail.example.com \
+  --token qm_live_xxx \
+  --cf-access-client-id xxx.access \
+  --cf-access-client-secret xxx
+```
+
+Both Access values are required together. For an environment-only CLI or MCP,
+set `QUICKMAIL_URL` and `QUICKMAIL_TOKEN` together. That pair does not inherit
+saved Access credentials; provide both Access environment variables when the
+environment-selected instance is protected:
+
+```text
+QUICKMAIL_URL
+QUICKMAIL_TOKEN
+QUICKMAIL_CF_ACCESS_CLIENT_ID
+QUICKMAIL_CF_ACCESS_CLIENT_SECRET
+```
+
+Saved configuration remains mode `0600`. Every API request sends the Access
+service-token headers and QuickMail's independent bearer token. QuickMail does
+not follow API redirects; an Access redirect or HTML login response reports a
+Cloudflare Access diagnostic distinct from a QuickMail JSON `401` or `403`.
+Neither credential is included in diagnostics.
+
 The same credentials drive an MCP server for Claude, Cursor, and other agents:
 
 ```json
@@ -245,7 +274,9 @@ The same credentials drive an MCP server for Claude, Cursor, and other agents:
       "args": ["quickmail", "mcp"],
       "env": {
         "QUICKMAIL_URL": "https://mail.example.com",
-        "QUICKMAIL_TOKEN": "qm_live_…"
+        "QUICKMAIL_TOKEN": "qm_live_…",
+        "QUICKMAIL_CF_ACCESS_CLIENT_ID": "xxx.access",
+        "QUICKMAIL_CF_ACCESS_CLIENT_SECRET": "xxx"
       }
     }
   }
@@ -254,6 +285,39 @@ The same credentials drive an MCP server for Claude, Cursor, and other agents:
 
 Tools: `list_threads`, `get_thread`, `search_mail`, `send_message`, `reply`,
 `list_attachments`.
+
+### Cloudflare Access deployment
+
+Access and QuickMail authorization are independent gates. Keep the normal
+identity-provider **Allow** policy for browser users, then add a **Service Auth**
+policy matching the CLI/MCP service token. Cloudflare documents the required
+policy action and the `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers in
+[Service tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-credentials/service-tokens/).
+Do not enable a single `Authorization`-header service-token mode: QuickMail owns
+that header for its scoped API key.
+
+Do not bypass `/api`, `/api/auth`, or the UI. When Resend handles inbound mail,
+create a separate Access application scoped exactly to
+`/api/webhooks/resend` and give only that application a public **Bypass** policy;
+the Worker must still validate every Resend signature. Cloudflare documents
+path-scoped applications in
+[Application paths](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/app-paths/)
+and narrowly scoped bypasses in
+[Common Access policies](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/common-policies/).
+
+Cloudflare Email delivery invokes the Worker's `email()` handler instead of the
+protected HTTP hostname, so it needs no HTTP bypass. See
+[Email Workers](https://developers.cloudflare.com/email-routing/email-workers/).
+
+Rotate and revoke the two credential systems independently:
+
+1. Create a replacement Access service token, update CLI/MCP secrets, verify it,
+   then revoke the old Access token.
+2. Create a replacement QuickMail API key with the same least-privilege scopes,
+   update CLI/MCP secrets, verify it, then revoke the old API key.
+
+Compromise of one credential must not be treated as compromise of the other,
+but rotate both if their storage environment may have been exposed.
 
 ## How inbound routing works
 

--- a/cli/client.test.ts
+++ b/cli/client.test.ts
@@ -1,6 +1,29 @@
 import assert from 'node:assert/strict';
-import { describe, test } from 'node:test';
-import { safeDownloadName } from './client.ts';
+import { afterEach, describe, test } from 'node:test';
+import {
+	createQuickMailClient,
+	QuickMailAccessError,
+	QuickMailClient,
+	QuickMailError,
+	safeDownloadName
+} from './client.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+function stubFetch(handler: (input: string | URL | Request, init?: RequestInit) => Response | Promise<Response>): void {
+	globalThis.fetch = handler as typeof fetch;
+}
+
+function accessClient(): QuickMailClient {
+	return new QuickMailClient('https://mail.example.com', 'qm_live_secret', {
+		cfAccessClientId: 'access-id.access',
+		cfAccessClientSecret: 'access-secret'
+	});
+}
 
 describe('safeDownloadName', () => {
 	test('strips directory components and absolute paths', () => {
@@ -14,5 +37,303 @@ describe('safeDownloadName', () => {
 		assert.equal(safeDownloadName(''), 'attachment');
 		assert.equal(safeDownloadName('..'), 'attachment');
 		assert.equal(safeDownloadName('/'), 'attachment');
+	});
+});
+
+describe('Cloudflare Access request handling', () => {
+	test('injects both auth layers and disables redirects for JSON requests', async () => {
+		let captured: RequestInit | undefined;
+		stubFetch((_input, init) => {
+			captured = init;
+			return new Response(JSON.stringify({ user: { id: 'u1', email: 'me@example.com', name: 'Me', is_admin: false } }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			});
+		});
+
+		await accessClient().whoami();
+		const headers = new Headers(captured?.headers);
+		assert.equal(headers.get('authorization'), 'Bearer qm_live_secret');
+		assert.equal(headers.get('cf-access-client-id'), 'access-id.access');
+		assert.equal(headers.get('cf-access-client-secret'), 'access-secret');
+		assert.equal(headers.get('accept'), 'application/json');
+		assert.equal(captured?.redirect, 'manual');
+	});
+
+	test('uses the same auth headers and redirect policy for attachment downloads', async () => {
+		let captured: RequestInit | undefined;
+		stubFetch((_input, init) => {
+			captured = init;
+			return new Response(new Uint8Array([1, 2, 3]), {
+				status: 200,
+				headers: {
+					'content-type': 'application/octet-stream',
+					'content-disposition': 'attachment; filename="invoice.pdf"'
+				}
+			});
+		});
+
+		const file = await accessClient().downloadAttachment('email', 'attachment');
+		const headers = new Headers(captured?.headers);
+		assert.equal(headers.get('authorization'), 'Bearer qm_live_secret');
+		assert.equal(headers.get('cf-access-client-id'), 'access-id.access');
+		assert.equal(headers.get('cf-access-client-secret'), 'access-secret');
+		assert.equal(captured?.redirect, 'manual');
+		assert.deepEqual(file.bytes, new Uint8Array([1, 2, 3]));
+	});
+
+	test('downloads legitimate HTML attachments instead of treating them as an Access page', async () => {
+		stubFetch(
+			() =>
+				new Response('<html><body>saved report</body></html>', {
+					status: 200,
+					headers: {
+						'content-type': 'text/html; charset=utf-8',
+						'content-disposition': 'attachment; filename="report.html"'
+					}
+				})
+		);
+
+		const attachment = await accessClient().downloadAttachment('email-1', 'attachment-1');
+		assert.equal(attachment.filename, 'report.html');
+		assert.equal(new TextDecoder().decode(attachment.bytes), '<html><body>saved report</body></html>');
+	});
+
+	test('still rejects an HTML Access page returned from an attachment route', async () => {
+		stubFetch(
+			() =>
+				new Response('<html>Access login</html>', {
+					status: 200,
+					headers: { 'content-type': 'text/html; charset=utf-8' }
+				})
+		);
+
+		await assert.rejects(
+			accessClient().downloadAttachment('email-1', 'attachment-1'),
+			QuickMailAccessError
+		);
+	});
+
+	test('rejects non-success HTML even when it claims to be an attachment', async () => {
+		stubFetch(
+			() =>
+				new Response('<html>Access denied</html>', {
+					status: 403,
+					headers: {
+						'content-type': 'text/html; charset=utf-8',
+						'content-disposition': 'attachment; filename="denied.html"'
+					}
+				})
+		);
+
+		await assert.rejects(
+			accessClient().downloadAttachment('email-1', 'attachment-1'),
+			QuickMailAccessError
+		);
+	});
+
+	test('preserves existing bearer-only behavior when Access is disabled', async () => {
+		let captured: RequestInit | undefined;
+		stubFetch((_input, init) => {
+			captured = init;
+			return new Response(JSON.stringify({ threads: [], total: 0, page: 1, pageCount: 1, pageSize: 25 }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			});
+		});
+
+		await new QuickMailClient('https://mail.example.com', 'qm_live_secret').listThreads();
+		const headers = new Headers(captured?.headers);
+		assert.equal(headers.get('authorization'), 'Bearer qm_live_secret');
+		assert.equal(headers.has('cf-access-client-id'), false);
+		assert.equal(headers.has('cf-access-client-secret'), false);
+	});
+
+	test('creates CLI and MCP clients from the same complete configuration', async () => {
+		let captured: RequestInit | undefined;
+		stubFetch((_input, init) => {
+			captured = init;
+			return new Response(JSON.stringify({ user: { id: 'u1', email: 'me@example.com', name: 'Me', is_admin: false } }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			});
+		});
+
+		await createQuickMailClient({
+			url: 'https://mail.example.com',
+			token: 'qm_live_secret',
+			cfAccessClientId: 'access-id.access',
+			cfAccessClientSecret: 'access-secret'
+		}).whoami();
+		const headers = new Headers(captured?.headers);
+		assert.equal(headers.get('cf-access-client-id'), 'access-id.access');
+		assert.equal(headers.get('cf-access-client-secret'), 'access-secret');
+	});
+
+	test('rejects a half-configured Access pair before making a request', () => {
+		assert.throws(
+			() =>
+				new QuickMailClient('https://mail.example.com', 'qm_live_secret', {
+					cfAccessClientId: 'access-id.access'
+				}),
+			/Cloudflare Access client ID and secret must be configured together/
+		);
+	});
+
+	test('reports an Access redirect distinctly without exposing credentials', async () => {
+		stubFetch(
+			() =>
+				new Response(null, {
+					status: 302,
+					headers: { location: 'https://team.cloudflareaccess.com/cdn-cgi/access/login/example' }
+				})
+		);
+
+		await assert.rejects(accessClient().whoami(), (error: unknown) => {
+			assert.ok(error instanceof QuickMailAccessError);
+			assert.match(error.message, /Cloudflare Access/);
+			assert.doesNotMatch(error.message, /access-id|access-secret|qm_live_secret/);
+			return true;
+		});
+	});
+
+	test('reports an HTML Access response distinctly without reading or echoing its body', async () => {
+		stubFetch(
+			() =>
+				new Response('<html>secret login challenge</html>', {
+					status: 200,
+					headers: { 'content-type': 'text/html; charset=utf-8' }
+				})
+		);
+
+		await assert.rejects(accessClient().whoami(), (error: unknown) => {
+			assert.ok(error instanceof QuickMailAccessError);
+			assert.doesNotMatch(error.message, /secret login challenge|access-secret|qm_live_secret/);
+			return true;
+		});
+	});
+
+	test('never exposes malformed credentials rejected while constructing headers', async () => {
+		let calls = 0;
+		stubFetch(() => {
+			calls += 1;
+			return new Response(JSON.stringify({ user: { id: 'u1' } }), {
+				headers: { 'content-type': 'application/json' }
+			});
+		});
+		const delCredential = `TOKEN_DEL_${String.fromCharCode(0x7f)}_MARK`;
+		const cases = [
+			{
+				secret: 'TOKEN_BAD_93f\nINJECTED',
+				createClient: () => new QuickMailClient('https://mail.example.com', 'TOKEN_BAD_93f\nINJECTED', {
+					cfAccessClientId: 'safe-id.access',
+					cfAccessClientSecret: 'safe-secret'
+				})
+			},
+			{
+				secret: 'ACCESS_ID_BAD_93f\nINJECTED',
+				createClient: () => new QuickMailClient('https://mail.example.com', 'safe-token', {
+					cfAccessClientId: 'ACCESS_ID_BAD_93f\nINJECTED',
+					cfAccessClientSecret: 'safe-secret'
+				})
+			},
+			{
+				secret: 'ACCESS_SECRET_BAD_93f😀',
+				createClient: () => new QuickMailClient('https://mail.example.com', 'safe-token', {
+					cfAccessClientId: 'safe-id.access',
+					cfAccessClientSecret: 'ACCESS_SECRET_BAD_93f😀'
+				})
+			},
+			{
+				secret: delCredential,
+				createClient: () => new QuickMailClient('https://mail.example.com', delCredential, {
+					cfAccessClientId: 'safe-id.access',
+					cfAccessClientSecret: 'safe-secret'
+				})
+			}
+		];
+
+		for (const entry of cases) {
+			assert.throws(entry.createClient, (error: unknown) => {
+				if (!(error instanceof Error)) return false;
+				assert.match(error.message, /Authentication credentials contain invalid characters/);
+				assert.equal(error.message.includes(entry.secret), false);
+				assert.doesNotMatch(
+					error.message,
+					/TOKEN_BAD|TOKEN_DEL|ACCESS_ID_BAD|ACCESS_SECRET_BAD|INJECTED|MARK/
+				);
+				return true;
+			});
+		}
+		assert.equal(calls, 0);
+	});
+
+	test('redacts credentials from transport exceptions', async () => {
+		stubFetch(() => {
+			throw new Error('network qm_live_secret access-id.access access-secret');
+		});
+
+		await assert.rejects(accessClient().whoami(), (error: unknown) => {
+			if (!(error instanceof QuickMailError)) return false;
+			assert.doesNotMatch(error.message, /qm_live_secret|access-id\.access|access-secret/);
+			assert.match(error.message, /\[REDACTED\]/);
+			return true;
+		});
+	});
+
+	test('fully redacts credentials that overlap by prefix', async () => {
+		stubFetch(() => {
+			throw new Error('network shared shared-id shared-id-secret');
+		});
+		const client = new QuickMailClient('https://mail.example.com', 'shared', {
+			cfAccessClientId: 'shared-id',
+			cfAccessClientSecret: 'shared-id-secret'
+		});
+
+		await assert.rejects(client.whoami(), (error: unknown) => {
+			if (!(error instanceof QuickMailError)) return false;
+			assert.equal(error.message, 'network [REDACTED] [REDACTED] [REDACTED]');
+			return true;
+		});
+	});
+
+	test('redacts all credentials if an API error reflects them', async () => {
+		stubFetch(
+			() =>
+				new Response(
+					JSON.stringify({
+						error: 'qm_live_secret access-id.access access-secret'
+					}),
+					{
+						status: 400,
+						headers: { 'content-type': 'application/json' }
+					}
+				)
+		);
+
+		await assert.rejects(accessClient().listThreads(), (error: unknown) => {
+			if (!(error instanceof QuickMailError)) return false;
+			assert.doesNotMatch(error.message, /qm_live_secret|access-id\.access|access-secret/);
+			assert.match(error.message, /\[REDACTED\]/);
+			return true;
+		});
+	});
+
+	test('keeps QuickMail JSON authorization errors distinct from Access failures', async () => {
+		stubFetch(
+			() =>
+				new Response(JSON.stringify({ error: 'Missing scope: mail:read' }), {
+					status: 403,
+					headers: { 'content-type': 'application/json' }
+				})
+		);
+
+		await assert.rejects(accessClient().listThreads(), (error: unknown) => {
+			assert.ok(error instanceof QuickMailError);
+			assert.equal(error instanceof QuickMailAccessError, false);
+			assert.equal(error.status, 403);
+			assert.equal(error.message, 'Missing scope: mail:read');
+			return true;
+		});
 	});
 });

--- a/cli/client.ts
+++ b/cli/client.ts
@@ -1,5 +1,9 @@
 import { basename } from 'node:path';
-import { normalizeUrl } from './config.ts';
+import {
+	normalizeUrl,
+	validateAccessCredentials,
+	type CliConfig
+} from './config.ts';
 
 /** Keep downloads inside the working directory — never honor `../` or absolute names. */
 export function safeDownloadName(name: string): string {
@@ -15,6 +19,27 @@ export class QuickMailError extends Error {
 	) {
 		super(message);
 		this.name = 'QuickMailError';
+	}
+}
+
+export class QuickMailAccessError extends QuickMailError {
+	constructor(status: number) {
+		super(
+			status,
+			'Cloudflare Access blocked the API request. Verify the service-token credentials and Service Auth policy.'
+		);
+		this.name = 'QuickMailAccessError';
+	}
+}
+
+export type QuickMailClientOptions = {
+	cfAccessClientId?: string;
+	cfAccessClientSecret?: string;
+};
+
+function assertValidCredential(value: string): void {
+	if (!/^[\x21-\x7e]+$/.test(value)) {
+		throw new QuickMailError(0, 'Authentication credentials contain invalid characters.');
 	}
 }
 
@@ -103,33 +128,106 @@ export type ListThreadsQuery = {
 
 export class QuickMailClient {
 	readonly url: string;
+	readonly cfAccessClientId?: string;
+	readonly cfAccessClientSecret?: string;
 
 	constructor(
 		url: string,
-		readonly token: string
+		readonly token: string,
+		options: QuickMailClientOptions = {}
 	) {
 		this.url = normalizeUrl(url);
+		const access = validateAccessCredentials(
+			options.cfAccessClientId,
+			options.cfAccessClientSecret
+		);
+		this.cfAccessClientId = access.cfAccessClientId;
+		this.cfAccessClientSecret = access.cfAccessClientSecret;
+		for (const credential of [this.token, this.cfAccessClientId, this.cfAccessClientSecret]) {
+			if (credential !== undefined) assertValidCredential(credential);
+		}
 	}
 
-	async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+	private requestHeaders(init: RequestInit): Headers {
 		const headers = new Headers(init.headers);
-		headers.set('authorization', `Bearer ${this.token}`);
-		headers.set('accept', 'application/json');
+		try {
+			headers.set('authorization', `Bearer ${this.token}`);
+			if (this.cfAccessClientId && this.cfAccessClientSecret) {
+				headers.set('cf-access-client-id', this.cfAccessClientId);
+				headers.set('cf-access-client-secret', this.cfAccessClientSecret);
+			}
+		} catch {
+			throw new QuickMailError(
+				0,
+				'Authentication credentials contain invalid HTTP header characters.'
+			);
+		}
+		if (!headers.has('accept')) headers.set('accept', 'application/json');
 		if (init.body && !headers.has('content-type')) {
 			headers.set('content-type', 'application/json');
 		}
+		return headers;
+	}
 
-		const res = await fetch(`${this.url}${path}`, { ...init, headers });
+	private async fetchResponse(
+		path: string,
+		init: RequestInit = {},
+		responseKind: 'json' | 'attachment' = 'json'
+	): Promise<Response> {
+		let res: Response;
+		try {
+			res = await fetch(`${this.url}${path}`, {
+				...init,
+				headers: this.requestHeaders(init),
+				redirect: 'manual'
+			});
+		} catch (error) {
+			if (error instanceof QuickMailError) throw error;
+			const message = error instanceof Error ? error.message : 'Network request failed';
+			throw new QuickMailError(0, this.redactCredentials(message));
+		}
+		const contentType = res.headers.get('content-type')?.toLowerCase() ?? '';
+		const contentDisposition = res.headers.get('content-disposition') ?? '';
+		const isHtmlAttachment =
+			res.ok &&
+			responseKind === 'attachment' &&
+			contentType.includes('text/html') &&
+			/^\s*attachment(?:;|$)/i.test(contentDisposition);
+		if (
+			(res.status >= 300 && res.status < 400) ||
+			(contentType.includes('text/html') && !isHtmlAttachment)
+		) {
+			throw new QuickMailAccessError(res.status);
+		}
+		return res;
+	}
+
+	private redactCredentials(message: string): string {
+		let redacted = message;
+		const credentials = [this.token, this.cfAccessClientId, this.cfAccessClientSecret]
+			.filter((credential): credential is string => Boolean(credential))
+			.sort((left, right) => right.length - left.length);
+		for (const credential of credentials) {
+			redacted = redacted.replaceAll(credential, '[REDACTED]');
+		}
+		return redacted;
+	}
+
+	async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+		const res = await this.fetchResponse(path, init);
 		if (res.headers.get('content-type')?.includes('application/json')) {
 			const body = (await res.json()) as T & { error?: string };
 			if (!res.ok) {
-				throw new QuickMailError(res.status, body.error ?? res.statusText);
+				throw new QuickMailError(
+					res.status,
+					this.redactCredentials(body.error ?? res.statusText)
+				);
 			}
 			return body;
 		}
 
 		if (!res.ok) {
-			throw new QuickMailError(res.status, res.statusText);
+			throw new QuickMailError(res.status, this.redactCredentials(res.statusText));
 		}
 		return undefined as T;
 	}
@@ -185,9 +283,10 @@ export class QuickMailClient {
 	}
 
 	async downloadAttachment(emailId: string, attachmentId: string): Promise<{ bytes: Uint8Array; filename: string; type: string }> {
-		const res = await fetch(
-			`${this.url}/api/mail/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(attachmentId)}?download=1`,
-			{ headers: { authorization: `Bearer ${this.token}` } }
+		const res = await this.fetchResponse(
+			`/api/mail/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(attachmentId)}?download=1`,
+			{ headers: { accept: 'application/octet-stream' } },
+			'attachment'
 		);
 		if (!res.ok) {
 			throw new QuickMailError(res.status, 'Failed to download attachment');
@@ -265,4 +364,11 @@ export class QuickMailClient {
 		);
 		return body.unrouted;
 	}
+}
+
+export function createQuickMailClient(config: CliConfig): QuickMailClient {
+	return new QuickMailClient(config.url, config.token, {
+		cfAccessClientId: config.cfAccessClientId,
+		cfAccessClientSecret: config.cfAccessClientSecret
+	});
 }

--- a/cli/config.test.ts
+++ b/cli/config.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, test } from 'node:test';
+import { loadConfig, saveConfig } from './config.ts';
+
+const ENV_KEYS = [
+	'QUICKMAIL_CONFIG',
+	'QUICKMAIL_URL',
+	'QUICKMAIL_TOKEN',
+	'QUICKMAIL_CF_ACCESS_CLIENT_ID',
+	'QUICKMAIL_CF_ACCESS_CLIENT_SECRET'
+] as const;
+const originalEnvironment = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+const temporaryDirectories: string[] = [];
+
+async function temporaryConfig(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'quickmail-config-test-'));
+	temporaryDirectories.push(directory);
+	const path = join(directory, 'config.json');
+	process.env.QUICKMAIL_CONFIG = path;
+	return path;
+}
+
+function restoreEnvironment(): void {
+	for (const key of ENV_KEYS) {
+		const value = originalEnvironment.get(key);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+afterEach(async () => {
+	restoreEnvironment();
+	await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+describe('Cloudflare Access CLI configuration', () => {
+	test('saves and loads a complete credential pair with mode 0600', async () => {
+		const path = await temporaryConfig();
+		await saveConfig({
+			url: 'https://mail.example.com',
+			token: 'qm_live_test',
+			cfAccessClientId: 'saved-id.access',
+			cfAccessClientSecret: 'saved-secret'
+		});
+
+		assert.equal((await stat(path)).mode & 0o777, 0o600);
+		assert.deepEqual(JSON.parse(await readFile(path, 'utf8')), {
+			url: 'https://mail.example.com',
+			token: 'qm_live_test',
+			cfAccessClientId: 'saved-id.access',
+			cfAccessClientSecret: 'saved-secret'
+		});
+		assert.deepEqual(await loadConfig(), {
+			url: 'https://mail.example.com',
+			token: 'qm_live_test',
+			cfAccessClientId: 'saved-id.access',
+			cfAccessClientSecret: 'saved-secret'
+		});
+	});
+
+	test('uses a complete environment pair instead of saved Access credentials', async () => {
+		const path = await temporaryConfig();
+		await writeFile(
+			path,
+			JSON.stringify({
+				url: 'https://saved.example.com',
+				token: 'saved-token',
+				cfAccessClientId: 'saved-id.access',
+				cfAccessClientSecret: 'saved-secret'
+			})
+		);
+		await chmod(path, 0o600);
+		process.env.QUICKMAIL_CF_ACCESS_CLIENT_ID = 'env-id.access';
+		process.env.QUICKMAIL_CF_ACCESS_CLIENT_SECRET = 'env-secret';
+
+		assert.deepEqual(await loadConfig(), {
+			url: 'https://saved.example.com',
+			token: 'saved-token',
+			cfAccessClientId: 'env-id.access',
+			cfAccessClientSecret: 'env-secret'
+		});
+	});
+
+	test('does not inherit saved Access credentials when URL and token come from the environment', async () => {
+		const path = await temporaryConfig();
+		await writeFile(
+			path,
+			JSON.stringify({
+				url: 'https://saved.example.com',
+				token: 'qm_live_saved',
+				cfAccessClientId: 'saved-id.access',
+				cfAccessClientSecret: 'saved-secret'
+			})
+		);
+		process.env.QUICKMAIL_URL = 'https://environment.example.com';
+		process.env.QUICKMAIL_TOKEN = 'qm_live_environment';
+
+		assert.deepEqual(await loadConfig(), {
+			url: 'https://environment.example.com',
+			token: 'qm_live_environment'
+		});
+	});
+
+	test('rejects a partial environment URL/token pair instead of mixing credential sources', async () => {
+		const path = await temporaryConfig();
+		await writeFile(
+			path,
+			JSON.stringify({
+				url: 'https://saved.example.com',
+				token: 'qm_live_saved'
+			})
+		);
+		process.env.QUICKMAIL_URL = 'https://environment.example.com';
+
+		await assert.rejects(
+			loadConfig(),
+			/QUICKMAIL_URL and QUICKMAIL_TOKEN must be configured together/
+		);
+	});
+
+	test('rejects a half-configured saved pair', async () => {
+		const path = await temporaryConfig();
+		await writeFile(
+			path,
+			JSON.stringify({
+				url: 'https://mail.example.com',
+				token: 'qm_live_test',
+				cfAccessClientId: 'saved-id.access'
+			})
+		);
+
+		await assert.rejects(loadConfig(), /Cloudflare Access client ID and secret must be configured together/);
+	});
+
+	test('rejects explicitly empty Access values instead of treating them as disabled', async () => {
+		await temporaryConfig();
+		for (const access of [
+			{ cfAccessClientId: '', cfAccessClientSecret: 'saved-secret' },
+			{ cfAccessClientId: 'saved-id.access', cfAccessClientSecret: '' },
+			{ cfAccessClientId: '', cfAccessClientSecret: '' }
+		]) {
+			await assert.rejects(
+				saveConfig({
+					url: 'https://mail.example.com',
+					token: 'qm_live_test',
+					...access
+				}),
+				/Cloudflare Access client ID and secret must be configured together/
+			);
+		}
+	});
+
+	test('rejects a half-configured environment pair instead of mixing it with saved credentials', async () => {
+		const path = await temporaryConfig();
+		await writeFile(
+			path,
+			JSON.stringify({
+				url: 'https://mail.example.com',
+				token: 'qm_live_test',
+				cfAccessClientId: 'saved-id.access',
+				cfAccessClientSecret: 'saved-secret'
+			})
+		);
+		process.env.QUICKMAIL_CF_ACCESS_CLIENT_ID = 'env-id.access';
+		delete process.env.QUICKMAIL_CF_ACCESS_CLIENT_SECRET;
+
+		await assert.rejects(loadConfig(), /Cloudflare Access client ID and secret must be configured together/);
+	});
+});

--- a/cli/config.ts
+++ b/cli/config.ts
@@ -5,7 +5,23 @@ import { dirname, join } from 'node:path';
 export type CliConfig = {
 	url: string;
 	token: string;
+	cfAccessClientId?: string;
+	cfAccessClientSecret?: string;
 };
+
+const ACCESS_PAIR_ERROR = 'Cloudflare Access client ID and secret must be configured together.';
+
+export function validateAccessCredentials(
+	cfAccessClientId: string | undefined,
+	cfAccessClientSecret: string | undefined
+): Pick<CliConfig, 'cfAccessClientId' | 'cfAccessClientSecret'> {
+	const hasClientId = cfAccessClientId !== undefined;
+	const hasClientSecret = cfAccessClientSecret !== undefined;
+	if (hasClientId !== hasClientSecret) throw new Error(ACCESS_PAIR_ERROR);
+	if (!hasClientId) return {};
+	if (!cfAccessClientId || !cfAccessClientSecret) throw new Error(ACCESS_PAIR_ERROR);
+	return { cfAccessClientId, cfAccessClientSecret };
+}
 
 function configPath(): string {
 	const override = process.env.QUICKMAIL_CONFIG;
@@ -48,35 +64,48 @@ export function normalizeUrl(url: string): string {
 export async function loadConfig(): Promise<CliConfig> {
 	const envUrl = process.env.QUICKMAIL_URL;
 	const envToken = process.env.QUICKMAIL_TOKEN;
-	if (envUrl && envToken) {
-		return { url: normalizeUrl(envUrl), token: envToken };
+	const envAccessClientId = process.env.QUICKMAIL_CF_ACCESS_CLIENT_ID;
+	const envAccessClientSecret = process.env.QUICKMAIL_CF_ACCESS_CLIENT_SECRET;
+	const hasCoreEnvironmentOverride = envUrl !== undefined || envToken !== undefined;
+	const hasAccessEnvironmentOverride =
+		envAccessClientId !== undefined || envAccessClientSecret !== undefined;
+	if (hasCoreEnvironmentOverride && (!envUrl || !envToken)) {
+		throw new Error('QUICKMAIL_URL and QUICKMAIL_TOKEN must be configured together.');
 	}
 
-	let raw: Partial<CliConfig>;
+	let raw: Partial<CliConfig> = {};
 	try {
 		raw = JSON.parse(await readFile(configPath(), 'utf8')) as Partial<CliConfig>;
 	} catch {
-		throw new Error(
-			'Not logged in. Run `quickmail login --url <instance> --token <key>` or set QUICKMAIL_URL and QUICKMAIL_TOKEN.'
-		);
+		if (!hasCoreEnvironmentOverride) {
+			throw new Error(
+				'Not logged in. Run `quickmail login --url <instance> --token <key>` or set QUICKMAIL_URL and QUICKMAIL_TOKEN.'
+			);
+		}
 	}
 
-	const url = envUrl ?? raw.url;
-	const token = envToken ?? raw.token;
+	const url = hasCoreEnvironmentOverride ? envUrl : raw.url;
+	const token = hasCoreEnvironmentOverride ? envToken : raw.token;
 	if (!url || !token) {
 		throw new Error(
 			'Not logged in. Run `quickmail login --url <instance> --token <key>` or set QUICKMAIL_URL and QUICKMAIL_TOKEN.'
 		);
 	}
-	return { url: normalizeUrl(url), token };
+	const access = hasAccessEnvironmentOverride
+		? validateAccessCredentials(envAccessClientId, envAccessClientSecret)
+		: hasCoreEnvironmentOverride
+			? {}
+			: validateAccessCredentials(raw.cfAccessClientId, raw.cfAccessClientSecret);
+	return { url: normalizeUrl(url), token, ...access };
 }
 
 export async function saveConfig(config: CliConfig): Promise<string> {
 	const path = configPath();
+	const access = validateAccessCredentials(config.cfAccessClientId, config.cfAccessClientSecret);
 	await mkdir(dirname(path), { recursive: true });
 	await writeFile(
 		path,
-		`${JSON.stringify({ url: normalizeUrl(config.url), token: config.token }, null, 2)}\n`,
+		`${JSON.stringify({ url: normalizeUrl(config.url), token: config.token, ...access }, null, 2)}\n`,
 		{ mode: 0o600 }
 	);
 	await chmod(path, 0o600);

--- a/cli/main.test.ts
+++ b/cli/main.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer, type IncomingMessage } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, test } from 'node:test';
+
+const execFileAsync = promisify(execFile);
+const temporaryDirectories: string[] = [];
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		servers.splice(0).map(
+			(server) => new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+		)
+	);
+	await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })));
+});
+
+async function fixtureServer(onRequest: (request: IncomingMessage) => void): Promise<string> {
+	const server = createServer((request, response) => {
+		onRequest(request);
+		response.writeHead(200, { 'content-type': 'application/json' });
+		response.end(
+			JSON.stringify({
+				user: { id: 'user-1', email: 'me@example.com', name: 'Me', is_admin: false }
+			})
+		);
+	});
+	servers.push(server);
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('fixture server did not bind');
+	return `http://127.0.0.1:${address.port}`;
+}
+
+async function configPath(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), 'quickmail-login-test-'));
+	temporaryDirectories.push(directory);
+	return join(directory, 'config.json');
+}
+
+async function runCli(
+	args: string[],
+	path: string,
+	environment: Record<string, string | undefined> = {}
+) {
+	return execFileAsync(process.execPath, ['cli/main.ts', ...args], {
+		cwd: new URL('..', import.meta.url),
+		env: {
+			...process.env,
+			QUICKMAIL_CONFIG: path,
+			QUICKMAIL_URL: undefined,
+			QUICKMAIL_TOKEN: undefined,
+			QUICKMAIL_CF_ACCESS_CLIENT_ID: undefined,
+			QUICKMAIL_CF_ACCESS_CLIENT_SECRET: undefined,
+			...environment
+		}
+	});
+}
+
+describe('quickmail login Cloudflare Access flags', () => {
+	test('uses both auth layers for login and saves the complete pair', async () => {
+		let request: IncomingMessage | undefined;
+		const url = await fixtureServer((value) => {
+			request = value;
+		});
+		const path = await configPath();
+
+		const result = await runCli(
+			[
+				'login',
+				'--url',
+				url,
+				'--token',
+				'qm_live_test',
+				'--cf-access-client-id',
+				'login-id.access',
+				'--cf-access-client-secret',
+				'login-secret'
+			],
+			path
+		);
+
+		assert.match(result.stdout, /Logged in as me@example.com/);
+		assert.equal(request?.headers.authorization, 'Bearer qm_live_test');
+		assert.equal(request?.headers['cf-access-client-id'], 'login-id.access');
+		assert.equal(request?.headers['cf-access-client-secret'], 'login-secret');
+		assert.deepEqual(JSON.parse(await readFile(path, 'utf8')), {
+			url,
+			token: 'qm_live_test',
+			cfAccessClientId: 'login-id.access',
+			cfAccessClientSecret: 'login-secret'
+		});
+	});
+
+	test('rejects a half-configured flag pair before contacting QuickMail or echoing the secret', async () => {
+		let requestCount = 0;
+		const url = await fixtureServer(() => {
+			requestCount += 1;
+		});
+		const path = await configPath();
+
+		await assert.rejects(
+			runCli(
+				[
+					'login',
+					'--url',
+					url,
+					'--token',
+					'qm_live_test',
+					'--cf-access-client-secret',
+					'login-secret'
+				],
+				path
+			),
+			(error: unknown) => {
+				if (!error || typeof error !== 'object') return false;
+				const stderr = String((error as { stderr?: string }).stderr ?? '');
+				assert.match(stderr, /Cloudflare Access client ID and secret must be configured together/);
+				assert.doesNotMatch(stderr, /login-secret|qm_live_test/);
+				return true;
+			}
+		);
+		assert.equal(requestCount, 0);
+	});
+
+	test('rejects mixed or valueless flag and environment Access pairs before contacting QuickMail', async () => {
+		let requestCount = 0;
+		const url = await fixtureServer(() => {
+			requestCount += 1;
+		});
+
+		for (const scenario of [
+			{
+				args: ['--cf-access-client-secret', 'flag-secret'],
+				environment: { QUICKMAIL_CF_ACCESS_CLIENT_ID: 'env-id.access' }
+			},
+			{
+				args: ['--cf-access-client-id', 'flag-id.access'],
+				environment: { QUICKMAIL_CF_ACCESS_CLIENT_SECRET: 'env-secret' }
+			},
+			{
+				args: ['--cf-access-client-id'],
+				environment: {
+					QUICKMAIL_CF_ACCESS_CLIENT_ID: 'env-id.access',
+					QUICKMAIL_CF_ACCESS_CLIENT_SECRET: 'env-secret'
+				}
+			},
+			{
+				args: ['--cf-access-client-secret'],
+				environment: {
+					QUICKMAIL_CF_ACCESS_CLIENT_ID: 'env-id.access',
+					QUICKMAIL_CF_ACCESS_CLIENT_SECRET: 'env-secret'
+				}
+			}
+		]) {
+			const path = await configPath();
+			await assert.rejects(
+				runCli(
+					['login', '--url', url, '--token', 'qm_live_test', ...scenario.args],
+					path,
+					scenario.environment
+				),
+				(error: unknown) => {
+					if (!error || typeof error !== 'object') return false;
+					const stderr = String((error as { stderr?: string }).stderr ?? '');
+					assert.match(stderr, /Cloudflare Access client ID and secret must be configured together/);
+					assert.doesNotMatch(stderr, /flag-secret|flag-id|env-secret|env-id|qm_live_test/);
+					return true;
+				}
+			);
+		}
+
+		assert.equal(requestCount, 0);
+	});
+});

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -1,6 +1,7 @@
 import { writeFile } from 'node:fs/promises';
 import { stdin as stdinStream } from 'node:process';
 import {
+	createQuickMailClient,
 	QuickMailClient,
 	QuickMailError,
 	safeDownloadName,
@@ -12,7 +13,8 @@ import { clearConfig, loadConfig, saveConfig } from './config.ts';
 const HELP = `quickmail — operate a QuickMail instance from the terminal
 
 Usage:
-  quickmail login --url <https://mail.example.com> --token <qm_live_…>
+  quickmail login --url <https://mail.example.com> --token <qm_live_…> \\
+    [--cf-access-client-id <id.access> --cf-access-client-secret <secret>]
   quickmail logout
   quickmail whoami
 
@@ -40,8 +42,11 @@ Admin:
 MCP:
   quickmail mcp
 
-Auth is a Settings → API keys bearer token. QUICKMAIL_URL and QUICKMAIL_TOKEN
-override the saved config. Use --json on mail/admin commands for raw output.
+Auth uses a Settings → API keys bearer token. Set QUICKMAIL_URL and
+QUICKMAIL_TOKEN together; this environment pair never inherits saved Access
+credentials. Configure both QUICKMAIL_CF_ACCESS_CLIENT_ID and
+QUICKMAIL_CF_ACCESS_CLIENT_SECRET or neither. Use --json on mail/admin commands
+for raw output.
 `;
 
 type Flags = Record<string, string | boolean>;
@@ -146,8 +151,7 @@ function printThreads(page: { threads: ThreadSummary[]; total: number; page: num
 }
 
 async function clientFromConfig(): Promise<QuickMailClient> {
-	const config = await loadConfig();
-	return new QuickMailClient(config.url, config.token);
+	return createQuickMailClient(await loadConfig());
 }
 
 async function resolveUserId(client: QuickMailClient, idOrEmail: string): Promise<string> {
@@ -187,15 +191,25 @@ async function run(argv: string[]): Promise<number> {
 		case 'login': {
 			const url = flagString(flags, 'url');
 			const token = flagString(flags, 'token') ?? process.env.QUICKMAIL_TOKEN;
+			const flagAccessClientId = flagString(flags, 'cf-access-client-id');
+			const flagAccessClientSecret = flagString(flags, 'cf-access-client-secret');
+			const hasAccessFlag =
+				Object.hasOwn(flags, 'cf-access-client-id') || Object.hasOwn(flags, 'cf-access-client-secret');
+			const cfAccessClientId = hasAccessFlag
+				? (flagAccessClientId ?? '')
+				: process.env.QUICKMAIL_CF_ACCESS_CLIENT_ID;
+			const cfAccessClientSecret = hasAccessFlag
+				? (flagAccessClientSecret ?? '')
+				: process.env.QUICKMAIL_CF_ACCESS_CLIENT_SECRET;
 			if (!url) {
 				throw new Error('login requires --url');
 			}
 			if (!token) {
 				throw new Error('login requires --token or QUICKMAIL_TOKEN (create a key in Settings → API keys)');
 			}
-			const client = new QuickMailClient(url, token);
-			const user = await client.whoami();
-			const path = await saveConfig({ url, token });
+			const config = { url, token, cfAccessClientId, cfAccessClientSecret };
+			const user = await createQuickMailClient(config).whoami();
+			const path = await saveConfig(config);
 			console.log(`Logged in as ${user.email} (${path})`);
 			return 0;
 		}

--- a/cli/mcp.ts
+++ b/cli/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { QuickMailClient, QuickMailError, type MailboxView } from './client.ts';
+import { createQuickMailClient, QuickMailError, type MailboxView } from './client.ts';
 import { loadConfig } from './config.ts';
 
 const views = ['inbox', 'starred', 'drafts', 'sent', 'trash'] as const;
@@ -22,7 +22,7 @@ function fail(error: unknown) {
 
 export async function startMcpServer(): Promise<void> {
 	const config = await loadConfig();
-	const client = new QuickMailClient(config.url, config.token);
+	const client = createQuickMailClient(config);
 
 	const server = new McpServer({ name: 'quickmail', version: '1.0.0' });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts cli/config.test.ts cli/main.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",


### PR DESCRIPTION
## Summary

- add optional Cloudflare Access service-token credentials to CLI configuration and `quickmail login`
- centralize CLI/MCP HTTP transport so JSON, admin, attachment, and MCP requests send both Access headers and the independent QuickMail bearer token
- reject half-configured Access credentials and let environment pairs override saved configuration
- disable API redirect following and distinguish Access redirect/HTML challenges from QuickMail JSON authorization failures
- redact both credential layers from reflected API errors
- document secure Access policy layout, narrowly scoped Resend webhook bypass, native Email Worker behavior, and independent credential rotation

## Security model

```text
CLI/MCP
  -> CF-Access-Client-Id + CF-Access-Client-Secret
  -> Authorization: Bearer <QuickMail API token>
  -> QuickMail
```

The credentials remain independent; Cloudflare Access does not replace QuickMail authorization.

## Test plan

- [x] full suite: 53/53 tests
- [x] focused CLI coverage suite: 27/27 tests
- [x] config persistence, `0600`, saved/environment precedence, and partial-pair rejection
- [x] login flag/environment source atomicity in both mixed directions, including valueless flag rejection
- [x] environment URL/token source atomicity; saved Access credentials are never inherited by another host
- [x] JSON and attachment request header injection
- [x] legitimate HTML attachment downloads versus Access HTML challenge detection
- [x] login flags exercised through the real CLI process
- [x] Access redirect and HTML diagnostics
- [x] reflected-secret redaction
- [x] malformed and prefix-overlapping credential redaction
- [x] visible-ASCII authentication validation, including DEL/control-character rejection before networking
- [x] bearer-only regression path
- [x] shared CLI/MCP client configuration
- [x] `bun run check` (0 errors; one pre-existing autofocus warning)
- [x] `bun run check:clean`
- [x] `actionlint .github/workflows/ci.yml`
- [x] `bun run build`
- [x] `git diff --check`
- [x] GitHub Actions now runs `bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Access service-token authentication for CLI and MCP connections.
  * Added login options and environment variables for Access credentials.
  * Saved configurations now securely store and validate paired Access credentials.
  * Added diagnostics for Access redirects and authentication failures.
  * Credentials are redacted from errors and request-related output.

* **Documentation**
  * Expanded CLI and deployment guidance for Cloudflare Access setup, policies, credential rotation, and webhooks.

* **Tests**
  * Added comprehensive coverage for authentication, configuration validation, redirects, error handling, and credential protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->