### PR TITLE
Add an optional signature per sending address

### DIFF
--- a/migrations/0011_address_signature.sql
+++ b/migrations/0011_address_signature.sql
@@ -1,0 +1,2 @@
+-- Optional sign-off per sending address. NULL means use the account signature.
+ALTER TABLE addresses ADD COLUMN signature TEXT;

--- a/src/lib/email-signature.test.ts
+++ b/src/lib/email-signature.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
 	appendEmailSignature,
-	normalizeEmailSignature
+	MAX_EMAIL_SIGNATURE_LENGTH,
+	normalizeEmailSignature,
+	parseMailboxSignature,
+	pickEmailSignature
 } from './email-signature';
 
 	describe('email signatures', () => {
@@ -43,6 +46,22 @@ import {
 		assert.deepEqual(
 			appendEmailSignature({ text: 'Hello', html: '<p>Hello</p>', signature: '   ' }),
 			{ text: 'Hello', html: '<p>Hello</p>' }
+		);
+	});
+
+	test('picks a mailbox signature over the account signature', () => {
+		assert.equal(pickEmailSignature('Support', 'Best,\nEmmanuel'), 'Support');
+		assert.equal(pickEmailSignature('  ', 'Best,\nEmmanuel'), 'Best,\nEmmanuel');
+		assert.equal(pickEmailSignature(null, ''), '');
+	});
+
+	test('rejects mailbox signatures over the character limit', () => {
+		assert.equal(parseMailboxSignature('  Best  '), 'Best');
+		assert.equal(parseMailboxSignature('   '), null);
+		assert.equal(parseMailboxSignature('x'.repeat(MAX_EMAIL_SIGNATURE_LENGTH))?.length, 1000);
+		assert.throws(
+			() => parseMailboxSignature('x'.repeat(MAX_EMAIL_SIGNATURE_LENGTH + 1)),
+			/1000 characters or fewer/
 		);
 	});
 });

--- a/src/lib/email-signature.ts
+++ b/src/lib/email-signature.ts
@@ -19,6 +19,23 @@ function escapeHtml(value: string): string {
 		.replaceAll("'", '&#39;');
 }
 
+/** Mailbox sign-off wins when set; otherwise the account signature. */
+export function pickEmailSignature(
+	mailbox: string | null | undefined,
+	account: string | null | undefined
+): string {
+	return normalizeEmailSignature(mailbox ?? '') || normalizeEmailSignature(account ?? '');
+}
+
+/** Empty input becomes null so the mailbox falls back to the account signature. */
+export function parseMailboxSignature(value: string): string | null {
+	const signature = normalizeEmailSignature(value);
+	if (signature.length > MAX_EMAIL_SIGNATURE_LENGTH) {
+		throw new Error(`Signature must be ${MAX_EMAIL_SIGNATURE_LENGTH} characters or fewer`);
+	}
+	return signature || null;
+}
+
 /** Append the configured sign-off to both MIME alternatives exactly once at send time. */
 export function appendEmailSignature(input: {
 	text: string;

--- a/src/lib/server/domains.ts
+++ b/src/lib/server/domains.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types';
 import type { Domain, MailAddress } from '$lib/types';
+import { parseMailboxSignature } from '$lib/email-signature';
 import type { EmailProvider, ProviderDomain } from './email-provider';
 
 type DomainRow = {
@@ -22,6 +23,7 @@ type AddressRow = {
 	address: string;
 	label: string | null;
 	is_default: number;
+	signature: string | null;
 	created_at: string;
 };
 
@@ -48,6 +50,7 @@ function mapAddress(row: AddressRow): MailAddress {
 		address: row.address,
 		label: row.label,
 		is_default: row.is_default === 1,
+		signature: row.signature,
 		created_at: row.created_at
 	};
 }
@@ -160,7 +163,7 @@ export async function syncDomains(db: D1Database, provider: EmailProvider): Prom
 /* -------------------------------------------------------------------------- */
 
 const ADDRESS_SELECT = `SELECT a.id, a.user_id, a.domain_id, d.name AS domain_name, a.address,
-	a.label, a.is_default, a.created_at
+	a.label, a.is_default, a.signature, a.created_at
 	FROM addresses a JOIN domains d ON d.id = a.domain_id`;
 
 export async function listAddressesForUser(
@@ -246,7 +249,7 @@ export async function updateAddress(
 	db: D1Database,
 	userId: string,
 	addressId: string,
-	patch: { label?: string | null }
+	patch: { label?: string | null; signature?: string | null }
 ): Promise<MailAddress> {
 	const current = await getAddressForUser(db, userId, addressId);
 	if (!current) {
@@ -254,10 +257,14 @@ export async function updateAddress(
 	}
 
 	const label = patch.label !== undefined ? patch.label?.trim() || null : current.label;
+	let signature = current.signature;
+	if (patch.signature !== undefined) {
+		signature = parseMailboxSignature(patch.signature ?? '');
+	}
 
 	await db
-		.prepare('UPDATE addresses SET label = ? WHERE id = ? AND user_id = ?')
-		.bind(label, addressId, userId)
+		.prepare('UPDATE addresses SET label = ?, signature = ? WHERE id = ? AND user_id = ?')
+		.bind(label, signature, addressId, userId)
 		.run();
 
 	const saved = await getAddressForUser(db, userId, addressId);

--- a/src/lib/server/outbox.test.ts
+++ b/src/lib/server/outbox.test.ts
@@ -20,6 +20,7 @@ type AddressRow = {
 	address: string;
 	label: string | null;
 	is_default: number;
+	signature: string | null;
 	created_at: string;
 };
 
@@ -73,6 +74,7 @@ const defaultAddress: AddressRow = {
 	address: 'ada@example.com',
 	label: 'Office',
 	is_default: 1,
+	signature: null,
 	created_at: user.created_at
 };
 

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -1,6 +1,6 @@
 import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 import type { MailAddress, OutboundAttachmentInput, User } from '$lib/types';
-import { appendEmailSignature } from '$lib/email-signature';
+import { appendEmailSignature, pickEmailSignature } from '$lib/email-signature';
 import { base64ByteLength, insertAttachments } from './attachments';
 import { MAX_TOTAL_ATTACHMENT_BYTES } from './constants';
 import {
@@ -88,6 +88,7 @@ export async function resolveReplyFromAddress(
 			domain_name: domain.name,
 			address: mailbox,
 			label: null,
+			signature: null,
 			is_default: false,
 			created_at: new Date().toISOString()
 		};
@@ -117,7 +118,7 @@ export async function sendAndStore(
 	const { text, html } = appendEmailSignature({
 		text: bodyText,
 		html: bodyHtml,
-		signature: await getEmailSignature(env.DB, user.id)
+		signature: pickEmailSignature(from.signature, await getEmailSignature(env.DB, user.id))
 	});
 
 	const attachments = input.attachments ?? [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,8 @@ export type MailAddress = {
 	/** From display name on outbound mail. Falls back to the account name. */
 	label: string | null;
 	is_default: boolean;
+	/** Sign-off for this mailbox. Falls back to the account signature when empty. */
+	signature: string | null;
 	created_at: string;
 };
 

--- a/src/routes/api/addresses/[id]/+server.ts
+++ b/src/routes/api/addresses/[id]/+server.ts
@@ -12,14 +12,21 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 		return json({ error: 'Unauthorized' }, { status: 401 });
 	}
 
-	const body = (await request.json()) as { isDefault?: boolean; label?: string | null };
+	const body = (await request.json()) as {
+		isDefault?: boolean;
+		label?: string | null;
+		signature?: string | null;
+	};
 	if (body.isDefault) {
 		await setDefaultAddress(db, locals.user.id, params.id!);
 	}
 
-	if (body.label !== undefined) {
+	if (body.label !== undefined || body.signature !== undefined) {
 		try {
-			await updateAddress(db, locals.user.id, params.id!, { label: body.label });
+			await updateAddress(db, locals.user.id, params.id!, {
+				label: body.label,
+				signature: body.signature
+			});
 		} catch (error) {
 			return json(
 				{ error: error instanceof Error ? error.message : 'Could not update address' },

--- a/src/routes/api/addresses/[id]/+server.ts
+++ b/src/routes/api/addresses/[id]/+server.ts
@@ -17,10 +17,6 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 		label?: string | null;
 		signature?: string | null;
 	};
-	if (body.isDefault) {
-		await setDefaultAddress(db, locals.user.id, params.id!);
-	}
-
 	if (body.label !== undefined || body.signature !== undefined) {
 		try {
 			await updateAddress(db, locals.user.id, params.id!, {
@@ -33,6 +29,10 @@ export const PATCH: RequestHandler = async ({ params, request, locals, platform 
 				{ status: 400 }
 			);
 		}
+	}
+
+	if (body.isDefault) {
+		await setDefaultAddress(db, locals.user.id, params.id!);
 	}
 
 	return json({ addresses: await listAddressesForUser(db, locals.user.id) });

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -253,6 +253,31 @@
 		if (res.ok) edited = body.addresses;
 	}
 
+	async function saveMailboxSignature(id: string, value: string) {
+		const current = addresses.find((address) => address.id === id);
+		if (!current || (current.signature ?? '') === value.trim()) return;
+
+		savingId = id;
+		error = '';
+		try {
+			const res = await fetch(`/api/addresses/${id}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ signature: value })
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				error = body.error ?? 'Could not save that signature';
+				return;
+			}
+			edited = body.addresses;
+		} catch {
+			error = 'Network error';
+		} finally {
+			savingId = '';
+		}
+	}
+
 	async function remove(id: string) {
 		const res = await fetch(`/api/addresses/${id}`, { method: 'DELETE' });
 		const body = await res.json();
@@ -307,6 +332,7 @@
 
 	<section class="surface-lg card">
 		<h2><Icon name="pencil-line" size={18} /> Signature</h2>
+		<p class="card-hint">Used when a mailbox has no signature of its own.</p>
 
 		<form class="signature-form" onsubmit={saveSignature}>
 			<textarea
@@ -333,43 +359,56 @@
 	<section class="surface-lg card">
 		<h2><Icon name="at-line" size={18} /> Addresses</h2>
 		<p class="card-hint">
-			The From name is what recipients see. Leave it blank to use your account name.
+			The From name is what recipients see. A signature on an address replaces the account
+			signature for that mailbox. Leave either blank to use the account default.
 		</p>
 
 		<ul class="address-list">
 			{#each addresses as address (address.id)}
 				<li class="address-row">
-					<div class="min-w-0 flex-1">
-						<input
-							type="text"
-							class="name-input"
-							value={address.label ?? ''}
-							placeholder="From name"
-							aria-label="From name for {address.address}"
-							disabled={savingId === address.id}
-							onchange={(event) => saveLabel(address.id, event.currentTarget.value)}
-						/>
-						<p class="address-domain">{address.address}</p>
+					<div class="address-head">
+						<div class="min-w-0 flex-1">
+							<input
+								type="text"
+								class="name-input"
+								value={address.label ?? ''}
+								placeholder="From name"
+								aria-label="From name for {address.address}"
+								disabled={savingId === address.id}
+								onchange={(event) => saveLabel(address.id, event.currentTarget.value)}
+							/>
+							<p class="address-domain">{address.address}</p>
+						</div>
+
+						{#if address.is_default}
+							<span class="badge">Default</span>
+						{:else}
+							<button type="button" class="btn-ghost text-xs" onclick={() => makeDefault(address.id)}>
+								Make default
+							</button>
+						{/if}
+
+						{#if addresses.length > 1}
+							<button
+								type="button"
+								class="icon-btn"
+								aria-label="Remove {address.address}"
+								onclick={() => remove(address.id)}
+							>
+								<Icon name="delete-bin-line" size={15} />
+							</button>
+						{/if}
 					</div>
-
-					{#if address.is_default}
-						<span class="badge">Default</span>
-					{:else}
-						<button type="button" class="btn-ghost text-xs" onclick={() => makeDefault(address.id)}>
-							Make default
-						</button>
-					{/if}
-
-					{#if addresses.length > 1}
-						<button
-							type="button"
-							class="icon-btn"
-							aria-label="Remove {address.address}"
-							onclick={() => remove(address.id)}
-						>
-							<Icon name="delete-bin-line" size={15} />
-						</button>
-					{/if}
+					<textarea
+						class="mailbox-signature"
+						rows="2"
+						maxlength={MAX_EMAIL_SIGNATURE_LENGTH}
+						value={address.signature ?? ''}
+						placeholder="Signature for this address"
+						aria-label="Signature for {address.address}"
+						disabled={savingId === address.id}
+						onchange={(event) => saveMailboxSignature(address.id, event.currentTarget.value)}
+					></textarea>
 				</li>
 			{/each}
 		</ul>
@@ -743,13 +782,20 @@
 
 	.address-row {
 		display: flex;
-		align-items: center;
-		gap: 0.625rem;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.5rem;
 		padding: 0.75rem 0;
 	}
 
 	.address-row + .address-row {
 		box-shadow: inset 0 1px 0 var(--color-line);
+	}
+
+	.address-head {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
 	}
 
 	.name-input {
@@ -764,6 +810,26 @@
 	.name-input::placeholder {
 		color: var(--color-muted);
 		font-weight: 400;
+	}
+
+	.mailbox-signature {
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		resize: vertical;
+		border-radius: 0.625rem;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		background: var(--color-surface-muted);
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		outline: none;
+	}
+
+	.mailbox-signature:focus {
+		box-shadow: inset 0 0 0 1px var(--color-focus-line), 0 0 0 3px var(--color-focus-halo);
+	}
+
+	.mailbox-signature::placeholder {
+		color: var(--color-muted);
 	}
 
 	.address-domain {


### PR DESCRIPTION
## Summary

Adds an optional plain-text signature on each sending address.

The account signature in Settings remains the default. When a mailbox has its own sign-off, that is what gets appended at send time.

This is the per-address follow-up called out when per-user signatures landed.

## What changed

* Added a `signature` column on `addresses` through D1 migration `0011`.
* Settings Addresses: a signature field on each row. Blank means use the account signature.
* `PATCH /api/addresses/:id` accepts `signature`.
* Applied through `sendAndStore()`, so new messages and replies both pick it up.
* Added `pickEmailSignature()` with tests for mailbox-over-account, empty mailbox, and empty account.

## Behaviour

* Mailbox signature, if set, replaces the account signature for that send.
* An empty mailbox signature falls back to the account signature.
* An empty account signature disables the feature unless the mailbox has one.
* Same 1,000-character limit and plain-text normalisation as the account signature.
* Drafts still do not contain the signature; it is appended when the message is sent.
* The automatic signature does not count as message content, so a signature-only email is still rejected.

## Validation

* `bun test src/lib/email-signature.test.ts` — 5 tests passed
* `bun run check` — 0 errors and one existing autofocus warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom email signatures per mailbox.
  * Added mailbox signature editing and saving in Settings.
  * Added editable sender names for mailboxes.
  * Mailbox signatures take precedence over account signatures; blank values fall back automatically.
  * Signatures are included in outgoing and reply emails with consistent formatting.
* **Bug Fixes**
  * Improved handling of empty, missing, whitespace-only, and overly long signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->