### PR TITLE
Prefer wrangler.deploy.jsonc for syncing a personal mailbox to latest QuickMail

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to .env (gitignored) or paste values in the Deploy to Cloudflare form.
+# These are Wrangler / Workers Builds variables, not Worker runtime secrets.
+#
+# Required when your Cloudflare login or API token can see more than one account.
+# Dashboard sidebar, or: wrangler whoami
+# https://developers.cloudflare.com/fundamentals/account/find-account-and-zone-ids/
+# Do not put a personal account id in wrangler.jsonc if you publish the repo.
+CLOUDFLARE_ACCOUNT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .wrangler
 worker-wrapper.js
 wrangler.deploy.jsonc
+!wrangler.deploy.jsonc.example
 /.svelte-kit
 /build
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ bun run setup
 bash scripts/setup.sh
 ```
 
+The button deploys to **your** Cloudflare account. If the form asks for
+`CLOUDFLARE_ACCOUNT_ID` (typical when your login can see more than one
+account), paste the ID from the dashboard sidebar — `wrangler whoami` also
+prints it. Prefer `.env` or `wrangler.deploy.jsonc` over committing that ID
+into the public `wrangler.jsonc`.
+
 The wizard creates the D1 database and R2 bucket, writes config, and onboards
 your domain. Budget about 30 minutes — most of that is waiting on DNS.
 
@@ -65,8 +71,30 @@ bun install          # or: npm install
 bunx wrangler login
 ```
 
+If `wrangler whoami` lists more than one account, copy `.env.example` to `.env`
+and set `CLOUDFLARE_ACCOUNT_ID` (dashboard sidebar). The setup wizard prompts
+for this when it cannot pick an account automatically.
+
 Cloudflare Email Sending needs **Wrangler 4.123+** (older versions hit a
 removed API path and 404).
+
+### Keeping a personal deploy in sync
+
+If you run your own mailbox from this repo (or a private sibling checkout),
+put real Cloudflare bindings in `wrangler.deploy.jsonc` — copy
+`wrangler.deploy.jsonc.example` and fill in account / D1 / route values.
+That file is gitignored. `bun run deploy`, `bun run db:migrate:remote`, and
+`bun run preview` pick it up automatically, so you can `git pull` the latest
+QuickMail without committing personal hostnames or ids into the template.
+
+```bash
+cp wrangler.deploy.jsonc.example wrangler.deploy.jsonc
+# edit database_id, account_id, routes, EMAIL_PROVIDER, …
+bun run db:migrate:remote
+bun run deploy
+```
+
+The setup wizard writes the same private file for you.
 
 ### 2. Create D1 and R2
 
@@ -75,8 +103,9 @@ bunx wrangler d1 create quickmail
 bunx wrangler r2 bucket create quickmail-attachments
 ```
 
-Copy the printed `database_id` into `wrangler.jsonc` (replacing
-`REPLACE_WITH_YOUR_D1_DATABASE_ID`), then run migrations:
+Copy the printed `database_id` into `wrangler.deploy.jsonc` (preferred; see
+`wrangler.deploy.jsonc.example`) or `wrangler.jsonc`, replacing
+`REPLACE_WITH_YOUR_D1_DATABASE_ID`, then run migrations:
 
 ```bash
 bun run db:migrate:remote
@@ -290,8 +319,9 @@ migrations/          D1 schema, applied in order
 | Mail never arrives (Cloudflare) | Apex MX must be Cloudflare Routing, catch-all must target this Worker, `EMAIL_PROVIDER=cloudflare`, Worker must be deployed |
 | Webhook 401 | `RESEND_WEBHOOK_SECRET` mismatch — secrets are shown once; recreate the webhook |
 | Webhook 500 | `bunx wrangler tail` |
-| Attachments missing | R2 bucket must exist and match `bucket_name` in `wrangler.jsonc` |
-| `database_id` errors on deploy | Paste the id from `wrangler d1 create` into `wrangler.jsonc` |
+| Attachments missing | R2 bucket must exist and match `bucket_name` in `wrangler.jsonc` (or `wrangler.deploy.jsonc`) |
+| `database_id` errors on deploy | Paste the id from `wrangler d1 create` into `wrangler.deploy.jsonc` (preferred) or `wrangler.jsonc` |
+| Deploy to Cloudflare / wrangler: more than one account, or no account id | Set `CLOUDFLARE_ACCOUNT_ID` in `.env` (see `.env.example`) or `account_id` in `wrangler.deploy.jsonc` — do not commit a personal id in the public template |
 | Setup shows no Cloudflare domains | Set `CLOUDFLARE_MAIL_DOMAINS` and `EMAIL_PROVIDER=cloudflare`, restart the dev server |
 
 ## License

--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && bun scripts/wrap-cloudflare-worker.mjs",
-		"preview": "bun run build && wrangler dev",
+		"preview": "bun run build && node scripts/wrangler-with-env.mjs dev",
 		"setup": "node scripts/setup.mjs",
-		"deploy": "bun run build && wrangler deploy",
-		"db:migrate:local": "wrangler d1 migrations apply quickmail --local",
-		"db:migrate:remote": "wrangler d1 migrations apply quickmail --remote",
+		"deploy": "bun run build && node scripts/wrangler-with-env.mjs deploy",
+		"db:migrate:local": "node scripts/wrangler-with-env.mjs d1 migrations apply quickmail --local",
+		"db:migrate:remote": "node scripts/wrangler-with-env.mjs d1 migrations apply quickmail --remote",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:clean": "bun scripts/check-template-clean.mjs",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"cf-typegen": "wrangler types",
+		"cf-typegen": "node scripts/wrangler-with-env.mjs types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts scripts/cloudflare-env.test.ts scripts/wrangler-config.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",
@@ -65,6 +65,9 @@
 			},
 			"RESEND_WEBHOOK_SECRET": {
 				"description": "Only for `EMAIL_PROVIDER=resend`: shown once when you create the webhook at [Resend webhooks](https://resend.com/webhooks). Keep the placeholder if using Cloudflare Email."
+			},
+			"CLOUDFLARE_ACCOUNT_ID": {
+				"description": "Your Cloudflare account ID (dashboard sidebar, or `wrangler whoami`). Required if your login can see more than one account. Leave empty only when you have a single account. Prefer `.env` or `wrangler.deploy.jsonc` — do not commit this into the public `wrangler.jsonc`."
 			}
 		}
 	}

--- a/scripts/check-template-clean.mjs
+++ b/scripts/check-template-clean.mjs
@@ -24,6 +24,7 @@ const FORBIDDEN = [
 	{ label: 'Cloudflare API token', pattern: /\bCLOUDFLARE_API_TOKEN\s*[:=]\s*["']?[A-Za-z0-9_-]{30,}/ },
 	{ label: 'Private key block', pattern: /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/ },
 	{ label: 'Live Cloudflare account id', pattern: /^\s*"account_id"\s*:\s*"[0-9a-f]{32}"/m },
+	{ label: 'Live Cloudflare account id in env', pattern: /^CLOUDFLARE_ACCOUNT_ID\s*=\s*[0-9a-f]{32}\s*$/m },
 	{ label: 'Maintainer infrastructure name', pattern: /divinprince[.-]/i }
 ];
 
@@ -94,7 +95,13 @@ if (!existsSync(wranglerPath)) {
 }
 
 // 4. The licence has to ship with the code.
-for (const required of ['LICENSE.md', 'README.md', '.dev.vars.example']) {
+for (const required of [
+	'LICENSE.md',
+	'README.md',
+	'.dev.vars.example',
+	'.env.example',
+	'wrangler.deploy.jsonc.example'
+]) {
 	if (!tracked.includes(required)) {
 		fail(`${required} is missing from the repository`);
 	}

--- a/scripts/cloudflare-env.mjs
+++ b/scripts/cloudflare-env.mjs
@@ -1,0 +1,87 @@
+/**
+ * Cloudflare account selection for setup and deploy.
+ *
+ * Wrangler reads CLOUDFLARE_ACCOUNT_ID from the process environment (not from
+ * Worker `.dev.vars`). Setup writes that id to `.env`; this module loads it
+ * back so later wrangler commands see it. A personal account id must never be
+ * committed in wrangler.jsonc.
+ */
+export const CLOUDFLARE_AUTH_KEYS = [
+	'CLOUDFLARE_ACCOUNT_ID',
+	'CLOUDFLARE_API_TOKEN',
+	'CLOUDFLARE_API_KEY',
+	'CLOUDFLARE_EMAIL'
+];
+
+export function isCloudflareAccountId(value) {
+	return typeof value === 'string' && /^[0-9a-f]{32}$/i.test(value.trim());
+}
+
+export function parseDotEnv(text) {
+	const out = {};
+	if (!text) return out;
+
+	for (const raw of text.split(/\r?\n/)) {
+		const line = raw.trim();
+		if (!line || line.startsWith('#')) continue;
+		const stripped = line.startsWith('export ') ? line.slice('export '.length).trim() : line;
+		const eq = stripped.indexOf('=');
+		if (eq <= 0) continue;
+		const key = stripped.slice(0, eq).trim();
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+		let value = stripped.slice(eq + 1).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		} else {
+			const comment = value.indexOf(' #');
+			if (comment !== -1) value = value.slice(0, comment).trim();
+		}
+		out[key] = value;
+	}
+	return out;
+}
+
+export function cloudflareAuthFromDotEnv(text) {
+	const parsed = parseDotEnv(text);
+	const out = {};
+	for (const key of CLOUDFLARE_AUTH_KEYS) {
+		const value = parsed[key];
+		if (value) out[key] = value;
+	}
+	return out;
+}
+
+/**
+ * Copy Cloudflare auth vars from dotenv text into `env` without overwriting
+ * values already set (CI / Workers Builds / the user's shell win).
+ */
+export function applyCloudflareAuthEnv(env, texts) {
+	const merged = {};
+	for (const text of texts) {
+		Object.assign(merged, cloudflareAuthFromDotEnv(text));
+	}
+	for (const [key, value] of Object.entries(merged)) {
+		if (!env[key] && value) env[key] = value;
+	}
+	return env;
+}
+
+export function setAccountIdInWrangler(source, accountId) {
+	if (!isCloudflareAccountId(accountId)) {
+		throw new Error('Invalid Cloudflare account id (expected 32 hex characters).');
+	}
+	const id = accountId.trim().toLowerCase();
+	if (/^\s*"account_id"\s*:/m.test(source)) {
+		return source.replace(/^(\s*"account_id"\s*:\s*")[^"]*(")/m, `$1${id}$2`);
+	}
+	if (/^\s*\/\/\s*"account_id"\s*:/m.test(source)) {
+		return source.replace(/^\s*\/\/\s*"account_id"\s*:\s*"[^"]*"\s*,?\s*$/m, `\t"account_id": "${id}",`);
+	}
+	if (/"workers_dev"\s*:/.test(source)) {
+		return source.replace(/("workers_dev"\s*:\s*(?:true|false),?\n)/, `$1\n\t"account_id": "${id}",\n`);
+	}
+	return `\t"account_id": "${id}",\n${source}`;
+}

--- a/scripts/cloudflare-env.test.ts
+++ b/scripts/cloudflare-env.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	applyCloudflareAuthEnv,
+	cloudflareAuthFromDotEnv,
+	isCloudflareAccountId,
+	parseDotEnv,
+	setAccountIdInWrangler
+} from './cloudflare-env.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const SAMPLE_ID = '0123456789abcdef0123456789abcdef';
+
+describe('Cloudflare account id', () => {
+	test('accepts a 32-character hex id and rejects placeholders', () => {
+		assert.equal(isCloudflareAccountId(SAMPLE_ID), true);
+		assert.equal(isCloudflareAccountId(SAMPLE_ID.toUpperCase()), true);
+		assert.equal(isCloudflareAccountId(''), false);
+		assert.equal(isCloudflareAccountId('REPLACE_WITH_YOUR_ACCOUNT_ID'), false);
+		assert.equal(isCloudflareAccountId('${CLOUDFLARE_ACCOUNT_ID}'), false);
+	});
+});
+
+describe('dotenv parsing', () => {
+	test('reads Cloudflare auth keys and ignores worker secrets', () => {
+		const parsed = parseDotEnv(`
+# comment
+CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID} # sidebar
+export CLOUDFLARE_API_TOKEN="tok_abc"
+RESEND_API_KEY=re_not_for_wrangler
+`);
+		assert.equal(parsed.CLOUDFLARE_ACCOUNT_ID, SAMPLE_ID);
+		assert.equal(parsed.CLOUDFLARE_API_TOKEN, 'tok_abc');
+		assert.equal(parsed.RESEND_API_KEY, 're_not_for_wrangler');
+
+		const auth = cloudflareAuthFromDotEnv(`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}\nRESEND_API_KEY=re_x`);
+		assert.deepEqual(auth, { CLOUDFLARE_ACCOUNT_ID: SAMPLE_ID });
+	});
+
+	test('does not overwrite an env var already set by the shell or CI', () => {
+		const env = { CLOUDFLARE_ACCOUNT_ID: 'already-set' };
+		applyCloudflareAuthEnv(env, [`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}`]);
+		assert.equal(env.CLOUDFLARE_ACCOUNT_ID, 'already-set');
+
+		const empty = {};
+		applyCloudflareAuthEnv(empty, [`CLOUDFLARE_ACCOUNT_ID=${SAMPLE_ID}`]);
+		assert.equal(empty.CLOUDFLARE_ACCOUNT_ID, SAMPLE_ID);
+	});
+});
+
+describe('wrangler.jsonc account_id', () => {
+	test('uncomments the template placeholder without inventing a committed id', () => {
+		const template = readFileSync(join(root, 'wrangler.jsonc'), 'utf8');
+		assert.match(template, /^\t\/\/ "account_id": ""/m);
+		assert.doesNotMatch(template, /^\s*"account_id"\s*:\s*"[0-9a-f]{32}"/m);
+		assert.match(template, /mail\.example\.com/);
+		assert.doesNotMatch(template, /mail\.yourdomain\.com/);
+
+		const next = setAccountIdInWrangler(template, SAMPLE_ID);
+		assert.match(next, new RegExp(`^\\t"account_id": "${SAMPLE_ID}",`, 'm'));
+		assert.doesNotMatch(next, /^\t\/\/ "account_id":/m);
+	});
+
+	test('replaces an existing account_id value', () => {
+		const source = '{\n\t"account_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",\n\t"name": "quickmail"\n}\n';
+		const next = setAccountIdInWrangler(source, SAMPLE_ID);
+		assert.equal(next.includes(SAMPLE_ID), true);
+		assert.equal(next.includes('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), false);
+	});
+});

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -17,9 +17,19 @@ import { delimiter, join } from 'node:path';
 import readline from 'node:readline/promises';
 import { stdin as stdinStream, stdout as stdoutStream } from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+	applyCloudflareAuthEnv,
+	isCloudflareAccountId,
+	setAccountIdInWrangler
+} from './cloudflare-env.mjs';
+import {
+	PRIVATE_WRANGLER_CONFIG,
+	TEMPLATE_WRANGLER_CONFIG
+} from './wrangler-config.mjs';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
-const wranglerFile = join(root, 'wrangler.jsonc');
+const wranglerTemplateFile = join(root, TEMPLATE_WRANGLER_CONFIG);
+const wranglerDeployFile = join(root, PRIVATE_WRANGLER_CONFIG);
 const devVarsFile = join(root, '.dev.vars');
 const devVarsExample = join(root, '.dev.vars.example');
 const envFile = join(root, '.env');
@@ -59,8 +69,9 @@ let rl = null;
 function printHelp() {
 	console.log(`QuickMail setup
 
-Installs tools, logs you into Cloudflare, creates D1/R2, writes env and
-wrangler config, and onboards your mail domain.
+Installs tools, logs you into Cloudflare, picks an account if your login
+can see more than one, creates D1/R2, writes env and a private
+wrangler.deploy.jsonc (gitignored), and onboards your mail domain.
 
   bun run setup
   bash scripts/setup.sh
@@ -174,6 +185,20 @@ function bunBin() {
 
 function hasBun() {
 	return Boolean(bunBin());
+}
+
+function applyCloudflareAuthFromDisk() {
+	const texts = [];
+	if (existsSync(envFile)) texts.push(readFileSync(envFile, 'utf8'));
+	if (existsSync(devVarsFile)) texts.push(readFileSync(devVarsFile, 'utf8'));
+	applyCloudflareAuthEnv(process.env, texts);
+}
+
+function rememberAccountId(id) {
+	const accountId = id.trim().toLowerCase();
+	process.env.CLOUDFLARE_ACCOUNT_ID = accountId;
+	upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accountId });
+	return accountId;
 }
 
 function childEnv(extra = {}) {
@@ -344,14 +369,21 @@ function readMutedLine() {
 }
 
 function readWrangler() {
-	if (!existsSync(wranglerFile)) {
-		throw new Error('wrangler.jsonc is missing. Run this from the QuickMail repo root.');
+	// Prefer an existing private deploy config so re-running setup does not
+	// wipe personal bindings. Fall back to the public template, which must
+	// stay placeholder-clean for release.
+	if (existsSync(wranglerDeployFile)) {
+		return readFileSync(wranglerDeployFile, 'utf8');
 	}
-	return readFileSync(wranglerFile, 'utf8');
+	if (!existsSync(wranglerTemplateFile)) {
+		throw new Error(`${TEMPLATE_WRANGLER_CONFIG} is missing. Run this from the QuickMail repo root.`);
+	}
+	return readFileSync(wranglerTemplateFile, 'utf8');
 }
 
 function writeWrangler(source) {
-	writeFileSync(wranglerFile, source.endsWith('\n') ? source : `${source}\n`);
+	// Always write personal config to the gitignored deploy overlay.
+	writeFileSync(wranglerDeployFile, source.endsWith('\n') ? source : `${source}\n`);
 }
 
 function jsoncString(source, key) {
@@ -585,11 +617,39 @@ async function ensureLogin() {
 	return pickAccount(next.accounts);
 }
 
+async function askAccountId() {
+	log('  wrangler did not list an account. Paste the ID from the Cloudflare dashboard sidebar.');
+	if (args.yes) {
+		throw new Error(
+			'Set CLOUDFLARE_ACCOUNT_ID (32-character hex from the dashboard sidebar) and re-run.'
+		);
+	}
+	while (true) {
+		const raw = (await prompt('Cloudflare account ID')).trim();
+		if (isCloudflareAccountId(raw)) {
+			const id = rememberAccountId(raw);
+			ok(`account ${id}`);
+			return { name: id, id };
+		}
+		warn('Paste the 32-character hex ID from the dashboard sidebar (or wrangler whoami).');
+	}
+}
+
 async function pickAccount(accounts) {
-	if (accounts.length === 0) return null;
+	const existing = process.env.CLOUDFLARE_ACCOUNT_ID?.trim() ?? '';
+	if (isCloudflareAccountId(existing)) {
+		const id = existing.toLowerCase();
+		const match = accounts.find((account) => account.id === id);
+		rememberAccountId(id);
+		ok(match ? `account ${match.name}` : `CLOUDFLARE_ACCOUNT_ID ${id}`);
+		return match ?? { name: id, id };
+	}
+
+	if (accounts.length === 0) return askAccountId();
+
 	if (accounts.length === 1) {
 		ok(`account ${accounts[0].name}`);
-		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		rememberAccountId(accounts[0].id);
 		return accounts[0];
 	}
 
@@ -599,7 +659,7 @@ async function pickAccount(accounts) {
 	});
 
 	if (args.yes) {
-		upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: accounts[0].id });
+		rememberAccountId(accounts[0].id);
 		ok(`using ${accounts[0].name}`);
 		return accounts[0];
 	}
@@ -611,7 +671,7 @@ async function pickAccount(accounts) {
 		chosen = accounts[index];
 		if (!chosen) warn('Pick a number from the list.');
 	}
-	upsertEnvFile(envFile, { CLOUDFLARE_ACCOUNT_ID: chosen.id });
+	rememberAccountId(chosen.id);
 	ok(`using ${chosen.name}`);
 	return chosen;
 }
@@ -1043,7 +1103,11 @@ function printNextSteps(state) {
 		log('  Local inbound needs a tunnel (cloudflared) — production uses the public Worker URL.');
 	}
 
-	log(`\n  ${c.dim('wrangler.jsonc now has a real D1 id. Do not commit that back to the public template.')}`);
+	log(
+		`\n  ${c.dim(
+			`${PRIVATE_WRANGLER_CONFIG} now has your D1 id (and maybe account_id). It is gitignored — the public ${TEMPLATE_WRANGLER_CONFIG} stays clean.`
+		)}`
+	);
 	if (state.publicUrl) log(`\n  ${c.green(state.publicUrl)}`);
 }
 
@@ -1057,6 +1121,8 @@ async function main() {
 
 	log(`\n${c.bold('QuickMail setup')}`);
 	log(c.dim('  A mailbox on your domain, on Cloudflare.\n'));
+
+	applyCloudflareAuthFromDisk();
 
 	const total = 8;
 
@@ -1111,6 +1177,9 @@ async function main() {
 		domains: provider === 'cloudflare' ? domain : ''
 	});
 	if (hostname) source = setRoutes(source, hostname);
+	if (isCloudflareAccountId(process.env.CLOUDFLARE_ACCOUNT_ID ?? '')) {
+		source = setAccountIdInWrangler(source, process.env.CLOUDFLARE_ACCOUNT_ID);
+	}
 	if (provider === 'cloudflare' && versionGte(wranglerVer, ADDRESSES_WRANGLER)) {
 		source = setAddresses(source, [`*@${domain}`]);
 	} else {

--- a/scripts/wrangler-config.mjs
+++ b/scripts/wrangler-config.mjs
@@ -1,0 +1,54 @@
+/**
+ * Resolve which Wrangler config file to use.
+ *
+ * The public template ships `wrangler.jsonc` with placeholders. Maintainers
+ * (and anyone who keeps a personal mailbox alongside the template) put real
+ * account / D1 / route values in `wrangler.deploy.jsonc`, which is gitignored.
+ * When that file exists, deploy / migrate / preview use it so pulling latest
+ * QuickMail does not wipe personal Cloudflare bindings.
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const TEMPLATE_WRANGLER_CONFIG = 'wrangler.jsonc';
+export const PRIVATE_WRANGLER_CONFIG = 'wrangler.deploy.jsonc';
+
+/**
+ * @param {string} root Absolute project root.
+ * @param {{ preferPrivate?: boolean }} [options]
+ * @returns {{ path: string, file: string, private: boolean }}
+ */
+export function resolveWranglerConfig(root, options = {}) {
+	const preferPrivate = options.preferPrivate !== false;
+	const privatePath = join(root, PRIVATE_WRANGLER_CONFIG);
+	if (preferPrivate && existsSync(privatePath)) {
+		return { path: privatePath, file: PRIVATE_WRANGLER_CONFIG, private: true };
+	}
+	return {
+		path: join(root, TEMPLATE_WRANGLER_CONFIG),
+		file: TEMPLATE_WRANGLER_CONFIG,
+		private: false
+	};
+}
+
+/**
+ * Build wrangler argv, injecting `--config <file>` when a private deploy
+ * config is active and the caller did not already pass `--config`.
+ *
+ * @param {string} root
+ * @param {string[]} argv
+ * @returns {{ args: string[], config: { path: string, file: string, private: boolean } }}
+ */
+export function wranglerArgsWithConfig(root, argv) {
+	const config = resolveWranglerConfig(root);
+	const hasConfigFlag = argv.some((arg, i) => {
+		if (arg === '--config' || arg === '-c') return true;
+		if (arg.startsWith('--config=')) return true;
+		if (i > 0 && (argv[i - 1] === '--config' || argv[i - 1] === '-c')) return true;
+		return false;
+	});
+	if (!config.private || hasConfigFlag) {
+		return { args: [...argv], config };
+	}
+	return { args: ['--config', config.file, ...argv], config };
+}

--- a/scripts/wrangler-config.test.ts
+++ b/scripts/wrangler-config.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	PRIVATE_WRANGLER_CONFIG,
+	TEMPLATE_WRANGLER_CONFIG,
+	resolveWranglerConfig,
+	wranglerArgsWithConfig
+} from './wrangler-config.mjs';
+
+describe('resolveWranglerConfig', () => {
+	test('falls back to the template when no private deploy config exists', () => {
+		const root = mkdtempSync(join(tmpdir(), 'qm-wrangler-'));
+		try {
+			const resolved = resolveWranglerConfig(root);
+			assert.equal(resolved.file, TEMPLATE_WRANGLER_CONFIG);
+			assert.equal(resolved.private, false);
+			assert.equal(resolved.path, join(root, TEMPLATE_WRANGLER_CONFIG));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test('prefers wrangler.deploy.jsonc when present', () => {
+		const root = mkdtempSync(join(tmpdir(), 'qm-wrangler-'));
+		try {
+			writeFileSync(join(root, PRIVATE_WRANGLER_CONFIG), '{ "name": "mail" }\n');
+			const resolved = resolveWranglerConfig(root);
+			assert.equal(resolved.file, PRIVATE_WRANGLER_CONFIG);
+			assert.equal(resolved.private, true);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('wranglerArgsWithConfig', () => {
+	test('injects --config for the private file', () => {
+		const root = mkdtempSync(join(tmpdir(), 'qm-wrangler-'));
+		try {
+			writeFileSync(join(root, PRIVATE_WRANGLER_CONFIG), '{ "name": "mail" }\n');
+			const { args, config } = wranglerArgsWithConfig(root, ['deploy']);
+			assert.equal(config.private, true);
+			assert.deepEqual(args, ['--config', PRIVATE_WRANGLER_CONFIG, 'deploy']);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test('leaves an explicit --config alone', () => {
+		const root = mkdtempSync(join(tmpdir(), 'qm-wrangler-'));
+		try {
+			writeFileSync(join(root, PRIVATE_WRANGLER_CONFIG), '{ "name": "mail" }\n');
+			const { args } = wranglerArgsWithConfig(root, ['deploy', '--config', 'other.jsonc']);
+			assert.deepEqual(args, ['deploy', '--config', 'other.jsonc']);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/scripts/wrangler-with-env.mjs
+++ b/scripts/wrangler-with-env.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Run wrangler with:
+ * 1. CLOUDFLARE_ACCOUNT_ID (and related auth) loaded from `.env` / `.dev.vars`
+ *    when the shell has not already set them.
+ * 2. `--config wrangler.deploy.jsonc` when that private file exists, so a
+ *    personal mailbox deploy can track latest QuickMail without committing
+ *    account ids / D1 ids / hostnames into the public template.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyCloudflareAuthEnv } from './cloudflare-env.mjs';
+import { wranglerArgsWithConfig } from './wrangler-config.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+const texts = [];
+for (const name of ['.env', '.dev.vars']) {
+	const file = join(root, name);
+	if (existsSync(file)) texts.push(readFileSync(file, 'utf8'));
+}
+applyCloudflareAuthEnv(process.env, texts);
+
+const { args, config } = wranglerArgsWithConfig(root, process.argv.slice(2));
+if (config.private && !process.env.QUICKMAIL_WRANGLER_QUIET) {
+	console.error(`Using private Wrangler config: ${config.file}`);
+}
+
+const wrangler = join(
+	root,
+	'node_modules',
+	'.bin',
+	process.platform === 'win32' ? 'wrangler.cmd' : 'wrangler'
+);
+const command = existsSync(wrangler) ? wrangler : 'wrangler';
+const child = spawn(command, args, {
+	stdio: 'inherit',
+	cwd: root,
+	env: process.env
+});
+
+child.on('exit', (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal);
+		return;
+	}
+	process.exit(code ?? 1);
+});

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,9 @@
 import adapter from '@sveltejs/adapter-cloudflare';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveWranglerConfig } from './scripts/wrangler-config.mjs';
+
+const wrangler = resolveWranglerConfig(dirname(fileURLToPath(import.meta.url)));
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -7,9 +12,9 @@ const config = {
 	},
 	kit: {
 		adapter: adapter({
-			config: 'wrangler.jsonc',
+			config: wrangler.file,
 			platformProxy: {
-				configPath: 'wrangler.jsonc',
+				configPath: wrangler.file,
 				persist: { path: '.wrangler/state/v3' }
 			}
 		}),

--- a/wrangler.deploy.jsonc.example
+++ b/wrangler.deploy.jsonc.example
@@ -1,0 +1,59 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	// Private deploy overlay — copy to wrangler.deploy.jsonc (gitignored) and
+	// fill in real values. `bun run deploy` / migrate / preview pick this file
+	// up automatically when it exists, so you can pull latest QuickMail without
+	// committing account ids, D1 ids, or personal hostnames into the template.
+	"name": "quickmail",
+	"main": ".svelte-kit/cloudflare/_worker.js",
+	"compatibility_date": "2025-06-01",
+	"compatibility_flags": ["nodejs_compat", "enable_nodejs_http_modules"],
+	"workers_dev": true,
+
+	// From the Cloudflare dashboard sidebar, or: wrangler whoami
+	// "account_id": "REPLACE_WITH_YOUR_ACCOUNT_ID",
+
+	// "routes": [
+	// 	{
+	// 		"pattern": "mail.example.com",
+	// 		"custom_domain": true
+	// 	}
+	// ],
+
+	"assets": {
+		"directory": ".svelte-kit/cloudflare",
+		"binding": "ASSETS"
+	},
+
+	"vars": {
+		"EMAIL_PROVIDER": "resend",
+		"CLOUDFLARE_MAIL_DOMAINS": ""
+	},
+
+	"send_email": [
+		{
+			"name": "EMAIL",
+			"remote": true
+		}
+	],
+
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "quickmail",
+			"database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID",
+			"migrations_dir": "migrations"
+		}
+	],
+
+	"r2_buckets": [
+		{
+			"binding": "ATTACHMENTS",
+			"bucket_name": "quickmail-attachments"
+		}
+	],
+
+	"observability": {
+		"enabled": true
+	}
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,8 +7,9 @@
 	"workers_dev": true,
 
 	// Your Cloudflare account is picked up from `wrangler login`. If you belong
-	// to more than one account, set CLOUDFLARE_ACCOUNT_ID in your environment
-	// or uncomment this and paste the ID from the Cloudflare dashboard sidebar.
+	// to more than one account, set CLOUDFLARE_ACCOUNT_ID in `.env` (see
+	// `.env.example`) or uncomment this and paste the ID from the dashboard
+	// sidebar. `bun run setup` writes this locally — do not commit a real ID.
 	// "account_id": "",
 
 	// Deploys to <name>.<your-subdomain>.workers.dev out of the box. To serve it


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lets a personal Wrangler mailbox (e.g. `mail.divinprince.com`) track latest QuickMail without committing account / D1 / route values into the public template.
- `bun run setup` writes gitignored `wrangler.deploy.jsonc`; `deploy` / `migrate` / `preview` / SvelteKit adapter prefer that file when present and load `CLOUDFLARE_ACCOUNT_ID` from `.env`.
- Adds `wrangler.deploy.jsonc.example`, `.env.example`, and README steps for “pull latest → migrate → deploy”.

## Syncing your divinprince mail Worker
This cloud agent could not reach private `DivinPrince/mail` or authenticate Cloudflare (`wrangler whoami` / Cloudflare MCP need login). After merging (or checking out this branch):

1. Copy your live Worker bindings into `wrangler.deploy.jsonc` (from the dashboard or your private checkout).
2. `wrangler login` (or set `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` in `.env`).
3. `bun run db:migrate:remote && bun run deploy`

## Test plan
- [x] `bun run check:clean`
- [x] `bun test` (includes new wrangler-config + cloudflare-env tests)
- [x] `bun run check`
- [ ] With a local `wrangler.deploy.jsonc`, confirm `bun run deploy` prints `Using private Wrangler config: wrangler.deploy.jsonc`
- [ ] Confirm the public `wrangler.jsonc` still has the D1 placeholder and no live account id

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cf2bac-1f20-4a8d-afd2-611551628f38?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cf2bac-1f20-4a8d-afd2-611551628f38&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

