### PR TITLE
Make deploy pick each operator's Cloudflare account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env (gitignored) or paste values in the Deploy to Cloudflare form.
+# These are Wrangler / Workers Builds variables, not Worker runtime secrets.
+#
+# Required when your Cloudflare login or API token can see more than one account.
+# Dashboard sidebar, or: wrangler whoami
+# https://developers.cloudflare.com/fundamentals/account/find-account-and-zone-ids/
+# Do not put a personal account id in wrangler.jsonc if you publish the repo.
+CLOUDFLARE_ACCOUNT_ID=

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ bun run setup
 bash scripts/setup.sh
 ```
 
+The button deploys to **your** Cloudflare account. If the form asks for
+`CLOUDFLARE_ACCOUNT_ID` (typical when your login can see more than one
+account), paste the ID from the dashboard sidebar — `wrangler whoami` also
+prints it. Do not commit that ID into `wrangler.jsonc`.
+
 The wizard creates the D1 database and R2 bucket, writes config, and onboards
 your domain. Budget about 30 minutes — most of that is waiting on DNS.
 
@@ -64,6 +69,10 @@ Only needed if you cannot run the wizard.
 bun install          # or: npm install
 bunx wrangler login
 ```
+
+If `wrangler whoami` lists more than one account, copy `.env.example` to `.env`
+and set `CLOUDFLARE_ACCOUNT_ID` (dashboard sidebar). The setup wizard prompts
+for this when it cannot pick an account automatically.
 
 Cloudflare Email Sending needs **Wrangler 4.123+** (older versions hit a
 removed API path and 404).
@@ -290,6 +299,7 @@ migrations/          D1 schema, applied in order
 | Webhook 500 | `bunx wrangler tail` |
 | Attachments missing | R2 bucket must exist and match `bucket_name` in `wrangler.jsonc` |
 | `database_id` errors on deploy | Paste the id from `wrangler d1 create` into `wrangler.jsonc` |
+| Deploy to Cloudflare / wrangler: more than one account, or no account id | Set `CLOUDFLARE_ACCOUNT_ID` from the dashboard sidebar or `wrangler whoami`. Use `.env` (see `.env.example`) or the deploy-button form — do not commit a personal id in `wrangler.jsonc` |
 | Setup shows no Cloudflare domains | Set `CLOUDFLARE_MAIL_DOMAINS` and `EMAIL_PROVIDER=cloudflare`, restart the dev server |
 
 ## License

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
 		"build": "vite build && bun scripts/wrap-cloudflare-worker.mjs",
 		"preview": "bun run build && wrangler dev",
 		"setup": "node scripts/setup.mjs",
-		"deploy": "bun run build && wrangler deploy",
+		"deploy": "bun run build && node scripts/wrangler-with-env.mjs deploy",
 		"db:migrate:local": "wrangler d1 migrations apply quickmail --local",
-		"db:migrate:remote": "wrangler d1 migrations apply quickmail --remote",
+		"db:migrate:remote": "node scripts/wrangler-with-env.mjs d1 migrations apply quickmail --remote",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:clean": "bun scripts/check-template-clean.mjs",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts scripts/cloudflare-env.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",
@@ -65,6 +65,9 @@
 			},
 			"RESEND_WEBHOOK_SECRET": {
 				"description": "Only for `EMAIL_PROVIDER=resend`: shown once when you create the webhook at [Resend webhooks](https://resend.com/webhooks). Keep the placeholder if using Cloudflare Email."
+			},
+			"CLOUDFLARE_ACCOUNT_ID": {
+				"description": "Your Cloudflare account ID (dashboard sidebar, or `wrangler whoami`). Required if your login can see more than one account. Leave empty only when you have a single account. Do not commit this into wrangler.jsonc."
 			}
 		}
 	}

--- a/scripts/check-template-clean.mjs
+++ b/scripts/check-template-clean.mjs
@@ -24,6 +24,7 @@ const FORBIDDEN = [
 	{ label: 'Cloudflare API token', pattern: /\bCLOUDFLARE_API_TOKEN\s*[:=]\s*["']?[A-Za-z0-9_-]{30,}/ },
 	{ label: 'Private key block', pattern: /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/ },
 	{ label: 'Live Cloudflare account id', pattern: /^\s*"account_id"\s*:\s*"[0-9a-f]{32}"/m },
+	{ label: 'Live Cloudflare account id in env', pattern: /^CLOUDFLARE_ACCOUNT_ID\s*=\s*[0-9a-f]{32}\s*$/m },
 	{ label: 'Maintainer infrastructure name', pattern: /divinprince[.-]/i }
 ];
 
@@ -94,7 +95,7 @@ if (!existsSync(wranglerPath)) {
 }
 
 // 4. The licence has to ship with the code.
-for (const required of ['LICENSE.md', 'README.md', '.dev.vars.example']) {
+for (const required of ['LICENSE.md', 'README.md', '.dev.vars.example', '.env.example']) {
 	if (!tracked.includes(required)) {
 		fail(`${required} is missing from the repository`);
 	}

--- a/scripts/cloudflare-env.mjs
+++ b/scripts/cloudflare-env.mjs
@@ -1,0 +1,87 @@
+/**
+ * Cloudflare account selection for setup and deploy.
+ *
+ * Wrangler reads CLOUDFLARE_ACCOUNT_ID from the process environment (not from
+ * Worker `.dev.vars`). Setup writes that id to `.env`; this module loads it
+ * back so later wrangler commands see it. A personal account id must never be
+ * committed in wrangler.jsonc.
+ */
+export const CLOUDFLARE_AUTH_KEYS = [
+	'CLOUDFLARE_ACCOUNT_ID',
+	'CLOUDFLARE_API_TOKEN',
+	'CLOUDFLARE_API_KEY',
+	'CLOUDFLARE_EMAIL'
+];
+
+export function isCloudflareAccountId(value) {
+	return typeof value === 'string' && /^[0-9a-f]{32}$/i.test(value.trim());
+}
+
+export function parseDotEnv(text) {
+	const out = {};
+	if (!text) return out;
+
+	for (const raw of text.split(/\r?\n/)) {
+		const line = raw.trim();
+		if (!line || line.startsWith('#')) continue;
+		const stripped = line.startsWith('export ') ? line.slice('export '.length).trim() : line;
+		const eq = stripped.indexOf('=');
+		if (eq <= 0) continue;
+		const key = stripped.slice(0, eq).trim();
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+		let value = stripped.slice(eq + 1).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		} else {
+			const comment = value.indexOf(' #');
+			if (comment !== -1) value = value.slice(0, comment).trim();
+		}
+		out[key] = value;
+	}
+	return out;
+}
+
+export function cloudflareAuthFromDotEnv(text) {
+	const parsed = parseDotEnv(text);
+	const out = {};
+	for (const key of CLOUDFLARE_AUTH_KEYS) {
+		const value = parsed[key];
+		if (value) out[key] = value;
+	}
+	return out;
+}
+
+/**
+ * Copy Cloudflare auth vars from dotenv text into `env` without overwriting
+ * values already set (CI / Workers Builds / the user's shell win).
+ */
+export function applyCloudflareAuthEnv(env, texts) {
+	const merged = {};
+	for (const text of texts) {
+		Object.assign(merged, cloudflareAuthFromDotEnv(text));
+	}
+	for (const [key, value] of Object.entries(merged)) {
+		if (!env[key] && value) env[key] = value;
+	}
+	return env;
+}
+
+export function setAccountIdInWrangler(source, accountId) {
+	if (!isCloudflareAccountId(accountId)) {
+		throw new Error('Invalid Cloudflare account id (expected 32 hex characters).');
+	}
+	const id = accountId.trim().toLowerCase();
+	if (/^\s*"account_id"\s*:/m.test(source)) {
+		return source.replace(/^(\s*"account_id"\s*:\s*")[^"]*(")/m, `$1${id}$2`);
+	}
+	if (/^\s*\/\/\s*"account_id"\s*:/m.test(source)) {
+		return source.replace(/^\s*\/\/\s*"account_id"\s*:\s*"[^"]*"\s*,?\s*$/m, `\t"account_id": "${id}",`);
+	}
+	if (/"workers_dev"\s*:/.test(source)) {
+		return source.replace(/("workers_dev"\s*:\s*(?:true|false),?\n)/, `$1\n\t"account_id": "${id}",\n`);
+	}
+	return `\t"account_id": "${id}",\n${source}`;
+}

--- a/scripts/cloudflare-env.test.ts
+++ b/scripts/cloudflare-env.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	applyCloudflareAuthEnv,
+	cloudflareAuthFromDotEnv,
+	isCloudflareAccountId,
+	parseDotEnv,
+	setAccountIdInWrangler
+} from './cloudflare-env.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const SAMPLE_ID = '0123456789abcdef0123456789abcdef';
+
+describe('Cloudflare account id', () => {
+	test('accepts a 32-character hex id and rejects placeholders', () => {
+		assert.equal(isCloudflareAccountId(SAMPLE_ID), true);
+		assert.equal(isCloudflareAccountId(SAMPLE_ID.toUpperCase()), true);
+		assert.equal(isCloudflareAccountId(''), false);
+		assert.equal(isCloudflareAccountId('REPLACE_WITH_YOUR_ACCOUNT_ID'), false);
+		assert.equal(isCloudflareAccountId('${CLOUDFLARE_ACCOUNT_ID}'), false);
+	});
+});
+
+describe('dotenv parsing', () => {
+	test('reads Cloudflare auth keys and ignores worker secrets', () => {
+		const parsed = parseDotEnv(`
+# comment
+CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID} # sidebar
+export CLOUDFLARE_API_TOKEN="tok_abc"
+RESEND_API_KEY=re_not_for_wrangler
+`);
+		assert.equal(parsed.CLOUDFLARE_ACCOUNT_ID, SAMPLE_ID);
+		assert.equal(parsed.CLOUDFLARE_API_TOKEN, 'tok_abc');
+		assert.equal(parsed.RESEND_API_KEY, 're_not_for_wrangler');
+
+		const auth = cloudflareAuthFromDotEnv(`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}\nRESEND_API_KEY=re_x`);
+		assert.deepEqual(auth, { CLOUDFLARE_ACCOUNT_ID: SAMPLE_ID });
+	});
+
+	test('does not overwrite an env var already set by the shell or CI', () => {
+		const env = { CLOUDFLARE_ACCOUNT_ID: 'already-set' };
+		applyCloudflareAuthEnv(env, [`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}`]);
+		assert.equal(env.CLOUDFLARE_ACCOUNT_ID, 'already-set');
+
+		const empty = {};
+		applyCloudflareAuthEnv(empty, [`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}`]);
+		assert.equal(empty.CLOUDFLARE_ACCOUNT_ID, SAMPLE_ID);
+	});
+});
+
+describe('wrangler.jsonc account_id', () => {
+	test('uncomments the template placeholder without inventing a committed id', () => {
+		const template = readFileSync(join(root, 'wrangler.jsonc'), 'utf8');
+		assert.match(template, /^\t\/\/ "account_id": ""/m);
+		assert.doesNotMatch(template, /^\s*"account_id"\s*:\s*"[0-9a-f]{32}"/m);
+		assert.match(template, /mail\.example\.com/);
+		assert.doesNotMatch(template, /mail\.yourdomain\.com/);
+
+		const next = setAccountIdInWrangler(template, SAMPLE_ID);
+		assert.match(next, new RegExp(`^\\t"account_id": "${SAMPLE_ID}",`, 'm'));
+		assert.doesNotMatch(next, /^\t\/\/ "account_id":/m);
+	});
+
+	test('replaces an existing account_id value', () => {
+		const source = '{\n\t"account_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",\n\t"name": "quickmail"\n}\n';
+		const next = setAccountIdInWrangler(source, SAMPLE_ID);
+		assert.equal(next.includes(SAMPLE_ID), true);
+		assert.equal(next.includes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), false);
+	});
+});

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -17,6 +17,11 @@ import { delimiter, join } from 'node:path';
 import readline from 'node:readline/promises';
 import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+	applyCloudflareAuthEnv,
+	isCloudflareAccountId,
+	setAccountIdInWrangler
+} from './cloudflare-env.mjs';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
 const wranglerFile = join(root, 'wrangler.jsonc');
@@ -59,8 +64,9 @@ let rl = null;
 function printHelp() {
 	console.log(`QuickMail setup
 
-Installs tools, logs you into Cloudflare, creates D1/R2, writes env and
-wrangler config, and onboards your mail domain.
+Installs tools, logs you into Cloudflare, picks an account if your login
+can see more than one, creates D1/R2, writes env and wrangler config, and
+onboards your mail domain.
 
   bun run setup
   bash scripts/setup.sh
@@ -174,6 +180,20 @@ function bunBin() {
 
 function hasBun() {
 	return Boolean(bunBin());
+}
+
+function applyCloudflareAuthFromDisk() {
+	const texts = [];
+	if (existsSync(envFile)) texts.push(readFileSync(envFile, 'utf8'));
+	if (existsSync(devVarsFile)) texts.push(readFileSync(devVarsFile, 'utf8'));
+	applyCloudflareAuthEnv(process.env, texts);
+}
+
+function rememberAccountId(id) {
+	const accountId = id.trim().toLowerCase();
+	process.env.CLOUDFLARE_ACCOUNT_ID = accountId;
+	upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accountId });
+	return accountId;
 }
 
 function childEnv(extra = {}) {
@@ -585,11 +605,39 @@ async function ensureLogin() {
 	return pickAccount(next.accounts);
 }
 
+async function askAccountId() {
+	log('  wrangler did not list an account. Paste the ID from the Cloudflare dashboard sidebar.');
+	if (args.yes) {
+		throw new Error(
+			'Set CLOUDFLARE_ACCOUNT_ID (32-character hex from the dashboard sidebar) and re-run.'
+		);
+	}
+	while (true) {
+		const raw = (await prompt('Cloudflare account ID')).trim();
+		if (isCloudflareAccountId(raw)) {
+			const id = rememberAccountId(raw);
+			ok(`account ${id}`);
+			return { name: id, id };
+		}
+		warn('Paste the 32-character hex ID from the dashboard sidebar (or wrangler whoami).');
+	}
+}
+
 async function pickAccount(accounts) {
-	if (accounts.length === 0) return null;
+	const existing = process.env.CLOUDFLARE_ACCOUNT_ID?.trim() ?? '';
+	if (isCloudflareAccountId(existing)) {
+		const id = existing.toLowerCase();
+		const match = accounts.find((account) => account.id === id);
+		rememberAccountId(id);
+		ok(match ? `account ${match.name}` : `CLOUDFLARE_ACCOUNT_ID ${id}`);
+		return match ?? { name: id, id };
+	}
+
+	if (accounts.length === 0) return askAccountId();
+
 	if (accounts.length === 1) {
 		ok(`account ${accounts[0].name}`);
-		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		rememberAccountId(accounts[0].id);
 		return accounts[0];
 	}
 
@@ -599,7 +647,7 @@ async function pickAccount(accounts) {
 	});
 
 	if (args.yes) {
-		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		rememberAccountId(accounts[0].id);
 		ok(`using ${accounts[0].name}`);
 		return accounts[0];
 	}
@@ -611,7 +659,7 @@ async function pickAccount(accounts) {
 		chosen = accounts[index];
 		if (!chosen) warn('Pick a number from the list.');
 	}
-	upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: chosen.id });
+	rememberAccountId(chosen.id);
 	ok(`using ${chosen.name}`);
 	return chosen;
 }
@@ -1043,7 +1091,7 @@ function printNextSteps(state) {
 		log('  Local inbound needs a tunnel (cloudflared) — production uses the public Worker URL.');
 	}
 
-	log(`\n  ${c.dim('wrangler.jsonc now has a real D1 id. Do not commit that back to the public template.')}`);
+	log(`\n  ${c.dim('wrangler.jsonc now has a real D1 id (and maybe account_id). Do not commit that back to the public template.')}`);
 	if (state.publicUrl) log(`\n  ${c.green(state.publicUrl)}`);
 }
 
@@ -1057,6 +1105,8 @@ async function main() {
 
 	log(`\n${c.bold('QuickMail setup')}`);
 	log(c.dim('  A mailbox on your domain, on Cloudflare.\n'));
+
+	applyCloudflareAuthFromDisk();
 
 	const total = 8;
 
@@ -1111,6 +1161,9 @@ async function main() {
 		domains: provider === 'cloudflare' ? domain : ''
 	});
 	if (hostname) source = setRoutes(source, hostname);
+	if (isCloudflareAccountId(process.env.CLOUDFLARE_ACCOUNT_ID ?? '')) {
+		source = setAccountIdInWrangler(source, process.env.CLOUDFLARE_ACCOUNT_ID);
+	}
 	if (provider === 'cloudflare' && versionGte(wranglerVer, ADDRESSES_WRANGLER)) {
 		source = setAddresses(source, [`*@${domain}`]);
 	} else {

--- a/scripts/wrangler-with-env.mjs
+++ b/scripts/wrangler-with-env.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Run wrangler with CLOUDFLARE_ACCOUNT_ID (and other Cloudflare auth vars)
+ * loaded from `.env` / `.dev.vars` when the shell has not already set them.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyCloudflareAuthEnv } from './cloudflare-env.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+const texts = [];
+for (const name of ['.env', '.dev.vars']) {
+	const file = join(root, name);
+	if (existsSync(file)) texts.push(readFileSync(file, 'utf8'));
+}
+applyCloudflareAuthEnv(process.env, texts);
+
+const wrangler = join(
+	root,
+	'node_modules',
+	'.bin',
+	process.platform === 'win32' ? 'wrangler.cmd' : 'wrangler'
+);
+const command = existsSync(wrangler) ? wrangler : 'wrangler';
+const child = spawn(command, process.argv.slice(2), {
+	stdio: 'inherit',
+	cwd: root,
+	env: process.env
+});
+
+child.on('exit', (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+	process.exit(code ?? 1);
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,8 +7,9 @@
 	"workers_dev": true,
 
 	// Your Cloudflare account is picked up from `wrangler login`. If you belong
-	// to more than one account, set CLOUDFLARE_ACCOUNT_ID in your environment
-	// or uncomment this and paste the ID from the Cloudflare dashboard sidebar.
+	// to more than one account, set CLOUDFLARE_ACCOUNT_ID in `.env` (see
+	// `.env.example`) or uncomment this and paste the ID from the dashboard
+	// sidebar. `bun run setup` writes this locally — do not commit a real ID.
 	// "account_id": "",
 
 	// Deploys to <name>.<your-subdomain>.workers.dev out of the box. To serve it


### PR DESCRIPTION
## Summary
- Fixes the Deploy to Cloudflare / wrangler path that fails when an account ID is missing (called out in #19; #18 tried to hardcode a personal `account_id` and was closed).
- Adds `.env.example` + a `CLOUDFLARE_ACCOUNT_ID` binding description so the deploy-button form can collect the operator's ID the Cloudflare-supported way.
- Setup now prompts when wrangler cannot pick an account, writes `CLOUDFLARE_ACCOUNT_ID` into `.env` **and** the process environment, and only then writes `account_id` into the local `wrangler.jsonc`. `bun run deploy` loads `.env` so wrangler actually sees it.
- The public template stays clean: commented empty `account_id`, `mail.example.com` route placeholder, and `check:clean` rejects a live account id in `wrangler.jsonc` or `.env.example`.

## Test plan
- [ ] `bun run check:clean` — no personal `account_id`, route still `mail.example.com`
- [ ] `bun test` — includes `scripts/cloudflare-env.test.ts`
- [ ] `bun run setup` with a login that sees **one** account — `.env` gets `CLOUDFLARE_ACCOUNT_ID`, local `wrangler.jsonc` gets `account_id`, deploy proceeds
- [ ] `bun run setup` with a login that sees **several** accounts — list + prompt; `--yes` without an env var uses the first and still exports it
- [ ] `bun run setup` with `CLOUDFLARE_ACCOUNT_ID` already in `.env` — uses that id without re-prompting
- [ ] Click **Deploy to Cloudflare** and confirm the form shows `CLOUDFLARE_ACCOUNT_ID` (paste from the dashboard sidebar if asked)
- [ ] Confirm `wrangler.jsonc` on this branch still has `// "account_id": ""` and no hex account id


Made with [Cursor](https://cursor.com)