### PR TITLE
Add a scalable design picker with a 0.email skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ no servers to maintain.
 - **Multiple domains and users** — per-user addresses, admin catch-all, unrouted-mail view
 - **Delivery status** — delivered / bounced / complained tracking
 - **REST API, CLI, and MCP server** — send and read mail from scripts, the terminal, or AI agents
-- Light and dark themes
+- Light and dark themes, plus a design picker (Mail or 0.email, extensible)
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/push-client.test.ts src/lib/designs/designs.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" data-design="mail">
+<html lang="en" data-design="mail" data-mailbox-layout="row">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -18,10 +18,15 @@
 				}
 
 				try {
-					document.documentElement.dataset.design =
-						localStorage.getItem('mail:design') || 'mail';
+					const design = localStorage.getItem('mail:design') || 'mail';
+					document.documentElement.dataset.design = design;
+					// First-paint layout only. The catalog is the source of truth
+					// after hydrate; add an entry here when a new design is not `row`.
+					document.documentElement.dataset.mailboxLayout =
+						design === 'zero' ? 'stack' : 'row';
 				} catch {
 					document.documentElement.dataset.design = 'mail';
+					document.documentElement.dataset.mailboxLayout = 'row';
 				}
 			})();
 		</script>

--- a/src/app.html
+++ b/src/app.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-design="mail">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="text-scale" content="scale" />
 		<script>
-			// Resolve the theme before first paint so there is no light flash.
+			// Resolve theme and design before first paint so there is no flash.
 			(() => {
 				try {
 					const stored = localStorage.getItem('mail:theme') || 'system';
@@ -15,6 +15,13 @@
 					document.documentElement.dataset.theme = dark ? 'dark' : 'light';
 				} catch {
 					document.documentElement.dataset.theme = 'light';
+				}
+
+				try {
+					document.documentElement.dataset.design =
+						localStorage.getItem('mail:design') || 'mail';
+				} catch {
+					document.documentElement.dataset.design = 'mail';
 				}
 			})();
 		</script>

--- a/src/lib/components/DesignPicker.svelte
+++ b/src/lib/components/DesignPicker.svelte
@@ -1,0 +1,268 @@
+<script lang="ts">
+	import Icon from './Icon.svelte';
+	import { chooseDesign, getActiveDesignId, listDesigns } from '$lib/designs';
+	import type { DesignDefinition } from '$lib/designs';
+
+	const designs = listDesigns();
+	let selected = $derived(getActiveDesignId());
+
+	function pick(design: DesignDefinition) {
+		chooseDesign(design.id);
+	}
+</script>
+
+<div class="design-gallery" role="radiogroup" aria-label="Design">
+	{#each designs as design (design.id)}
+		<button
+			type="button"
+			role="radio"
+			aria-checked={selected === design.id}
+			class="design-card"
+			class:selected={selected === design.id}
+			data-design-preview={design.id}
+			onclick={() => pick(design)}
+		>
+			<span class="design-stage" aria-hidden="true" style:--p-bg={design.preview.background} style:--p-surface={design.preview.surface} style:--p-sidebar={design.preview.sidebar} style:--p-accent={design.preview.accent} style:--p-text={design.preview.text} style:--p-muted={design.preview.muted}>
+				<span class="mini-app">
+					<span class="mini-rail">
+						<span class="mini-mark"></span>
+						<span class="mini-compose"></span>
+						<span class="mini-nav"></span>
+						<span class="mini-nav short"></span>
+						<span class="mini-nav"></span>
+					</span>
+					<span class="mini-pane">
+						<span class="mini-search"></span>
+						{#if design.mailboxLayout === 'stack'}
+							<span class="mini-stack">
+								<span class="mini-stack-row">
+									<span class="mini-dot"></span>
+									<span class="mini-stack-lines">
+										<span class="mini-bar"></span>
+										<span class="mini-line"></span>
+									</span>
+								</span>
+								<span class="mini-stack-row">
+									<span class="mini-dot dim"></span>
+									<span class="mini-stack-lines">
+										<span class="mini-bar"></span>
+										<span class="mini-line"></span>
+									</span>
+								</span>
+							</span>
+						{:else}
+							<span class="mini-row"></span>
+							<span class="mini-row faint"></span>
+							<span class="mini-row"></span>
+						{/if}
+					</span>
+				</span>
+			</span>
+
+			<span class="design-meta">
+				<span class="design-name">{design.label}</span>
+				<span class="design-copy">{design.description}</span>
+			</span>
+
+			{#if selected === design.id}
+				<span class="design-check"><Icon name="check-line" size={14} /></span>
+			{/if}
+		</button>
+	{/each}
+</div>
+
+<style>
+	.design-gallery {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(14.5rem, 1fr));
+		gap: 0.75rem;
+		margin-top: 1rem;
+	}
+
+	.design-card {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 0.625rem;
+		border-radius: 0.875rem;
+		text-align: left;
+		box-shadow: inset 0 0 0 1px var(--color-line);
+		transition: box-shadow 0.15s, background 0.15s;
+	}
+
+	.design-card:hover {
+		background: var(--color-surface-muted);
+	}
+
+	.design-card.selected {
+		box-shadow: inset 0 0 0 2px var(--color-accent);
+	}
+
+	.design-stage {
+		display: block;
+		height: 7.25rem;
+		padding: 0.5rem;
+		border-radius: 0.5rem;
+		background: var(--p-bg);
+		overflow: hidden;
+	}
+
+	.mini-app {
+		display: flex;
+		height: 100%;
+		border-radius: 0.375rem;
+		overflow: hidden;
+		box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--p-text) 8%, transparent);
+	}
+
+	.mini-rail {
+		display: flex;
+		flex-direction: column;
+		gap: 0.28rem;
+		width: 2.35rem;
+		padding: 0.4rem 0.3rem;
+		background: var(--p-sidebar);
+	}
+
+	.mini-mark {
+		width: 0.85rem;
+		height: 0.85rem;
+		border-radius: 0.2rem;
+		background: var(--p-accent);
+	}
+
+	.mini-compose {
+		height: 0.55rem;
+		border-radius: 0.15rem;
+		background: var(--p-accent);
+	}
+
+	.mini-nav {
+		height: 0.28rem;
+		border-radius: 9999px;
+		background: var(--p-muted);
+		opacity: 0.7;
+	}
+
+	.mini-nav.short {
+		width: 70%;
+	}
+
+	.mini-pane {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		gap: 0.35rem;
+		padding: 0.4rem 0.45rem;
+		background: var(--p-surface);
+	}
+
+	.mini-search {
+		height: 0.55rem;
+		border-radius: 0.2rem;
+		background: color-mix(in srgb, var(--p-muted) 35%, var(--p-surface));
+	}
+
+	.mini-row,
+	.mini-bar,
+	.mini-line {
+		height: 0.32rem;
+		border-radius: 9999px;
+		background: var(--p-text);
+		opacity: 0.55;
+	}
+
+	.mini-row {
+		width: 100%;
+	}
+
+	.mini-row.faint {
+		width: 78%;
+		opacity: 0.28;
+	}
+
+	.mini-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		margin-top: 0.15rem;
+	}
+
+	.mini-stack-row {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.3rem;
+	}
+
+	.mini-dot {
+		width: 0.45rem;
+		height: 0.45rem;
+		margin-top: 0.05rem;
+		border-radius: 9999px;
+		background: var(--p-accent);
+		flex-shrink: 0;
+	}
+
+	.mini-dot.dim {
+		background: var(--p-muted);
+		opacity: 0.45;
+	}
+
+	.mini-stack-lines {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		gap: 0.18rem;
+	}
+
+	.mini-bar {
+		width: 55%;
+		height: 0.28rem;
+		opacity: 0.9;
+	}
+
+	.mini-line {
+		width: 88%;
+		height: 0.22rem;
+		opacity: 0.35;
+	}
+
+	.design-meta {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		padding: 0 0.125rem 0.125rem;
+	}
+
+	.design-name {
+		font-size: 0.875rem;
+		font-weight: 600;
+		letter-spacing: -0.015em;
+		color: var(--color-text);
+	}
+
+	.design-copy {
+		font-size: 0.75rem;
+		line-height: 1.4;
+		color: var(--color-text-secondary);
+	}
+
+	.design-check {
+		position: absolute;
+		top: 0.75rem;
+		right: 0.75rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.125rem;
+		height: 1.125rem;
+		border-radius: 9999px;
+		color: var(--color-on-accent);
+		background: var(--color-accent);
+	}
+
+	:global([data-design='zero']) .design-card {
+		border-radius: 0.5rem;
+	}
+</style>

--- a/src/lib/components/EmailBody.svelte
+++ b/src/lib/components/EmailBody.svelte
@@ -34,6 +34,7 @@
 		const doc = frame?.contentDocument;
 		if (!doc) return;
 		doc.documentElement.dataset.theme = document.documentElement.dataset.theme ?? 'light';
+		doc.documentElement.dataset.design = document.documentElement.dataset.design ?? 'mail';
 	}
 
 	/**
@@ -81,7 +82,7 @@
 		theme = new MutationObserver(syncTheme);
 		theme.observe(document.documentElement, {
 			attributes: true,
-			attributeFilter: ['data-theme']
+			attributeFilter: ['data-theme', 'data-design']
 		});
 	}
 

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-	import { getActiveDesign } from '$lib/designs';
 	import type { DesignMark } from '$lib/designs';
 
-	// The app mark follows the active design. New marks must be handled
-	// exhaustively here so a catalog addition fails the typecheck.
+	// Both marks stay in the DOM. Visibility follows <html data-design>,
+	// which app.html stamps before paint, so there is no hydration flicker.
 	let {
 		size = 30,
 		class: className = ''
@@ -11,8 +10,6 @@
 		size?: number;
 		class?: string;
 	} = $props();
-
-	const design = $derived(getActiveDesign());
 
 	function markLabel(mark: DesignMark): string {
 		switch (mark) {
@@ -28,44 +25,57 @@
 	}
 </script>
 
-{#if design.mark === 'zero'}
-	<svg
-		class={className}
-		width={size}
-		height={size}
-		viewBox="0 0 191 191"
-		xmlns="http://www.w3.org/2000/svg"
-		role="img"
-		aria-label={markLabel(design.mark)}
+<svg
+	class="logo-mark logo-mark-mail {className}"
+	data-mark="mail"
+	width={size}
+	height={size}
+	viewBox="0 0 64 64"
+	xmlns="http://www.w3.org/2000/svg"
+	role="img"
+	aria-label={markLabel('mail')}
+>
+	<rect width="64" height="64" rx="16.5" fill="#90ac9a" />
+	<g
+		transform="translate(9.7 9.7) scale(1.858)"
+		fill="none"
+		stroke="#363636"
+		stroke-width="2.3"
+		stroke-linecap="round"
+		stroke-linejoin="round"
 	>
-		<!-- Official Mail-0 / 0.email mark -->
-		<path
-			d="M38.125 190.625V152.5H0V38.125H38.125V0H152.5V38.125H190.625V152.5H152.5V190.625H38.125ZM38.125 114.375H76.25V150.975H152.5V76.25H114.375V114.375H76.25V76.25H114.375V39.65H38.125V114.375Z"
-			fill="currentColor"
-		/>
-	</svg>
-{:else}
-	<svg
-		class={className}
-		width={size}
-		height={size}
-		viewBox="0 0 64 64"
-		xmlns="http://www.w3.org/2000/svg"
-		role="img"
-		aria-label={markLabel(design.mark)}
-	>
-		<rect width="64" height="64" rx="16.5" fill="#90ac9a" />
-		<g
-			transform="translate(9.7 9.7) scale(1.858)"
-			fill="none"
-			stroke="#363636"
-			stroke-width="2.3"
-			stroke-linecap="round"
-			stroke-linejoin="round"
-		>
-			<path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
-			<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-			<path d="m16 19 2 2 4-4" />
-		</g>
-	</svg>
-{/if}
+		<path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
+		<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+		<path d="m16 19 2 2 4-4" />
+	</g>
+</svg>
+<svg
+	class="logo-mark logo-mark-zero {className}"
+	data-mark="zero"
+	width={size}
+	height={size}
+	viewBox="0 0 191 191"
+	xmlns="http://www.w3.org/2000/svg"
+	role="img"
+	aria-label={markLabel('zero')}
+>
+	<!-- Official Mail-0 / 0.email mark -->
+	<path
+		d="M38.125 190.625V152.5H0V38.125H38.125V0H152.5V38.125H190.625V152.5H152.5V190.625H38.125ZM38.125 114.375H76.25V150.975H152.5V76.25H114.375V114.375H76.25V76.25H114.375V39.65H38.125V114.375Z"
+		fill="currentColor"
+	/>
+</svg>
+
+<style>
+	.logo-mark-zero {
+		display: none;
+	}
+
+	:global(html[data-design='zero']) .logo-mark-mail {
+		display: none;
+	}
+
+	:global(html[data-design='zero']) .logo-mark-zero {
+		display: block;
+	}
+</style>

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-	// The app mark: a sage tile with a mail-check glyph. Kept inline so it stays
-	// crisp at any size and can be dropped straight into a flex row.
+	import { getActiveDesign } from '$lib/designs';
+	import type { DesignMark } from '$lib/designs';
+
+	// The app mark follows the active design. New marks must be handled
+	// exhaustively here so a catalog addition fails the typecheck.
 	let {
 		size = 30,
 		class: className = ''
@@ -8,28 +11,61 @@
 		size?: number;
 		class?: string;
 	} = $props();
+
+	const design = $derived(getActiveDesign());
+
+	function markLabel(mark: DesignMark): string {
+		switch (mark) {
+			case 'mail':
+				return 'Mail';
+			case 'zero':
+				return '0.email';
+			default: {
+				const _never: never = mark;
+				return _never;
+			}
+		}
+	}
 </script>
 
-<svg
-	class={className}
-	width={size}
-	height={size}
-	viewBox="0 0 64 64"
-	xmlns="http://www.w3.org/2000/svg"
-	role="img"
-	aria-label="Mail"
->
-	<rect width="64" height="64" rx="16.5" fill="#90ac9a" />
-	<g
-		transform="translate(9.7 9.7) scale(1.858)"
-		fill="none"
-		stroke="#363636"
-		stroke-width="2.3"
-		stroke-linecap="round"
-		stroke-linejoin="round"
+{#if design.mark === 'zero'}
+	<svg
+		class={className}
+		width={size}
+		height={size}
+		viewBox="0 0 191 191"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label={markLabel(design.mark)}
 	>
-		<path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
-		<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
-		<path d="m16 19 2 2 4-4" />
-	</g>
-</svg>
+		<!-- Official Mail-0 / 0.email mark -->
+		<path
+			d="M38.125 190.625V152.5H0V38.125H38.125V0H152.5V38.125H190.625V152.5H152.5V190.625H38.125ZM38.125 114.375H76.25V150.975H152.5V76.25H114.375V114.375H76.25V76.25H114.375V39.65H38.125V114.375Z"
+			fill="currentColor"
+		/>
+	</svg>
+{:else}
+	<svg
+		class={className}
+		width={size}
+		height={size}
+		viewBox="0 0 64 64"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label={markLabel(design.mark)}
+	>
+		<rect width="64" height="64" rx="16.5" fill="#90ac9a" />
+		<g
+			transform="translate(9.7 9.7) scale(1.858)"
+			fill="none"
+			stroke="#363636"
+			stroke-width="2.3"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+		>
+			<path d="M22 13V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h8" />
+			<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+			<path d="m16 19 2 2 4-4" />
+		</g>
+	</svg>
+{/if}

--- a/src/lib/components/MailboxView.svelte
+++ b/src/lib/components/MailboxView.svelte
@@ -6,7 +6,6 @@
 	import EmptyState from './EmptyState.svelte';
 	import DeliveryStatus from './DeliveryStatus.svelte';
 	import { formatRelativeDate } from '$lib/utils/date';
-	import { getActiveDesign, type MailboxLayout } from '$lib/designs';
 	import type { MailboxFilters, MailboxPage, MailboxView, ThreadSummary } from '$lib/types';
 
 	let {
@@ -28,19 +27,6 @@
 	};
 
 	const meta = $derived(META[view]);
-	const design = $derived(getActiveDesign());
-
-	function mailboxLayoutAttr(layout: MailboxLayout): MailboxLayout {
-		switch (layout) {
-			case 'row':
-			case 'stack':
-				return layout;
-			default: {
-				const _never: never = layout;
-				return _never;
-			}
-		}
-	}
 
 	// Local copy so stars and reads can flip before the server round trip lands.
 	let items = $state<ThreadSummary[]>([]);
@@ -162,7 +148,7 @@
 	const rangeEnd = $derived(Math.min(mailbox.page * mailbox.pageSize, mailbox.total));
 </script>
 
-<section class="mailbox" data-layout={mailboxLayoutAttr(design.mailboxLayout)}>
+<section class="mailbox">
 	<header class="toolbar">
 		<div class="toolbar-left">
 			<div class="select-all">

--- a/src/lib/components/MailboxView.svelte
+++ b/src/lib/components/MailboxView.svelte
@@ -6,6 +6,7 @@
 	import EmptyState from './EmptyState.svelte';
 	import DeliveryStatus from './DeliveryStatus.svelte';
 	import { formatRelativeDate } from '$lib/utils/date';
+	import { getActiveDesign, type MailboxLayout } from '$lib/designs';
 	import type { MailboxFilters, MailboxPage, MailboxView, ThreadSummary } from '$lib/types';
 
 	let {
@@ -27,6 +28,19 @@
 	};
 
 	const meta = $derived(META[view]);
+	const design = $derived(getActiveDesign());
+
+	function mailboxLayoutAttr(layout: MailboxLayout): MailboxLayout {
+		switch (layout) {
+			case 'row':
+			case 'stack':
+				return layout;
+			default: {
+				const _never: never = layout;
+				return _never;
+			}
+		}
+	}
 
 	// Local copy so stars and reads can flip before the server round trip lands.
 	let items = $state<ThreadSummary[]>([]);
@@ -148,7 +162,7 @@
 	const rangeEnd = $derived(Math.min(mailbox.page * mailbox.pageSize, mailbox.total));
 </script>
 
-<section class="mailbox">
+<section class="mailbox" data-layout={mailboxLayoutAttr(design.mailboxLayout)}>
 	<header class="toolbar">
 		<div class="toolbar-left">
 			<div class="select-all">
@@ -456,6 +470,9 @@
 
 							<span class="sender" title={people(thread)}>
 								<span class="sender-names">{people(thread)}</span>
+								{#if !thread.is_read}
+									<span class="unread-pip" aria-hidden="true"></span>
+								{/if}
 								{#if thread.message_count > 1}
 									<span class="count">{thread.message_count}</span>
 								{/if}
@@ -465,7 +482,7 @@
 							<span class="body">
 								<span class="subject">{thread.subject || '(no subject)'}</span>
 								{#if thread.preview}
-									<span class="preview">— {thread.preview}</span>
+									<span class="preview"><span class="preview-sep">— </span>{thread.preview}</span>
 								{/if}
 							</span>
 
@@ -875,6 +892,10 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.unread-pip {
+		display: none;
 	}
 
 	/* How many messages the conversation holds. */

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { getActiveDesign } from '$lib/designs';
+	import { listDesigns } from '$lib/designs';
 	import Icon from './Icon.svelte';
 	import Logo from './Logo.svelte';
 	import DomainSwitcher from './DomainSwitcher.svelte';
@@ -48,7 +48,7 @@
 		return $page.url.pathname === href || $page.url.pathname.startsWith(`${href}/`);
 	}
 
-	const design = $derived(getActiveDesign());
+	const designs = listDesigns();
 </script>
 
 {#if mobileOpen}
@@ -62,15 +62,23 @@
 
 <aside class="sidebar" class:collapsed class:mobile-open={mobileOpen}>
 	<div class="sidebar-top">
-		<a href="/inbox" class="brand" title={design.brandName}>
-			<Logo size={design.mark === 'zero' ? 22 : 30} />
-			{#if !collapsed}<span class="brand-name">{design.brandName}</span>{/if}
+		<a href="/inbox" class="brand" title="Inbox">
+			<Logo size={30} />
+			{#if !collapsed}
+				{#each designs as item (item.id)}
+					<span class="brand-name" data-for-design={item.id}>{item.brandName}</span>
+				{/each}
+			{/if}
 		</a>
 	</div>
 
-	<a href="/compose" class="new-message" title={design.composeLabel}>
+	<a href="/compose" class="new-message" title="Compose">
 		<Icon name="pencil-line" size={collapsed ? 18 : 16} />
-		{#if !collapsed}<span>{design.composeLabel}</span>{/if}
+		{#if !collapsed}
+			{#each designs as item (item.id)}
+				<span data-for-design={item.id}>{item.composeLabel}</span>
+			{/each}
+		{/if}
 	</a>
 
 	<nav class="nav">

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { getActiveDesign } from '$lib/designs';
 	import Icon from './Icon.svelte';
 	import Logo from './Logo.svelte';
 	import DomainSwitcher from './DomainSwitcher.svelte';
@@ -46,6 +47,8 @@
 	function isActive(href: string): boolean {
 		return $page.url.pathname === href || $page.url.pathname.startsWith(`${href}/`);
 	}
+
+	const design = $derived(getActiveDesign());
 </script>
 
 {#if mobileOpen}
@@ -59,15 +62,15 @@
 
 <aside class="sidebar" class:collapsed class:mobile-open={mobileOpen}>
 	<div class="sidebar-top">
-		<a href="/inbox" class="brand" title="Mail">
-			<Logo size={30} />
-			{#if !collapsed}<span class="brand-name">Mail</span>{/if}
+		<a href="/inbox" class="brand" title={design.brandName}>
+			<Logo size={design.mark === 'zero' ? 22 : 30} />
+			{#if !collapsed}<span class="brand-name">{design.brandName}</span>{/if}
 		</a>
 	</div>
 
-	<a href="/compose" class="new-message" title="New message">
+	<a href="/compose" class="new-message" title={design.composeLabel}>
 		<Icon name="pencil-line" size={collapsed ? 18 : 16} />
-		{#if !collapsed}<span>New message</span>{/if}
+		{#if !collapsed}<span>{design.composeLabel}</span>{/if}
 	</a>
 
 	<nav class="nav">

--- a/src/lib/designs/apply.ts
+++ b/src/lib/designs/apply.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_DESIGN_ID, getDesign, isDesignId } from './catalog';
+
+export const DESIGN_STORAGE_KEY = 'mail:design';
+
+export function readDesignId(): string {
+	if (typeof localStorage === 'undefined') return DEFAULT_DESIGN_ID;
+	const stored = localStorage.getItem(DESIGN_STORAGE_KEY);
+	return isDesignId(stored) ? stored! : DEFAULT_DESIGN_ID;
+}
+
+/**
+ * Stamps the chosen design on <html>. The same thing happens in the inline
+ * script in app.html so the first paint is already correct.
+ */
+export function applyDesign(id: string): void {
+	const design = getDesign(id);
+	document.documentElement.dataset.design = design.id;
+}
+
+export function setDesignPreference(id: string): void {
+	const design = getDesign(id);
+	localStorage.setItem(DESIGN_STORAGE_KEY, design.id);
+	applyDesign(design.id);
+}

--- a/src/lib/designs/apply.ts
+++ b/src/lib/designs/apply.ts
@@ -15,6 +15,7 @@ export function readDesignId(): string {
 export function applyDesign(id: string): void {
 	const design = getDesign(id);
 	document.documentElement.dataset.design = design.id;
+	document.documentElement.dataset.mailboxLayout = design.mailboxLayout;
 }
 
 export function setDesignPreference(id: string): void {

--- a/src/lib/designs/catalog.ts
+++ b/src/lib/designs/catalog.ts
@@ -1,0 +1,25 @@
+import { mailDesign } from './mail';
+import type { DesignDefinition } from './types';
+import { zeroDesign } from './zero';
+
+/**
+ * Registered designs, in the order they appear in Settings.
+ * Append new entries here — do not special-case them in the shell.
+ */
+export const DESIGNS: readonly DesignDefinition[] = [mailDesign, zeroDesign];
+
+export const DEFAULT_DESIGN_ID = mailDesign.id;
+
+const byId = new Map(DESIGNS.map((design) => [design.id, design]));
+
+export function isDesignId(value: string | null | undefined): boolean {
+	return Boolean(value && byId.has(value));
+}
+
+export function getDesign(id: string | null | undefined): DesignDefinition {
+	return (id && byId.get(id)) || mailDesign;
+}
+
+export function listDesigns(): readonly DesignDefinition[] {
+	return DESIGNS;
+}

--- a/src/lib/designs/designs.test.ts
+++ b/src/lib/designs/designs.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, test } from 'node:test';
+import { DEFAULT_DESIGN_ID, DESIGNS, getDesign, isDesignId } from './catalog';
+import { DESIGN_STORAGE_KEY, readDesignId } from './apply';
+import type { DesignDefinition, DesignMark, MailboxLayout } from './types';
+
+const MARKS = new Set<DesignMark>(['mail', 'zero']);
+const LAYOUTS = new Set<MailboxLayout>(['row', 'stack']);
+
+function assertDesign(design: DesignDefinition) {
+	assert.ok(design.id.trim(), 'design id is required');
+	assert.ok(design.label.trim(), `${design.id} needs a label`);
+	assert.ok(design.description.trim(), `${design.id} needs a description`);
+	assert.ok(design.brandName.trim(), `${design.id} needs a brandName`);
+	assert.ok(design.composeLabel.trim(), `${design.id} needs a composeLabel`);
+	assert.ok(MARKS.has(design.mark), `${design.id} has unknown mark ${design.mark}`);
+	assert.ok(LAYOUTS.has(design.mailboxLayout), `${design.id} has unknown mailbox layout`);
+	assert.ok(Array.isArray(design.fonts), `${design.id} fonts must be an array`);
+	for (const font of design.fonts) {
+		assert.ok(font.href.startsWith('https://'), `${design.id} font href must be absolute`);
+		assert.ok(font.family.trim(), `${design.id} font family is required`);
+	}
+
+	for (const key of ['background', 'surface', 'sidebar', 'accent', 'text', 'muted'] as const) {
+		assert.match(
+			design.preview[key],
+			/^(#|hsl\(|rgb\(|oklch\()/i,
+			`${design.id} preview.${key} must be a color`
+		);
+	}
+}
+
+describe('design catalog', () => {
+	test('ships Mail and 0.email, with Mail as the default', () => {
+		assert.equal(DEFAULT_DESIGN_ID, 'mail');
+		assert.ok(DESIGNS.some((design) => design.id === 'mail'));
+		assert.ok(DESIGNS.some((design) => design.id === 'zero'));
+		assert.equal(getDesign('zero').label, '0.email');
+	});
+
+	test('every registered design is complete and uniquely identified', () => {
+		const ids = DESIGNS.map((design) => design.id);
+		assert.equal(ids.length, new Set(ids).size);
+		for (const design of DESIGNS) assertDesign(design);
+	});
+
+	test('unknown ids fall back to Mail so a stale localStorage value cannot crash the shell', () => {
+		assert.equal(isDesignId('zero'), true);
+		assert.equal(isDesignId('mail'), true);
+		assert.equal(isDesignId('does-not-exist'), false);
+		assert.equal(isDesignId(null), false);
+		assert.equal(getDesign('does-not-exist').id, DEFAULT_DESIGN_ID);
+		assert.equal(getDesign(undefined).id, DEFAULT_DESIGN_ID);
+	});
+
+	test('non-default designs ship a CSS file scoped to their data-design attribute', () => {
+		for (const design of DESIGNS) {
+			if (design.id === DEFAULT_DESIGN_ID) continue;
+			const cssPath = fileURLToPath(
+				new URL(`../../styles/designs/${design.id}.css`, import.meta.url)
+			);
+			assert.ok(existsSync(cssPath), `missing src/styles/designs/${design.id}.css`);
+			const css = readFileSync(cssPath, 'utf8');
+			assert.ok(
+				css.includes(`[data-design='${design.id}']`),
+				`${design.id}.css must scope rules to [data-design='${design.id}']`
+			);
+		}
+	});
+
+	test('0.email CSS uses Zero’s compose blue and Geist', () => {
+		const cssPath = fileURLToPath(new URL('../../styles/designs/zero.css', import.meta.url));
+		const css = readFileSync(cssPath, 'utf8');
+		assert.ok(css.includes('#006ffe'));
+		assert.ok(css.includes('Geist Variable'));
+		assert.ok(css.includes('--sidebar-width: 14rem'));
+	});
+
+	test('persists the choice under a stable key', () => {
+		assert.equal(DESIGN_STORAGE_KEY, 'mail:design');
+		if (typeof localStorage === 'undefined') return;
+		localStorage.removeItem(DESIGN_STORAGE_KEY);
+		assert.equal(readDesignId(), DEFAULT_DESIGN_ID);
+		localStorage.setItem(DESIGN_STORAGE_KEY, 'zero');
+		assert.equal(readDesignId(), 'zero');
+		localStorage.setItem(DESIGN_STORAGE_KEY, 'not-a-design');
+		assert.equal(readDesignId(), DEFAULT_DESIGN_ID);
+		localStorage.removeItem(DESIGN_STORAGE_KEY);
+	});
+});

--- a/src/lib/designs/designs.test.ts
+++ b/src/lib/designs/designs.test.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import { DEFAULT_DESIGN_ID, DESIGNS, getDesign, isDesignId } from './catalog';
-import { DESIGN_STORAGE_KEY, readDesignId } from './apply';
+import { applyDesign, DESIGN_STORAGE_KEY, readDesignId } from './apply';
 import type { DesignDefinition, DesignMark, MailboxLayout } from './types';
 
 const MARKS = new Set<DesignMark>(['mail', 'zero']);
@@ -78,6 +78,15 @@ describe('design catalog', () => {
 		assert.ok(css.includes('--sidebar-width: 14rem'));
 	});
 
+	test('stacked mailbox layout is a shared stylesheet, not a one-off in 0.email', () => {
+		const cssPath = fileURLToPath(new URL('../../styles/designs/layouts.css', import.meta.url));
+		assert.ok(existsSync(cssPath));
+		const css = readFileSync(cssPath, 'utf8');
+		assert.ok(css.includes("[data-mailbox-layout='stack']"));
+		assert.equal(getDesign('zero').mailboxLayout, 'stack');
+		assert.equal(getDesign('mail').mailboxLayout, 'row');
+	});
+
 	test('persists the choice under a stable key', () => {
 		assert.equal(DESIGN_STORAGE_KEY, 'mail:design');
 		if (typeof localStorage === 'undefined') return;
@@ -88,5 +97,17 @@ describe('design catalog', () => {
 		localStorage.setItem(DESIGN_STORAGE_KEY, 'not-a-design');
 		assert.equal(readDesignId(), DEFAULT_DESIGN_ID);
 		localStorage.removeItem(DESIGN_STORAGE_KEY);
+	});
+
+	test('applyDesign stamps both the design and the mailbox layout on the root', () => {
+		if (typeof document === 'undefined') return;
+		applyDesign('zero');
+		assert.equal(document.documentElement.dataset.design, 'zero');
+		assert.equal(document.documentElement.dataset.mailboxLayout, 'stack');
+		applyDesign('mail');
+		assert.equal(document.documentElement.dataset.design, 'mail');
+		assert.equal(document.documentElement.dataset.mailboxLayout, 'row');
+		applyDesign('not-a-design');
+		assert.equal(document.documentElement.dataset.design, 'mail');
 	});
 });

--- a/src/lib/designs/index.ts
+++ b/src/lib/designs/index.ts
@@ -1,0 +1,4 @@
+export { DESIGN_STORAGE_KEY, applyDesign, readDesignId, setDesignPreference } from './apply';
+export { DEFAULT_DESIGN_ID, DESIGNS, getDesign, isDesignId, listDesigns } from './catalog';
+export { chooseDesign, getActiveDesign, getActiveDesignId, hydrateDesign } from './state.svelte';
+export type { DesignDefinition, DesignFont, DesignMark, DesignPreview, MailboxLayout } from './types';

--- a/src/lib/designs/mail.ts
+++ b/src/lib/designs/mail.ts
@@ -1,0 +1,20 @@
+import type { DesignDefinition } from './types';
+
+export const mailDesign: DesignDefinition = {
+	id: 'mail',
+	label: 'Mail',
+	description: 'Sage, Inter, and the original QuickMail chrome.',
+	brandName: 'Mail',
+	composeLabel: 'New message',
+	mark: 'mail',
+	mailboxLayout: 'row',
+	fonts: [],
+	preview: {
+		background: '#fafafa',
+		surface: '#ffffff',
+		sidebar: '#ffffff',
+		accent: '#90ac9a',
+		text: '#0a0a0a',
+		muted: '#a3a3a3'
+	}
+};

--- a/src/lib/designs/state.svelte.ts
+++ b/src/lib/designs/state.svelte.ts
@@ -1,16 +1,11 @@
 import { applyDesign, readDesignId, setDesignPreference } from './apply';
-import { DEFAULT_DESIGN_ID, getDesign, isDesignId } from './catalog';
+import { DEFAULT_DESIGN_ID, getDesign } from './catalog';
 import type { DesignDefinition } from './types';
 
-function initialId(): string {
-	if (typeof document !== 'undefined') {
-		const stamped = document.documentElement.dataset.design;
-		if (isDesignId(stamped)) return stamped!;
-	}
-	return DEFAULT_DESIGN_ID;
-}
-
-let designId = $state(initialId());
+// Always start at the default so the SSR markup matches the first client
+// render. app.html already stamped data-design for CSS; this store catches
+// up in hydrateDesign() after mount.
+let designId = $state(DEFAULT_DESIGN_ID);
 
 export function getActiveDesignId(): string {
 	return designId;

--- a/src/lib/designs/state.svelte.ts
+++ b/src/lib/designs/state.svelte.ts
@@ -1,0 +1,32 @@
+import { applyDesign, readDesignId, setDesignPreference } from './apply';
+import { DEFAULT_DESIGN_ID, getDesign, isDesignId } from './catalog';
+import type { DesignDefinition } from './types';
+
+function initialId(): string {
+	if (typeof document !== 'undefined') {
+		const stamped = document.documentElement.dataset.design;
+		if (isDesignId(stamped)) return stamped!;
+	}
+	return DEFAULT_DESIGN_ID;
+}
+
+let designId = $state(initialId());
+
+export function getActiveDesignId(): string {
+	return designId;
+}
+
+export function getActiveDesign(): DesignDefinition {
+	return getDesign(designId);
+}
+
+export function hydrateDesign(): void {
+	designId = readDesignId();
+	applyDesign(designId);
+}
+
+export function chooseDesign(id: string): void {
+	const next = getDesign(id);
+	designId = next.id;
+	setDesignPreference(next.id);
+}

--- a/src/lib/designs/types.ts
+++ b/src/lib/designs/types.ts
@@ -8,6 +8,8 @@
  *     from `layout.css`
  *  4. If you need a new brand mark, add a `DesignMark` variant and handle
  *     it exhaustively in `Logo.svelte`
+ *  5. If `mailboxLayout` is not `row`, add the id to the first-paint map
+ *     in `app.html` so the inbox does not flash the Mail row layout
  *
  * Light / dark / system stay independent — they resolve to `data-theme`
  * and each design supplies tokens for both schemes.

--- a/src/lib/designs/types.ts
+++ b/src/lib/designs/types.ts
@@ -1,0 +1,43 @@
+/**
+ * A visual language the app can wear.
+ *
+ * Add a new design by:
+ *  1. Creating `src/lib/designs/<id>.ts` with a `DesignDefinition`
+ *  2. Creating `src/styles/designs/<id>.css` scoped to `[data-design='<id>']`
+ *  3. Registering the definition in `catalog.ts` and importing the CSS
+ *     from `layout.css`
+ *  4. If you need a new brand mark, add a `DesignMark` variant and handle
+ *     it exhaustively in `Logo.svelte`
+ *
+ * Light / dark / system stay independent — they resolve to `data-theme`
+ * and each design supplies tokens for both schemes.
+ */
+export type DesignMark = 'mail' | 'zero';
+
+export type MailboxLayout = 'row' | 'stack';
+
+export type DesignFont = {
+	href: string;
+	family: string;
+};
+
+export type DesignPreview = {
+	background: string;
+	surface: string;
+	sidebar: string;
+	accent: string;
+	text: string;
+	muted: string;
+};
+
+export type DesignDefinition = {
+	id: string;
+	label: string;
+	description: string;
+	brandName: string;
+	composeLabel: string;
+	mark: DesignMark;
+	mailboxLayout: MailboxLayout;
+	fonts: DesignFont[];
+	preview: DesignPreview;
+};

--- a/src/lib/designs/zero.ts
+++ b/src/lib/designs/zero.ts
@@ -1,0 +1,32 @@
+import type { DesignDefinition } from './types';
+
+/**
+ * 0.email / Zero visual language.
+ *
+ * Tokens and chrome match Mail-0/Zero (`apps/mail/app/globals.css`, sidebar
+ * 14rem, compose `#006FFE`, stacked thread rows) — the same system as
+ * https://www.figma.com/design/m0r4V9eYITRjtCAPvcAbLQ/0.email-design?node-id=5537-2149
+ */
+export const zeroDesign: DesignDefinition = {
+	id: 'zero',
+	label: '0.email',
+	description: 'Geist, ink surfaces, and Zero’s blue compose chip.',
+	brandName: '0.email',
+	composeLabel: 'New Email',
+	mark: 'zero',
+	mailboxLayout: 'stack',
+	fonts: [
+		{
+			href: 'https://cdn.jsdelivr.net/npm/@fontsource-variable/geist@5.2.6/index.min.css',
+			family: 'Geist Variable'
+		}
+	],
+	preview: {
+		background: '#111113',
+		surface: '#19191c',
+		sidebar: '#111113',
+		accent: '#006ffe',
+		text: '#fafafa',
+		muted: '#8c8c8c'
+	}
+};

--- a/src/lib/utils/email-html.ts
+++ b/src/lib/utils/email-html.ts
@@ -124,6 +124,11 @@ blockquote { border-color: rgba(0, 0, 0, 0.12) !important; }
 :root[data-theme='dark'] blockquote { border-color: rgba(255, 255, 255, 0.16) !important; }
 :root[data-theme='dark'] .quote-toggle { color: #a8a8b3; background: #2b2b31; }
 :root[data-theme='dark'] .quote-toggle:hover { background: #3a3a42; }
+
+:root[data-design='zero'] a { color: #0066ff; }
+:root[data-design='zero'][data-theme='dark'] a { color: #437dfb !important; }
+:root[data-design='zero'][data-theme='dark'] .quote-toggle { color: #8c8c8c; background: #26262b; }
+:root[data-design='zero'][data-theme='dark'] .quote-toggle:hover { background: #313136; }
 `;
 
 /**

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,10 +5,12 @@
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import Topbar from '$lib/components/Topbar.svelte';
 	import { disablePushForCurrentAccount } from '$lib/push-client';
+	import { getActiveDesign, hydrateDesign } from '$lib/designs';
 	import { watchSystemTheme } from '$lib/theme';
+	import type { Snippet } from 'svelte';
 	import type { LayoutData } from './$types';
 
-	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
+	let { children, data }: { children: Snippet; data: LayoutData } = $props();
 
 	// Onboarding runs before the user has an address, so the shell would be empty.
 	const showShell = $derived(Boolean(data.user) && $page.url.pathname !== '/onboarding');
@@ -22,6 +24,11 @@
 
 	// app.html already applied the theme; this keeps "System" live afterwards.
 	$effect(() => watchSystemTheme());
+
+	// Same for the visual design — stamp from storage and keep the store in step.
+	$effect(() => hydrateDesign());
+
+	const design = $derived(getActiveDesign());
 
 	// Remember the collapsed sidebar between visits.
 	$effect(() => {
@@ -56,6 +63,9 @@
 		href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
 		rel="stylesheet"
 	/>
+	{#each design.fonts as font (font.href)}
+		<link rel="stylesheet" href={font.href} />
+	{/each}
 </svelte:head>
 
 {#if showShell}

--- a/src/routes/compose/+page.svelte
+++ b/src/routes/compose/+page.svelte
@@ -3,6 +3,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import RichTextEditor from '$lib/components/RichTextEditor.svelte';
 	import AttachmentPicker from '$lib/components/AttachmentPicker.svelte';
+	import { getActiveDesign } from '$lib/designs';
 	import { htmlToPlainText, isHtmlEmpty } from '$lib/utils/html';
 	import type { OutboundAttachmentInput } from '$lib/types';
 	import type { PageData } from './$types';
@@ -35,6 +36,8 @@
 	let savedAt = $state('');
 
 	const isEmpty = $derived(!to.trim() && !subject.trim() && isHtmlEmpty(html));
+	const design = $derived(getActiveDesign());
+	const composeTitle = $derived(draftId ? 'Draft' : design.composeLabel);
 
 	async function saveDraft() {
 		if (savingDraft || isEmpty) return;
@@ -120,13 +123,13 @@
 </script>
 
 <svelte:head>
-	<title>{draftId ? 'Draft' : 'Compose'} — Mail</title>
+	<title>{composeTitle} — {design.brandName}</title>
 </svelte:head>
 
 <form class="compose-page" onsubmit={submit}>
 	<header class="compose-header">
 		<div class="compose-heading">
-			<h1 class="page-title">{draftId ? 'Draft' : 'New message'}</h1>
+			<h1 class="page-title">{composeTitle}</h1>
 			{#if savedAt}<span class="saved">Saved {savedAt}</span>{/if}
 		</div>
 

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -1,6 +1,21 @@
 @import 'tailwindcss';
 @import 'remixicon/fonts/remixicon.css';
+@import '../styles/designs/layouts.css';
 @import '../styles/designs/zero.css';
+
+/*
+ * Copy that belongs to a specific design is rendered for every catalog
+ * entry and shown via [data-for-design]. Default: Mail. Each design CSS
+ * file reveals its own labels.
+ */
+[data-for-design] {
+	display: none;
+}
+
+:root[data-design='mail'] [data-for-design='mail'],
+:root:not([data-design]) [data-for-design='mail'] {
+	display: inline;
+}
 
 @theme {
 	--font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;

--- a/src/routes/layout.css
+++ b/src/routes/layout.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'remixicon/fonts/remixicon.css';
+@import '../styles/designs/zero.css';
 
 @theme {
 	--font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -4,6 +4,7 @@
 	import Check from '$lib/components/Check.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
 	import DesktopNotifications from '$lib/components/DesktopNotifications.svelte';
+	import DesignPicker from '$lib/components/DesignPicker.svelte';
 	import {
 		readThemePreference,
 		setThemePreference,
@@ -300,6 +301,16 @@
 
 	<section class="surface-lg card">
 		<h2><Icon name="contrast-2-line" size={18} /> Appearance</h2>
+
+		<h3 class="appearance-label">Design</h3>
+		<p class="card-hint">
+			A visual language for the whole app. 0.email applies Zero’s inbox; more designs can be
+			registered in the catalog without touching this page.
+		</p>
+		<DesignPicker />
+
+		<h3 class="appearance-label appearance-label-later">Color</h3>
+		<p class="card-hint">Light, dark, or follow the system — applied inside the selected design.</p>
 
 		<div class="theme-options" role="radiogroup" aria-label="Theme">
 			{#each THEME_OPTIONS as option (option.value)}
@@ -663,11 +674,23 @@
 		color: var(--tone-good-fg);
 	}
 
+	.appearance-label {
+		margin-top: 0.25rem;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		letter-spacing: -0.01em;
+		color: var(--color-text);
+	}
+
+	.appearance-label-later {
+		margin-top: 1.5rem;
+	}
+
 	.theme-options {
 		display: grid;
 		grid-template-columns: repeat(3, minmax(0, 1fr));
 		gap: 0.625rem;
-		margin-top: 1rem;
+		margin-top: 0.75rem;
 	}
 
 	.theme-option {

--- a/src/styles/designs/layouts.css
+++ b/src/styles/designs/layouts.css
@@ -1,0 +1,125 @@
+/*
+ * Mailbox layout variants. `applyDesign` (and the app.html boot script)
+ * stamp `data-mailbox-layout` on <html>. Colour and chrome stay in the
+ * design CSS file.
+ */
+
+:root[data-mailbox-layout='stack'] .mailbox .row {
+	display: grid;
+	grid-template-columns: auto auto 1fr;
+	align-items: start;
+	gap: 0.375rem;
+	margin: 0.25rem 0.25rem 0;
+	padding: 0.5rem 0.5rem 0.5rem 0.375rem;
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0.5rem;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .row:last-child {
+	box-shadow: none;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .row.unread {
+	background: transparent;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .row-link {
+	display: grid;
+	grid-template-columns: 2rem minmax(0, 1fr) auto;
+	grid-template-areas:
+		'avatar sender date'
+		'avatar body body';
+	align-items: start;
+	gap: 0.125rem 0.75rem;
+	padding: 0;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .avatar {
+	grid-area: avatar;
+	width: 2rem;
+	height: 2rem;
+	margin-top: 0.125rem;
+	font-size: 0.6875rem;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .sender {
+	grid-area: sender;
+	font-size: 0.875rem;
+	font-weight: 500;
+	text-transform: none;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .row.unread .sender {
+	font-weight: 700;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .unread-pip {
+	display: inline-block;
+	width: 0.5rem;
+	height: 0.5rem;
+	margin-left: 0.125rem;
+	border-radius: 9999px;
+	background: var(--color-accent);
+	flex-shrink: 0;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .date {
+	grid-area: date;
+	font-size: 0.75rem;
+	font-weight: 400;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .body {
+	grid-area: body;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 0.25rem;
+	white-space: normal;
+	overflow: hidden;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .subject,
+:root[data-mailbox-layout='stack'] .mailbox .row.unread .subject {
+	font-size: 0.875rem;
+	font-weight: 400;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .preview-sep {
+	display: none;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .preview {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	white-space: normal;
+	font-size: 0.75rem;
+	line-height: 1.4;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .indicators {
+	display: none;
+}
+
+:root[data-mailbox-layout='stack'] .mailbox .star {
+	margin-top: 0.375rem;
+}
+
+@media (max-width: 780px) {
+	:root[data-mailbox-layout='stack'] .mailbox .row-link {
+		grid-template-columns: minmax(0, 1fr) auto;
+		grid-template-areas:
+			'sender date'
+			'body body';
+	}
+
+	:root[data-mailbox-layout='stack'] .mailbox .avatar {
+		display: none;
+	}
+}

--- a/src/styles/designs/zero.css
+++ b/src/styles/designs/zero.css
@@ -9,6 +9,14 @@
  * (Figma 0.email-design / node 5537-2149).
  */
 
+:root[data-design='zero'] [data-for-design] {
+	display: none;
+}
+
+:root[data-design='zero'] [data-for-design='zero'] {
+	display: inline;
+}
+
 :root[data-design='zero'] {
 	--font-sans: 'Geist Variable', 'Geist', ui-sans-serif, system-ui, sans-serif;
 	--color-bg: hsl(0 0% 100%);
@@ -146,6 +154,11 @@
 	font-size: 0.875rem;
 	font-weight: 600;
 	letter-spacing: -0.03em;
+}
+
+:root[data-design='zero'] .brand .logo-mark {
+	width: 22px;
+	height: 22px;
 }
 
 :root[data-design='zero'] .brand-name {
@@ -305,26 +318,6 @@
 	background: var(--color-bg);
 }
 
-:root[data-design='zero'] .mailbox .row {
-	display: grid;
-	grid-template-columns: auto auto 1fr;
-	align-items: start;
-	gap: 0.375rem;
-	margin: 0.25rem 0.25rem 0;
-	padding: 0.5rem 0.5rem 0.5rem 0.375rem;
-	background: transparent;
-	box-shadow: none;
-	border-radius: 0.5rem;
-}
-
-:root[data-design='zero'] .mailbox .row:last-child {
-	box-shadow: none;
-}
-
-:root[data-design='zero'] .mailbox .row.unread {
-	background: transparent;
-}
-
 :root[data-design='zero'] .mailbox .row:hover,
 :root[data-design='zero'] .mailbox .row.unread:hover {
 	background: var(--zero-row-hover);
@@ -336,97 +329,27 @@
 	box-shadow: inset 0 0 0 1px var(--color-line);
 }
 
-:root[data-design='zero'] .mailbox .row-link {
-	display: grid;
-	grid-template-columns: 2rem minmax(0, 1fr) auto;
-	grid-template-areas:
-		'avatar sender date'
-		'avatar body body';
-	align-items: start;
-	gap: 0.125rem 0.75rem;
-	padding: 0;
-}
-
-:root[data-design='zero'] .mailbox .avatar {
-	grid-area: avatar;
-	width: 2rem;
-	height: 2rem;
-	margin-top: 0.125rem;
-	font-size: 0.6875rem;
-}
-
 :root[data-design='zero'] .mailbox .sender {
-	grid-area: sender;
-	font-size: 0.875rem;
-	font-weight: 500;
-	text-transform: none;
 	color: var(--color-text);
 }
 
-:root[data-design='zero'] .mailbox .row.unread .sender {
-	font-weight: 700;
-}
-
 :root[data-design='zero'] .mailbox .unread-pip {
-	display: inline-block;
-	width: 0.5rem;
-	height: 0.5rem;
-	margin-left: 0.125rem;
-	border-radius: 9999px;
 	background: #006ffe;
-	flex-shrink: 0;
 }
 
-:root[data-design='zero'] .mailbox .date {
-	grid-area: date;
-	font-size: 0.75rem;
-	font-weight: 400;
+:root[data-design='zero'] .mailbox .date,
+:root[data-design='zero'] .mailbox .row.unread .date {
 	color: var(--zero-preview);
 	opacity: 0.7;
 }
 
-:root[data-design='zero'] .mailbox .row.unread .date {
-	font-weight: 400;
-	color: var(--zero-preview);
-}
-
-:root[data-design='zero'] .mailbox .body {
-	grid-area: body;
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-	gap: 0.25rem;
-	white-space: normal;
-	overflow: hidden;
-}
-
 :root[data-design='zero'] .mailbox .subject,
 :root[data-design='zero'] .mailbox .row.unread .subject {
-	font-size: 0.875rem;
-	font-weight: 400;
 	color: var(--zero-preview);
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
-:root[data-design='zero'] .mailbox .preview-sep {
-	display: none;
 }
 
 :root[data-design='zero'] .mailbox .preview {
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
-	-webkit-line-clamp: 2;
-	line-clamp: 2;
-	white-space: normal;
-	font-size: 0.75rem;
-	line-height: 1.4;
 	color: var(--color-text-secondary);
-}
-
-:root[data-design='zero'] .mailbox .indicators {
-	display: none;
 }
 
 :root[data-design='zero'] .mailbox .row-actions {
@@ -435,7 +358,6 @@
 }
 
 :root[data-design='zero'] .mailbox .star {
-	margin-top: 0.375rem;
 	color: var(--zero-icon);
 }
 
@@ -448,19 +370,6 @@
 	margin: 0 0.5rem 0.25rem;
 	border-radius: 0.5rem;
 	box-shadow: none;
-}
-
-@media (max-width: 780px) {
-	:root[data-design='zero'] .mailbox .row-link {
-		grid-template-columns: minmax(0, 1fr) auto;
-		grid-template-areas:
-			'sender date'
-			'body body';
-	}
-
-	:root[data-design='zero'] .mailbox .avatar {
-		display: none;
-	}
 }
 
 :root[data-design='zero'] .empty-icon {

--- a/src/styles/designs/zero.css
+++ b/src/styles/designs/zero.css
@@ -1,0 +1,480 @@
+/*
+ * 0.email / Zero.
+ *
+ * Scoped entirely to [data-design='zero'] so a third design can land as
+ * another file without touching this one.
+ *
+ * Colour, type, and radius come from Mail-0/Zero `globals.css`. Compose
+ * chrome, sidebar width, and stacked thread rows match the same source
+ * (Figma 0.email-design / node 5537-2149).
+ */
+
+:root[data-design='zero'] {
+	--font-sans: 'Geist Variable', 'Geist', ui-sans-serif, system-ui, sans-serif;
+	--color-bg: hsl(0 0% 100%);
+	--color-surface: hsl(0 0% 100%);
+	--color-surface-muted: #f5f5f5;
+	--color-surface-hover: hsl(240 4.8% 95.9%);
+	--color-text: hsl(240 10% 3.9%);
+	--color-text-secondary: hsl(240 3.8% 46.1%);
+	--color-muted: #8c8c8c;
+	--color-accent: #006ffe;
+	--color-accent-hover: #0056cc;
+	--color-accent-soft: rgba(0, 111, 254, 0.1);
+	--color-accent-text: #0066ff;
+	--color-on-accent: #ffffff;
+	--color-line: hsl(240 5.9% 90%);
+	--color-focus-line: hsl(240 10% 3.9%);
+	--color-focus-halo: rgba(0, 111, 254, 0.16);
+	--color-scrim: rgba(0, 0, 0, 0.25);
+	--color-danger: hsl(0 84.2% 60.2%);
+	--color-star: #eab308;
+	--tone-good-fg: #14532d;
+	--tone-good-bg: #dcfce7;
+	--tone-warn-fg: #7c2d12;
+	--tone-warn-bg: #ffedd5;
+	--tone-bad-fg: #7f1d1d;
+	--tone-bad-bg: #fee2e2;
+	--tone-notice-line: #fed7aa;
+	--shadow-xs: none;
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+	--shadow-md: 0 8px 24px rgba(0, 0, 0, 0.12);
+	--shadow-header: 0 1px 0 hsl(240 5.9% 90%);
+	--sidebar-width: 14rem;
+	--sidebar-width-collapsed: 3rem;
+	--topbar-height: 3.25rem;
+	--zero-row-hover: #f5f5f5;
+	--zero-preview: #8c8c8c;
+	--zero-icon: #6d6d6d;
+	--radius-control: 0.5rem;
+}
+
+:root[data-design='zero'][data-theme='dark'] {
+	color-scheme: dark;
+	--color-bg: hsl(240 3.9% 7%);
+	--color-surface: hsl(240 3.7% 10.2%);
+	--color-surface-muted: hsl(240 3.7% 15.9%);
+	--color-surface-hover: hsl(240 5.9% 10%);
+	--color-text: hsl(0 0% 98%);
+	--color-text-secondary: hsl(240 5% 64.9%);
+	--color-muted: #8c8c8c;
+	--color-accent: #006ffe;
+	--color-accent-hover: #0056cc;
+	--color-accent-soft: rgba(0, 111, 254, 0.14);
+	--color-accent-text: #437dfb;
+	--color-on-accent: #ffffff;
+	--color-line: hsl(240 3.7% 20%);
+	--color-focus-line: hsl(240 4.9% 83.9%);
+	--color-focus-halo: rgba(0, 111, 254, 0.22);
+	--color-scrim: rgba(0, 0, 0, 0.6);
+	--color-danger: hsl(0 62.8% 50%);
+	--color-star: #facc15;
+	--tone-good-fg: #86efac;
+	--tone-good-bg: rgba(34, 197, 94, 0.16);
+	--tone-warn-fg: #fdba74;
+	--tone-warn-bg: rgba(249, 115, 22, 0.16);
+	--tone-bad-fg: #fca5a5;
+	--tone-bad-bg: rgba(239, 68, 68, 0.16);
+	--tone-notice-line: rgba(249, 115, 22, 0.45);
+	--shadow-xs: none;
+	--shadow-sm: none;
+	--shadow-md: 0 8px 24px rgba(0, 0, 0, 0.5);
+	--shadow-header: 0 1px 0 hsl(240 3.7% 15.9%);
+	--zero-row-hover: rgba(250, 250, 250, 0.05);
+	--zero-preview: #8c8c8c;
+	--zero-icon: #898989;
+}
+
+:root[data-design='zero'] body {
+	font-feature-settings: 'ss01' on, 'cv01' on;
+	letter-spacing: -0.011em;
+}
+
+:root[data-design='zero'] .surface,
+:root[data-design='zero'] .surface-lg,
+:root[data-design='zero'] .auth-card {
+	border-radius: var(--radius-control);
+	box-shadow: none;
+	border: 1px solid var(--color-line);
+}
+
+:root[data-design='zero'] .btn-primary,
+:root[data-design='zero'] .btn-ghost,
+:root[data-design='zero'] .icon-btn,
+:root[data-design='zero'] .auth-input {
+	border-radius: var(--radius-control);
+}
+
+:root[data-design='zero'] .btn-primary {
+	height: 2rem;
+	padding: 0 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	box-shadow: none;
+}
+
+:root[data-design='zero'] .app-main {
+	padding: 0.75rem 0.75rem 1.5rem;
+}
+
+:root[data-design='zero'] .sidebar {
+	width: var(--sidebar-width);
+	padding: 0.625rem 0.75rem 0.5rem;
+	background: var(--color-bg);
+	box-shadow: inset -1px 0 0 var(--color-line);
+}
+
+:root[data-design='zero'] .sidebar.collapsed {
+	width: var(--sidebar-width-collapsed);
+	padding: 0.5rem 0.375rem;
+}
+
+:root[data-design='zero'] .sidebar.collapsed .brand {
+	justify-content: center;
+}
+
+:root[data-design='zero'] .sidebar.collapsed .new-message {
+	padding: 0;
+}
+
+:root[data-design='zero'] .sidebar-top {
+	padding: 0.25rem 0.125rem 0.5rem;
+}
+
+:root[data-design='zero'] .brand {
+	gap: 0.5rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	letter-spacing: -0.03em;
+}
+
+:root[data-design='zero'] .brand-name {
+	font-variant-numeric: tabular-nums;
+}
+
+:root[data-design='zero'] .new-message {
+	height: 2rem;
+	margin-bottom: 1.25rem;
+	border-radius: 0.5rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1;
+	color: #ffffff;
+	background: #006ffe;
+	box-shadow: none;
+	border: none;
+}
+
+:root[data-design='zero'] .new-message:hover {
+	background: #0056cc;
+}
+
+:root[data-design='zero'][data-theme='light'] .new-message {
+	border: 1px solid #e5e7eb;
+}
+
+:root[data-design='zero'] .nav {
+	gap: 0.125rem;
+}
+
+:root[data-design='zero'] .nav-link {
+	height: 2rem;
+	padding: 0 0.5rem;
+	border-radius: 0.5rem;
+	font-size: 0.875rem;
+	color: var(--color-text-secondary);
+}
+
+:root[data-design='zero'] .nav-link:hover {
+	background: var(--color-surface-muted);
+	color: var(--color-text);
+}
+
+:root[data-design='zero'] .nav-link.active {
+	background: var(--color-surface-muted);
+	color: var(--color-text);
+	font-weight: 500;
+}
+
+:root[data-design='zero'] .nav-badge {
+	min-width: 1.125rem;
+	padding: 0.0625rem 0.3125rem;
+	border-radius: 0.375rem;
+	font-size: 0.6875rem;
+	font-weight: 500;
+	color: var(--color-text);
+	background: var(--color-surface-hover);
+}
+
+:root[data-design='zero'] .nav-dot {
+	background: #006ffe;
+}
+
+:root[data-design='zero'] .nav-tools {
+	margin-top: 0.5rem;
+	padding-top: 0.5rem;
+}
+
+:root[data-design='zero'] .section-title {
+	letter-spacing: 0.04em;
+	font-weight: 500;
+}
+
+:root[data-design='zero'] .collapse-btn {
+	width: 1.75rem;
+	height: 1.75rem;
+	border-radius: 0.5rem;
+	background: transparent;
+	color: var(--zero-icon);
+}
+
+:root[data-design='zero'] .topbar {
+	height: var(--topbar-height);
+	padding: 0 0.75rem;
+	background: var(--color-bg);
+	box-shadow: inset 0 -1px 0 var(--color-line);
+}
+
+:root[data-design='zero'] .search {
+	height: 2rem;
+	max-width: 36rem;
+	padding: 0 0.625rem;
+	border-radius: 0.5rem;
+	background: var(--color-surface-muted);
+	color: var(--zero-icon);
+	box-shadow: none;
+}
+
+:root[data-design='zero'] .search:focus-within {
+	background: var(--color-surface);
+	box-shadow: inset 0 0 0 1px var(--color-line);
+}
+
+:root[data-design='zero'] .account-trigger {
+	border-radius: 0.5rem;
+	padding: 0.125rem 0.25rem 0.125rem 0.5rem;
+}
+
+:root[data-design='zero'] .avatar {
+	border-radius: 9999px;
+	background: var(--color-surface-muted);
+}
+
+:root[data-design='zero'] .menu {
+	border-radius: 0.5rem;
+	box-shadow: var(--shadow-md);
+	border: 1px solid var(--color-line);
+}
+
+:root[data-design='zero'] .mailbox {
+	background: var(--color-bg);
+	border-radius: 0;
+	box-shadow: none;
+	border: none;
+}
+
+:root[data-design='zero'] .mailbox .toolbar {
+	padding: 0.5rem 0.75rem;
+	box-shadow: none;
+}
+
+:root[data-design='zero'] .mailbox .title {
+	font-size: 1rem;
+	font-weight: 600;
+	letter-spacing: -0.02em;
+}
+
+:root[data-design='zero'] .mailbox .pill {
+	height: 1.75rem;
+	border-radius: 0.5rem;
+	box-shadow: inset 0 0 0 1px var(--color-line);
+}
+
+:root[data-design='zero'] .mailbox .pill-on {
+	background: var(--color-surface-muted);
+	box-shadow: none;
+}
+
+:root[data-design='zero'] .mailbox .tool-btn,
+:root[data-design='zero'] .mailbox .pager-btn {
+	border-radius: 0.5rem;
+}
+
+:root[data-design='zero'] .mailbox .list {
+	padding: 0 0.25rem 0.5rem;
+	background: var(--color-bg);
+}
+
+:root[data-design='zero'] .mailbox .row {
+	display: grid;
+	grid-template-columns: auto auto 1fr;
+	align-items: start;
+	gap: 0.375rem;
+	margin: 0.25rem 0.25rem 0;
+	padding: 0.5rem 0.5rem 0.5rem 0.375rem;
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0.5rem;
+}
+
+:root[data-design='zero'] .mailbox .row:last-child {
+	box-shadow: none;
+}
+
+:root[data-design='zero'] .mailbox .row.unread {
+	background: transparent;
+}
+
+:root[data-design='zero'] .mailbox .row:hover,
+:root[data-design='zero'] .mailbox .row.unread:hover {
+	background: var(--zero-row-hover);
+}
+
+:root[data-design='zero'] .mailbox .row.checked,
+:root[data-design='zero'] .mailbox .row.checked:hover {
+	background: var(--color-accent-soft);
+	box-shadow: inset 0 0 0 1px var(--color-line);
+}
+
+:root[data-design='zero'] .mailbox .row-link {
+	display: grid;
+	grid-template-columns: 2rem minmax(0, 1fr) auto;
+	grid-template-areas:
+		'avatar sender date'
+		'avatar body body';
+	align-items: start;
+	gap: 0.125rem 0.75rem;
+	padding: 0;
+}
+
+:root[data-design='zero'] .mailbox .avatar {
+	grid-area: avatar;
+	width: 2rem;
+	height: 2rem;
+	margin-top: 0.125rem;
+	font-size: 0.6875rem;
+}
+
+:root[data-design='zero'] .mailbox .sender {
+	grid-area: sender;
+	font-size: 0.875rem;
+	font-weight: 500;
+	text-transform: none;
+	color: var(--color-text);
+}
+
+:root[data-design='zero'] .mailbox .row.unread .sender {
+	font-weight: 700;
+}
+
+:root[data-design='zero'] .mailbox .unread-pip {
+	display: inline-block;
+	width: 0.5rem;
+	height: 0.5rem;
+	margin-left: 0.125rem;
+	border-radius: 9999px;
+	background: #006ffe;
+	flex-shrink: 0;
+}
+
+:root[data-design='zero'] .mailbox .date {
+	grid-area: date;
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--zero-preview);
+	opacity: 0.7;
+}
+
+:root[data-design='zero'] .mailbox .row.unread .date {
+	font-weight: 400;
+	color: var(--zero-preview);
+}
+
+:root[data-design='zero'] .mailbox .body {
+	grid-area: body;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 0.25rem;
+	white-space: normal;
+	overflow: hidden;
+}
+
+:root[data-design='zero'] .mailbox .subject,
+:root[data-design='zero'] .mailbox .row.unread .subject {
+	font-size: 0.875rem;
+	font-weight: 400;
+	color: var(--zero-preview);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+:root[data-design='zero'] .mailbox .preview-sep {
+	display: none;
+}
+
+:root[data-design='zero'] .mailbox .preview {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	line-clamp: 2;
+	white-space: normal;
+	font-size: 0.75rem;
+	line-height: 1.4;
+	color: var(--color-text-secondary);
+}
+
+:root[data-design='zero'] .mailbox .indicators {
+	display: none;
+}
+
+:root[data-design='zero'] .mailbox .row-actions {
+	background: linear-gradient(to right, transparent, var(--zero-row-hover) 1.25rem);
+	border-radius: 0.5rem;
+}
+
+:root[data-design='zero'] .mailbox .star {
+	margin-top: 0.375rem;
+	color: var(--zero-icon);
+}
+
+:root[data-design='zero'] .mailbox .list-foot {
+	box-shadow: none;
+	padding: 0.5rem 0.875rem 0.75rem;
+}
+
+:root[data-design='zero'] .mailbox .search-note {
+	margin: 0 0.5rem 0.25rem;
+	border-radius: 0.5rem;
+	box-shadow: none;
+}
+
+@media (max-width: 780px) {
+	:root[data-design='zero'] .mailbox .row-link {
+		grid-template-columns: minmax(0, 1fr) auto;
+		grid-template-areas:
+			'sender date'
+			'body body';
+	}
+
+	:root[data-design='zero'] .mailbox .avatar {
+		display: none;
+	}
+}
+
+:root[data-design='zero'] .empty-icon {
+	border-radius: 0.5rem;
+	box-shadow: none;
+	border: 1px solid var(--color-line);
+	background: var(--color-surface-muted);
+}
+
+:root[data-design='zero'] .theme-option,
+:root[data-design='zero'] .theme-preview {
+	border-radius: 0.5rem;
+}
+
+:root[data-design='zero'] .reply-prompt {
+	border-radius: 0.5rem;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Settings → Appearance now has a **Design** gallery, separate from light/dark/system. Choosing **0.email** restyles the whole app to Zero’s inbox language. Choosing **Mail** keeps the current sage/Inter chrome.

The picker is a catalog, not a one-off theme flag. A later design is: definition + scoped CSS + one registry line.

## How to add another design

1. `src/lib/designs/<id>.ts` — `DesignDefinition` (label, brand, compose copy, mark, mailbox layout, fonts, preview swatches)
2. `src/styles/designs/<id>.css` — tokens and chrome under `[data-design='<id>']`
3. Register in `src/lib/designs/catalog.ts` and `@import` the CSS from `layout.css`
4. New brand marks go on the `DesignMark` union and are handled exhaustively in `Logo.svelte`
5. If the inbox is not the Mail row layout, add the id to the first-paint map in `app.html`

The choice is stored as `mail:design` and stamped on `<html data-design>` (and `data-mailbox-layout`) before paint, same pattern as theme.

## 0.email fidelity

Figma MCP cannot authenticate in this cloud environment (desktop-only login). Tokens and chrome were taken from the same system the Figma file documents — Mail-0/Zero:

- Geist, 8px radius, 14rem / 3rem sidebar
- Compose chip `#006FFE` / hover `#0056CC`, copy “New Email”
- Official 0 mark (CSS-toggled so SSR cannot flash the Mail tile)
- Stacked inbox rows (shared `layouts.css`), unread pip `#006FFE`, preview `#8C8C8C`
- Light and dark palettes from `apps/mail/app/globals.css`

Design: [0.email-design / 5537-2149](https://www.figma.com/design/m0r4V9eYITRjtCAPvcAbLQ/0.email-design?node-id=5537-2149)

## Verify

- `bun test` — 43 pass, including `src/lib/designs/designs.test.ts`
- `bun run check` — 0 errors (existing autofocus a11y warning only)
- Settings → pick **0.email**, then **Mail**; reload to confirm no flash
- Inbox, compose, login, and a thread under both designs and both color schemes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f9e7eaf-2f64-44bd-8c44-376c65ab4d86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f9e7eaf-2f64-44bd-8c44-376c65ab4d86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

