### PR TITLE
Add forward so a message can be sent on with its attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/attachments.test.ts src/lib/server/forward.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/lib/server/attachments.test.ts
+++ b/src/lib/server/attachments.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { base64ByteLength, base64ToBytes, bytesToBase64 } from './attachments';
+
+describe('attachment encoding', () => {
+	test('bytes survive the trip to base64 and back', () => {
+		const bytes = new Uint8Array([0, 1, 2, 253, 254, 255, 65, 66, 67]);
+		assert.deepEqual(base64ToBytes(bytesToBase64(bytes)), bytes);
+	});
+
+	test('a file larger than one chunk is not corrupted or truncated', () => {
+		// 0x8000 is the chunk size, so this crosses the boundary several times.
+		const bytes = new Uint8Array(0x8000 * 3 + 17);
+		for (let index = 0; index < bytes.length; index += 1) bytes[index] = index % 256;
+
+		const round = base64ToBytes(bytesToBase64(bytes));
+		assert.equal(round.length, bytes.length);
+		assert.deepEqual(round, bytes);
+	});
+
+	test('an empty part encodes to an empty string', () => {
+		assert.equal(bytesToBase64(new Uint8Array(0)), '');
+	});
+
+	test('the reported size matches the bytes encoded, whatever the padding', () => {
+		for (const length of [0, 1, 2, 3, 4, 5, 6, 100, 1023]) {
+			const bytes = new Uint8Array(length).fill(7);
+			assert.equal(base64ByteLength(bytesToBase64(bytes)), length);
+		}
+	});
+});

--- a/src/lib/server/attachments.ts
+++ b/src/lib/server/attachments.ts
@@ -81,6 +81,48 @@ export async function insertAttachmentBytes(
 		.run();
 }
 
+/**
+ * The stored parts of a message in the shape an outbound send takes.
+ *
+ * Forwarding carries the original's files with it, and those already live in
+ * R2 — so they are read back here rather than being uploaded again from the
+ * browser. A part whose bytes have gone missing is skipped: losing one file is
+ * better than failing the forward.
+ */
+export async function readOutboundAttachments(
+	db: D1Database,
+	bucket: R2Bucket,
+	userId: string,
+	emailId: string
+): Promise<OutboundAttachmentInput[]> {
+	const { results } = await db
+		.prepare(
+			`SELECT a.id, a.email_id, a.filename, a.content_type, a.size_bytes,
+			        a.storage_key, a.content_base64, a.created_at
+			 FROM email_attachments a
+			 JOIN emails e ON e.id = a.email_id
+			 WHERE a.email_id = ? AND e.user_id = ?
+			 ORDER BY a.created_at ASC`
+		)
+		.bind(emailId, userId)
+		.all<StoredAttachmentRow>();
+
+	const attachments: OutboundAttachmentInput[] = [];
+
+	for (const row of results.slice(0, MAX_ATTACHMENTS_PER_EMAIL)) {
+		const bytes = await readAttachmentBytes(bucket, row);
+		if (!bytes) continue;
+
+		attachments.push({
+			filename: row.filename,
+			type: row.content_type,
+			content: bytesToBase64(bytes)
+		});
+	}
+
+	return attachments;
+}
+
 export async function listAttachments(
 	db: D1Database,
 	emailId: string
@@ -143,9 +185,24 @@ function base64ToBytes(base64: string): Uint8Array {
 	return Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
 }
 
+/**
+ * Providers take attachments as base64. Converted in chunks because spreading a
+ * whole file into `fromCharCode` overruns the call stack once it is big enough.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+	const CHUNK = 0x8000;
+	let binary = '';
+
+	for (let offset = 0; offset < bytes.length; offset += CHUNK) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + CHUNK));
+	}
+
+	return btoa(binary);
+}
+
 function base64ByteLength(base64: string): number {
 	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
 	return Math.floor((base64.length * 3) / 4) - padding;
 }
 
-export { base64ToBytes, base64ByteLength };
+export { base64ToBytes, base64ByteLength, bytesToBase64 };

--- a/src/lib/server/forward.test.ts
+++ b/src/lib/server/forward.test.ts
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { buildForwardedMessage, formatForwardDate, forwardSubject } from './forward';
+
+const original = {
+	from_addr: 'ada@example.com',
+	to_addr: 'support@ourdomain.test',
+	cc_addr: 'grace@example.com',
+	subject: 'Quarterly figures',
+	body_text: 'The numbers are attached.',
+	body_html: '<p>The numbers are attached.</p>',
+	created_at: '2026-08-24 08:30:00'
+};
+
+describe('forwarding a message', () => {
+	test('the subject is marked as a forward', () => {
+		assert.equal(forwardSubject('Quarterly figures'), 'Fwd: Quarterly figures');
+	});
+
+	test('a message that is already a forward is not marked twice', () => {
+		assert.equal(forwardSubject('Fwd: Quarterly figures'), 'Fwd: Quarterly figures');
+		assert.equal(forwardSubject('FW: Quarterly figures'), 'FW: Quarterly figures');
+		assert.equal(forwardSubject('Fwd[2]: Quarterly figures'), 'Fwd[2]: Quarterly figures');
+	});
+
+	test('a reply being forwarded keeps its own prefix and gains one', () => {
+		assert.equal(forwardSubject('Re: Quarterly figures'), 'Fwd: Re: Quarterly figures');
+	});
+
+	test('stored timestamps are read as UTC, not as local time', () => {
+		assert.equal(formatForwardDate('2026-08-24 08:30:00'), 'Mon, 24 Aug 2026 08:30:00 GMT');
+	});
+
+	test('an unreadable timestamp is passed through rather than dropped', () => {
+		assert.equal(formatForwardDate('sometime'), 'sometime');
+	});
+
+	test('the forwarded message carries the headers it arrived with', () => {
+		const { text } = buildForwardedMessage(original);
+
+		assert.match(text, /^---------- Forwarded message ----------/);
+		assert.match(text, /From: ada@example\.com/);
+		assert.match(text, /Date: Mon, 24 Aug 2026 08:30:00 GMT/);
+		assert.match(text, /Subject: Quarterly figures/);
+		assert.match(text, /To: support@ourdomain\.test/);
+		assert.match(text, /Cc: grace@example\.com/);
+		assert.match(text, /The numbers are attached\./);
+	});
+
+	test('a message nobody was copied on carries no Cc line', () => {
+		const { text } = buildForwardedMessage({ ...original, cc_addr: null });
+		assert.equal(text.includes('Cc:'), false);
+	});
+
+	test('a note is placed above the forwarded message in both forms', () => {
+		const { text, html } = buildForwardedMessage(original, {
+			note: { text: 'See below.', html: '<p>See below.</p>' }
+		});
+
+		assert.match(text, /^See below\.\n\n---------- Forwarded message/);
+		assert.match(html, /^<p>See below\.<\/p><div class="gmail_quote">/);
+	});
+
+	test('the forwarded part is wrapped so a reader can fold it', () => {
+		const { html } = buildForwardedMessage(original);
+		assert.match(html, /<div class="gmail_quote">/);
+		assert.match(html, /<p>The numbers are attached\.<\/p>/);
+	});
+
+	test('header values are escaped so a crafted subject cannot inject markup', () => {
+		const { html } = buildForwardedMessage({
+			...original,
+			subject: '<img src=x onerror="alert(1)">'
+		});
+
+		assert.equal(html.includes('<img src=x'), false);
+		assert.match(html, /&lt;img src=x/);
+	});
+
+	test('a message held only as HTML still forwards as readable text', () => {
+		const { text } = buildForwardedMessage({
+			...original,
+			body_text: null,
+			body_html: '<p>Hello</p><p>Goodbye</p>'
+		});
+
+		assert.match(text, /Hello\nGoodbye/);
+	});
+
+	test('a message held only as text still forwards as HTML', () => {
+		const { html } = buildForwardedMessage({
+			...original,
+			body_text: 'Line one\nLine two',
+			body_html: null
+		});
+
+		assert.match(html, /Line one<br>\nLine two/);
+	});
+});

--- a/src/lib/server/forward.test.ts
+++ b/src/lib/server/forward.test.ts
@@ -61,6 +61,38 @@ describe('forwarding a message', () => {
 		assert.match(html, /^<p>See below\.<\/p><div class="gmail_quote">/);
 	});
 
+	test('a note written only as text still reaches the HTML part', () => {
+		const { text, html } = buildForwardedMessage(original, {
+			note: { text: 'See below.\nThanks.' }
+		});
+
+		assert.match(text, /^See below\.\nThanks\.\n\n---------- Forwarded message/);
+		assert.match(html, /^<p>See below\.<br>\nThanks\.<\/p><div class="gmail_quote">/);
+	});
+
+	test('a note written only as HTML still reaches the text part', () => {
+		const { text, html } = buildForwardedMessage(original, {
+			note: { html: '<p>See below.</p>' }
+		});
+
+		assert.match(text, /^See below\.\n\n---------- Forwarded message/);
+		assert.match(html, /^<p>See below\.<\/p><div class="gmail_quote">/);
+	});
+
+	test('a text note is escaped rather than treated as markup', () => {
+		const { html } = buildForwardedMessage(original, {
+			note: { text: '<img src=x onerror="alert(1)">' }
+		});
+
+		assert.equal(html.includes('<img src=x'), false);
+		assert.match(html, /&lt;img src=x/);
+	});
+
+	test('no note leaves the forwarded message at the top', () => {
+		const { html } = buildForwardedMessage(original);
+		assert.match(html, /^<div class="gmail_quote">/);
+	});
+
 	test('the forwarded part is wrapped so a reader can fold it', () => {
 		const { html } = buildForwardedMessage(original);
 		assert.match(html, /<div class="gmail_quote">/);

--- a/src/lib/server/forward.ts
+++ b/src/lib/server/forward.ts
@@ -43,6 +43,11 @@ export function formatForwardDate(createdAt: string): string {
 	return Number.isNaN(date.getTime()) ? createdAt : date.toUTCString();
 }
 
+/** Plain text as a paragraph, for the HTML part of a message that lacks one. */
+function asHtmlParagraph(text: string): string {
+	return `<p>${escapeHtml(text).replaceAll('\n', '<br>\n')}</p>`;
+}
+
 /** What the sender writes above the forwarded message, in both forms. */
 export type ForwardNote = {
 	text?: string | null;
@@ -63,8 +68,11 @@ export function buildForwardedMessage(
 
 	if (original.cc_addr?.trim()) headers.push(['Cc', original.cc_addr.trim()]);
 
-	const noteHtml = options.note?.html?.trim() || null;
-	const noteText = options.note?.text?.trim() || (noteHtml ? stripHtml(noteHtml) : '');
+	// The two forms fill in for each other: a note written in one still reaches a
+	// recipient whose client shows the other.
+	const writtenHtml = options.note?.html?.trim() || null;
+	const noteText = options.note?.text?.trim() || (writtenHtml ? stripHtml(writtenHtml) : '');
+	const noteHtml = writtenHtml ?? (noteText ? asHtmlParagraph(noteText) : '');
 	const originalText = original.body_text?.trim() || stripHtml(original.body_html ?? '');
 	const originalHtml = original.body_html?.trim() || null;
 
@@ -79,14 +87,14 @@ export function buildForwardedMessage(
 	// `gmail_quote` is what mail clients — this one included — fold a forwarded
 	// message behind, so the reader sees the note first rather than the history.
 	const html = [
-		noteHtml ?? '',
+		noteHtml,
 		'<div class="gmail_quote">',
 		'<div class="gmail_attr">---------- Forwarded message ----------<br>',
 		headers
 			.map(([label, value]) => `<b>${label}:</b> ${escapeHtml(value)}`)
 			.join('<br>'),
 		'</div><br>',
-		originalHtml ?? `<p>${escapeHtml(originalText).replaceAll('\n', '<br>\n')}</p>`,
+		originalHtml ?? asHtmlParagraph(originalText),
 		'</div>'
 	].join('');
 

--- a/src/lib/server/forward.ts
+++ b/src/lib/server/forward.ts
@@ -1,0 +1,94 @@
+import { stripHtml } from './html';
+import { escapeHtml } from './send-mail';
+
+/**
+ * Forwarding a message.
+ *
+ * A forward is not a reply: it carries the original to someone who has not seen
+ * it, so the message itself becomes the content. What the sender adds is a note
+ * on top, and everything below the divider is the message as it arrived —
+ * headers included, because without them a forward loses who sent it and when.
+ */
+
+/** Already a forward? Senders write "Fwd:", "FW:" and "Fwd[2]:" for the same thing. */
+const FORWARD_PREFIX = /^\s*(fw|fwd)\s*(\[\d+\])?\s*:/i;
+
+export type ForwardedOriginal = {
+	from_addr: string;
+	to_addr: string;
+	cc_addr?: string | null;
+	subject: string;
+	body_text: string | null;
+	body_html: string | null;
+	created_at: string;
+};
+
+export function forwardSubject(subject: string): string {
+	const trimmed = subject.trim();
+	if (!trimmed) return 'Fwd:';
+	return FORWARD_PREFIX.test(trimmed) ? trimmed : `Fwd: ${trimmed}`;
+}
+
+/**
+ * D1 stores `datetime('now')` as `YYYY-MM-DD HH:MM:SS` in UTC. Parsed as-is
+ * that reads as local time in some runtimes, so the zone is made explicit
+ * before it is turned into the RFC 2822 form mail headers use.
+ */
+export function formatForwardDate(createdAt: string): string {
+	const iso = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(createdAt.trim())
+		? `${createdAt.trim().replace(' ', 'T')}Z`
+		: createdAt;
+
+	const date = new Date(iso);
+	return Number.isNaN(date.getTime()) ? createdAt : date.toUTCString();
+}
+
+/** What the sender writes above the forwarded message, in both forms. */
+export type ForwardNote = {
+	text?: string | null;
+	html?: string | null;
+};
+
+/** The message as it arrived, ready to sit under whatever the sender adds. */
+export function buildForwardedMessage(
+	original: ForwardedOriginal,
+	options: { note?: ForwardNote } = {}
+): { subject: string; text: string; html: string } {
+	const headers: Array<[string, string]> = [
+		['From', original.from_addr],
+		['Date', formatForwardDate(original.created_at)],
+		['Subject', original.subject],
+		['To', original.to_addr]
+	];
+
+	if (original.cc_addr?.trim()) headers.push(['Cc', original.cc_addr.trim()]);
+
+	const noteHtml = options.note?.html?.trim() || null;
+	const noteText = options.note?.text?.trim() || (noteHtml ? stripHtml(noteHtml) : '');
+	const originalText = original.body_text?.trim() || stripHtml(original.body_html ?? '');
+	const originalHtml = original.body_html?.trim() || null;
+
+	const text = [
+		noteText ? `${noteText}\n\n` : '',
+		'---------- Forwarded message ----------\n',
+		headers.map(([label, value]) => `${label}: ${value}`).join('\n'),
+		'\n\n',
+		originalText
+	].join('');
+
+	// `gmail_quote` is what mail clients — this one included — fold a forwarded
+	// message behind, so the reader sees the note first rather than the history.
+	const html = [
+		noteHtml ?? '',
+		'<div class="gmail_quote">',
+		'<div class="gmail_attr">---------- Forwarded message ----------<br>',
+		headers
+			.map(([label, value]) => `<b>${label}:</b> ${escapeHtml(value)}`)
+			.join('<br>'),
+		'</div><br>',
+		originalHtml ?? `<p>${escapeHtml(originalText).replaceAll('\n', '<br>\n')}</p>`,
+		'</div>'
+	].join('');
+
+	return { subject: forwardSubject(original.subject), text, html };
+}

--- a/src/routes/api/mail/[id]/forward/+server.ts
+++ b/src/routes/api/mail/[id]/forward/+server.ts
@@ -1,0 +1,79 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { readOutboundAttachments } from '$lib/server/attachments';
+import {
+	describeProviderError,
+	getEmailProvider,
+	statusForProviderError
+} from '$lib/server/context';
+import { buildForwardedMessage } from '$lib/server/forward';
+import { getEmailForUser } from '$lib/server/mail-store';
+import { resolveReplyFromAddress, sendAndStore } from '$lib/server/outbox';
+import { parseRecipients } from '$lib/server/send-mail';
+
+type ForwardBody = {
+	fromAddressId?: string;
+	to?: string;
+	cc?: string;
+	bcc?: string;
+	/** What the sender adds above the forwarded message. */
+	text?: string;
+	html?: string;
+	/** Carry the original's files along; on by default. */
+	includeAttachments?: boolean;
+};
+
+/** Sends a copy of a message on to someone who has not seen it. */
+export const POST: RequestHandler = async ({ params, request, locals, platform }) => {
+	const db = platform?.env.DB;
+	const bucket = platform?.env.ATTACHMENTS;
+	if (!db || !bucket || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const original = await getEmailForUser(db, locals.user.id, params.id!);
+	if (!original) {
+		return json({ error: 'Not found' }, { status: 404 });
+	}
+
+	const body = (await request.json()) as ForwardBody;
+	if (parseRecipients(body.to).length === 0) {
+		return json({ error: 'A recipient is required' }, { status: 400 });
+	}
+
+	const { subject, text, html } = buildForwardedMessage(original, {
+		note: { text: body.text, html: body.html }
+	});
+
+	// Same identity rule as a reply: the mailbox the message arrived at, unless
+	// the sender picked another one.
+	const fromAddress = body.fromAddressId
+		? undefined
+		: await resolveReplyFromAddress(db, locals.user, original);
+
+	// A forward goes to someone outside the original exchange, so it starts its
+	// own conversation rather than continuing that one — no In-Reply-To chain.
+	try {
+		const provider = getEmailProvider(platform);
+		const { emailId } = await sendAndStore({ DB: db, ATTACHMENTS: bucket }, provider, locals.user, {
+			fromAddressId: body.fromAddressId,
+			fromAddress,
+			to: body.to!,
+			cc: body.cc,
+			bcc: body.bcc,
+			subject,
+			text,
+			html,
+			attachments:
+				body.includeAttachments === false
+					? []
+					: await readOutboundAttachments(db, bucket, locals.user.id, original.id)
+		});
+
+		return json({ ok: true, id: emailId });
+	} catch (error) {
+		return json(
+			{ error: describeProviderError(error, 'Failed to forward message') },
+			{ status: statusForProviderError(error) }
+		);
+	}
+};

--- a/src/routes/mail/[id]/+page.svelte
+++ b/src/routes/mail/[id]/+page.svelte
@@ -17,9 +17,17 @@
 	let sending = $state(false);
 	let error = $state('');
 
+	let forwardOpen = $state(false);
+	let forwardTo = $state('');
+	let forwardHtml = $state('');
+	let includeAttachments = $state(true);
+
 	const messages = $derived(data.messages);
 	const latest = $derived(messages[messages.length - 1]);
 	const starred = $derived(messages.some((message) => message.is_starred));
+
+	/** A forward carries the files of the message it copies. */
+	const forwardFiles = $derived(latest?.attachments.length ?? 0);
 
 	const backHref = $derived(
 		data.trashed ? '/trash' : latest?.direction === 'outbound' ? '/sent' : '/inbox'
@@ -95,6 +103,56 @@
 		if (!latest) return;
 		await fetch(`/api/mail/${latest.id}`, { method: 'DELETE' });
 		goto('/trash');
+	}
+
+	/** Reply and forward share the space below the thread, so only one is open. */
+	function openReply() {
+		forwardOpen = false;
+		replyOpen = !replyOpen;
+		error = '';
+	}
+
+	function openForward() {
+		replyOpen = false;
+		forwardOpen = !forwardOpen;
+		error = '';
+	}
+
+	/** Forwards the newest message in the conversation, files included. */
+	async function sendForward(event: SubmitEvent) {
+		event.preventDefault();
+		if (!latest || !forwardTo.trim()) return;
+
+		sending = true;
+		error = '';
+
+		try {
+			const res = await fetch(`/api/mail/${latest.id}/forward`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					to: forwardTo,
+					html: isHtmlEmpty(forwardHtml) ? undefined : forwardHtml,
+					text: isHtmlEmpty(forwardHtml) ? undefined : htmlToPlainText(forwardHtml),
+					includeAttachments
+				})
+			});
+			const body = await res.json();
+			if (!res.ok) {
+				error = body.error ?? 'Failed to forward';
+				return;
+			}
+
+			forwardTo = '';
+			forwardHtml = '';
+			forwardOpen = false;
+			// The forward is our own message now, so the mailbox has changed.
+			await invalidateAll();
+		} catch {
+			error = 'Network error';
+		} finally {
+			sending = false;
+		}
 	}
 
 	/** Replies continue from the newest message, so the chain stays intact. */
@@ -185,7 +243,17 @@
 				</button>
 			{/if}
 
-			<button type="button" class="btn-primary reply-launch" onclick={() => (replyOpen = !replyOpen)}>
+			<button
+				type="button"
+				class="icon-btn"
+				class:active={forwardOpen}
+				aria-label="Forward"
+				onclick={openForward}
+			>
+				<Icon name="share-forward-line" size={16} />
+			</button>
+
+			<button type="button" class="btn-primary reply-launch" onclick={openReply}>
 				<Icon name="reply-line" size={16} />
 				{replyOpen ? 'Close' : 'Reply'}
 			</button>
@@ -217,7 +285,62 @@
 		</div>
 	</article>
 
-	{#if replyOpen}
+	{#if forwardOpen}
+		<form class="reply-section" onsubmit={sendForward}>
+			<div class="forward-row">
+				<label class="field-label" for="forward-to">To</label>
+				<input
+					id="forward-to"
+					type="text"
+					bind:value={forwardTo}
+					placeholder="recipient@example.com"
+					autocomplete="off"
+					autocapitalize="none"
+					spellcheck="false"
+					required
+					class="field-input"
+				/>
+			</div>
+			{#if data.replyFrom}
+				<p class="reply-from">
+					From
+					<strong>
+						{#if data.replyFromName}{data.replyFromName} · {/if}{data.replyFrom}
+					</strong>
+				</p>
+			{/if}
+
+			<RichTextEditor
+				bind:html={forwardHtml}
+				embedded
+				minHeight={140}
+				placeholder="Add a note…"
+			/>
+
+			{#if forwardFiles > 0}
+				<label class="forward-files">
+					<input type="checkbox" bind:checked={includeAttachments} />
+					Include {forwardFiles === 1 ? 'the attachment' : `all ${forwardFiles} attachments`}
+				</label>
+			{/if}
+
+			<div class="reply-footer forward-footer">
+				<div class="reply-actions">
+					<button type="button" class="btn-ghost" onclick={() => (forwardOpen = false)}>
+						Cancel
+					</button>
+					<button type="submit" class="btn-primary" disabled={sending}>
+						<Icon name="share-forward-line" size={16} />
+						{sending ? 'Sending…' : 'Forward'}
+					</button>
+				</div>
+			</div>
+
+			{#if error}
+				<p class="reply-status">{error}</p>
+			{/if}
+		</form>
+	{:else if replyOpen}
 		<form class="reply-section" onsubmit={sendReply}>
 			<p class="reply-to">
 				Replying to
@@ -254,7 +377,7 @@
 			{/if}
 		</form>
 	{:else}
-		<button type="button" class="reply-prompt" onclick={() => (replyOpen = true)}>
+		<button type="button" class="reply-prompt" onclick={openReply}>
 			<Icon name="reply-line" size={15} />
 			Reply
 		</button>
@@ -277,6 +400,11 @@
 
 	.toolbar-actions :global(.icon-btn.starred) {
 		color: var(--color-star);
+	}
+
+	.toolbar-actions :global(.icon-btn.active) {
+		background: var(--color-accent-soft);
+		color: var(--color-accent-text);
 	}
 
 	.toolbar-actions :global(.icon-btn.danger:hover) {
@@ -344,6 +472,32 @@
 	.reply-from strong {
 		font-weight: 500;
 		color: var(--color-text-secondary);
+	}
+
+	.forward-row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		margin-bottom: 0.625rem;
+		box-shadow: inset 0 -1px 0 var(--color-line);
+	}
+
+	.forward-row .field-label {
+		width: 2.5rem;
+	}
+
+	.forward-footer {
+		justify-content: flex-end;
+	}
+
+	.forward-files {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-top: 0.625rem;
+		font-size: 0.8125rem;
+		color: var(--color-muted);
+		cursor: pointer;
 	}
 
 	.reply-footer {


### PR DESCRIPTION
## Summary

Reply was the only way to send a message onward. Passing one to somebody outside the conversation meant selecting the text, copying it into a new message by hand, and losing the attachments and the headers along with it.

This adds forward.

## What changed

- `src/lib/server/forward.ts` — new. Builds the forwarded body: the original beneath a `---------- Forwarded message ----------` divider carrying From, Date, Subject and the recipients, with whatever the sender writes above it. Both the text and HTML parts are produced, so a message stored in only one form still forwards readably in both.
- `POST /api/mail/[id]/forward` — sends it through `sendAndStore`, so signatures, delivery status and the Sent copy work exactly as they do for a reply.
- `readOutboundAttachments` in `src/lib/server/attachments.ts` reads the original's parts back out of R2 and hands them to the send as base64, so the files travel with the forward instead of being uploaded again from the browser. A part whose bytes have gone missing is skipped rather than failing the whole forward.
- The thread view gets a Forward button beside Reply, opening a composer with a To field, an optional note, and a checkbox to leave the attachments behind.

Two details worth calling out:

- **Identity** follows the same rule as a reply: the mailbox the message arrived at, catch-all included.
- **Threading** is deliberately not continued. A forward carries no `In-Reply-To` or `References`, because it opens a conversation with somebody who was not part of the previous one.

## Behaviour

| | Before | After |
|---|---|---|
| Send a received message to someone else | Copy the text by hand | Forward, with headers intact |
| Attachments on that message | Lost | Carried, or left behind by choice |
| Subject | — | `Fwd: …`, and not doubled if it is already one |
| Sender identity | — | The mailbox that received it |

Forwarded content is wrapped in `gmail_quote`, which is what the reader already folds, so a note stays above the fold rather than being buried under the history.

## Validation

- `bun run test` — 65 pass, 16 of them new: subject prefixing, header block, note placement, HTML escaping of header values, text/HTML fallbacks, and a base64 round trip across the chunk boundary so a large attachment cannot be silently corrupted
- `bun run check` — 0 errors
- `bun run check:clean` — clean
- `bun run build` — succeeds
- The new attachment query was run against a migrated local D1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward the latest email to multiple recipients with optional Cc and Bcc fields.
  * Add an optional text or HTML note.
  * Choose whether to include original attachments.
  * Preserve forwarded headers and support text-only or HTML content.
  * Reply and forward composers now work seamlessly together.
* **Bug Fixes**
  * Improved attachment handling, encoding, and missing-file resilience.
  * Added clearer validation and error reporting for forwarding failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->