### PR TITLE
Add an admin toggle when creating users, and let admins delete users

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts src/lib/server/auth.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
+import type { User } from '$lib/types';
+import { deleteUser } from './auth';
+
+const actor: User = {
+	id: 'admin-1',
+	email: 'ada@example.com',
+	name: 'Ada',
+	is_admin: true,
+	created_at: '2026-01-01T00:00:00.000Z'
+};
+
+const targetRow = {
+	id: 'admin-2',
+	email: 'grace@example.com',
+	name: 'Grace',
+	is_admin: 1,
+	created_at: '2026-01-02T00:00:00.000Z'
+};
+
+function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
+	const deleteStatements: string[] = [];
+
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(..._args: unknown[]) {
+					return {
+						async first() {
+							return sql.includes('FROM users WHERE id = ?') ? targetRow : null;
+						},
+						async all() {
+							if (sql.includes('FROM email_attachments')) {
+								return {
+									results: (options.storageKeys ?? []).map((storage_key) => ({ storage_key }))
+								};
+							}
+							return { results: [] };
+						},
+						async run() {
+							if (sql.includes('DELETE FROM users')) {
+								deleteStatements.push(sql);
+								return { meta: { changes: options.deleteChanges } };
+							}
+							return { meta: { changes: 0 } };
+						}
+					};
+				}
+			};
+		}
+	} as unknown as D1Database;
+
+	return { db, deleteStatements };
+}
+
+function mockBucket() {
+	const deleted: string[] = [];
+	const bucket = {
+		async delete(key: string) {
+			deleted.push(key);
+		}
+	} as unknown as R2Bucket;
+	return { bucket, deleted };
+}
+
+describe('deleteUser', () => {
+	test('refuses to delete the account making the request', async () => {
+		const { db, deleteStatements } = mockDb({ deleteChanges: 1 });
+		const { bucket, deleted } = mockBucket();
+
+		await assert.rejects(
+			() => deleteUser(db, bucket, actor, actor.id),
+			/cannot delete your own account/
+		);
+		assert.deepEqual(deleteStatements, []);
+		assert.deepEqual(deleted, []);
+	});
+
+	test('removes the R2 objects the deleted mail referenced', async () => {
+		const { db } = mockDb({ storageKeys: ['att/one', 'att/two'], deleteChanges: 1 });
+		const { bucket, deleted } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		assert.deepEqual(deleted.sort(), ['att/one', 'att/two']);
+	});
+
+	test('leaves R2 untouched when the delete is refused', async () => {
+		// changes = 0 means the last-admin guard in the statement rejected it.
+		const { db } = mockDb({ storageKeys: ['att/one'], deleteChanges: 0 });
+		const { bucket, deleted } = mockBucket();
+
+		await assert.rejects(
+			() => deleteUser(db, bucket, actor, targetRow.id),
+			/Keep at least one admin/
+		);
+		assert.deepEqual(deleted, []);
+	});
+
+	test('enforces the last-admin rule inside the DELETE, not a preceding read', async () => {
+		// A count read followed by an unconditional DELETE lets two admins delete
+		// each other concurrently and leave the instance with none. The guard has
+		// to travel with the statement, so assert it is actually there.
+		const { db, deleteStatements } = mockDb({ deleteChanges: 1 });
+		const { bucket } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		assert.equal(deleteStatements.length, 1);
+		assert.match(deleteStatements[0], /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
+	});
+
+	test('works without a bucket configured', async () => {
+		const { db } = mockDb({ storageKeys: ['att/one'], deleteChanges: 1 });
+
+		await assert.doesNotReject(() => deleteUser(db, undefined, actor, targetRow.id));
+	});
+});

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -22,12 +22,14 @@ const targetRow = {
 
 function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 	const deleteStatements: string[] = [];
+	const batched: string[] = [];
 
 	const db = {
 		prepare(sql: string) {
 			return {
 				bind(..._args: unknown[]) {
 					return {
+						sql,
 						async first() {
 							return sql.includes('FROM users WHERE id = ?') ? targetRow : null;
 						},
@@ -49,10 +51,14 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 					};
 				}
 			};
+		},
+		async batch(statements: { sql: string }[]) {
+			batched.push(...statements.map((statement) => statement.sql));
+			return statements.map(() => ({ meta: { changes: 0 } }));
 		}
 	} as unknown as D1Database;
 
-	return { db, deleteStatements };
+	return { db, deleteStatements, batched };
 }
 
 function mockBucket(options: { failOn?: string } = {}) {
@@ -122,6 +128,50 @@ describe('deleteUser', () => {
 
 		await assert.doesNotReject(() => deleteUser(db, bucket, actor, targetRow.id));
 		assert.deepEqual(deleted, ['att/two']);
+	});
+
+	test('clears child rows explicitly, for databases without cascade enforcement', async () => {
+		// Older D1 databases were created without ON DELETE CASCADE enforced, so
+		// the user row going away is not enough — mail, addresses, sessions,
+		// tokens and push subscriptions would all be left behind.
+		const { db, batched } = mockDb({ deleteChanges: 1 });
+		const { bucket } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		for (const table of [
+			'email_attachments',
+			'emails',
+			'addresses',
+			'sessions',
+			'api_tokens',
+			'push_subscriptions'
+		]) {
+			assert.ok(
+				batched.some((sql) => sql.includes(`DELETE FROM ${table}`)),
+				`expected the cleanup batch to delete from ${table}`
+			);
+		}
+
+		assert.ok(
+			batched.some((sql) => sql.includes('UPDATE domains SET catchall_user_id = NULL')),
+			'expected the catch-all reference to be cleared'
+		);
+
+		// Attachment metadata is reachable only through emails, so it has to go first.
+		assert.ok(
+			batched.findIndex((sql) => sql.includes('DELETE FROM email_attachments')) <
+				batched.findIndex((sql) => sql.includes('DELETE FROM emails WHERE')),
+			'email_attachments must be cleared before the emails it hangs off'
+		);
+	});
+
+	test('leaves child rows alone when the delete is refused', async () => {
+		const { db, batched } = mockDb({ deleteChanges: 0 });
+		const { bucket } = mockBucket();
+
+		await assert.rejects(() => deleteUser(db, bucket, actor, targetRow.id));
+		assert.deepEqual(batched, []);
 	});
 
 	test('works without a bucket configured', async () => {

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -33,14 +33,6 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 						async first() {
 							return sql.includes('FROM users WHERE id = ?') ? targetRow : null;
 						},
-						async all() {
-							if (sql.includes('FROM email_attachments')) {
-								return {
-									results: (options.storageKeys ?? []).map((storage_key) => ({ storage_key }))
-								};
-							}
-							return { results: [] };
-						},
 						async run() {
 							return { meta: { changes: 0 } };
 						}
@@ -50,8 +42,13 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 		},
 		async batch(statements: { sql: string }[]) {
 			batches.push(statements.map((statement) => statement.sql));
-			return statements.map((_, index) => ({
-				meta: { changes: index === 0 ? options.deleteChanges : 0 }
+			return statements.map((statement) => ({
+				results: statement.sql.includes('SELECT storage_key')
+					? (options.storageKeys ?? []).map((storage_key) => ({ storage_key }))
+					: [],
+				meta: {
+					changes: statement.sql.includes('DELETE FROM users') ? options.deleteChanges : 0
+				}
 			}));
 		}
 	} as unknown as D1Database;
@@ -142,8 +139,9 @@ describe('deleteUser', () => {
 
 		await deleteUser(db, bucket, actor, targetRow.id);
 
-		assert.match(batches[0][0], /DELETE FROM users/);
-		assert.match(batches[0][0], /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
+		const userDelete = batches[0].find((sql) => sql.includes('DELETE FROM users'));
+		assert.ok(userDelete);
+		assert.match(userDelete, /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
 	});
 
 	test('clears every child table, for databases without cascade enforcement', async () => {
@@ -190,9 +188,30 @@ describe('deleteUser', () => {
 
 		await deleteUser(db, bucket, actor, targetRow.id);
 
-		for (const sql of batches[0].slice(1)) {
+		const userDeleteAt = batches[0].findIndex((sql) => sql.includes('DELETE FROM users'));
+		const children = batches[0].slice(userDeleteAt + 1);
+		assert.ok(children.length > 0);
+		for (const sql of children) {
 			assert.match(sql, /NOT EXISTS \(SELECT 1 FROM users WHERE id = \?\)/);
 		}
+	});
+
+	test('reads the attachment keys inside the deletion transaction', async () => {
+		// Reading them beforehand leaves a window where inbound delivery commits an
+		// attachment whose metadata this deletes without collecting its object.
+		const { db, batches } = mockDb({ storageKeys: ['att/one'], deleteChanges: 1 });
+		const { bucket, deleted } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		assert.equal(batches.length, 1);
+		assert.match(batches[0][0], /SELECT storage_key FROM email_attachments/);
+		assert.ok(
+			batches[0].findIndex((sql) => sql.includes('SELECT storage_key')) <
+				batches[0].findIndex((sql) => sql.includes('DELETE FROM users')),
+			'the key read must precede the delete inside the transaction'
+		);
+		assert.deepEqual(deleted, ['att/one']);
 	});
 
 	test('works without a bucket configured', async () => {

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -20,9 +20,9 @@ const targetRow = {
 	created_at: '2026-01-02T00:00:00.000Z'
 };
 
+/** `deleteChanges` stands in for what the guarded DELETE reports: 0 means refused. */
 function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
-	const deleteStatements: string[] = [];
-	const batched: string[] = [];
+	const batches: string[][] = [];
 
 	const db = {
 		prepare(sql: string) {
@@ -42,10 +42,6 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 							return { results: [] };
 						},
 						async run() {
-							if (sql.includes('DELETE FROM users')) {
-								deleteStatements.push(sql);
-								return { meta: { changes: options.deleteChanges } };
-							}
 							return { meta: { changes: 0 } };
 						}
 					};
@@ -53,12 +49,14 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 			};
 		},
 		async batch(statements: { sql: string }[]) {
-			batched.push(...statements.map((statement) => statement.sql));
-			return statements.map(() => ({ meta: { changes: 0 } }));
+			batches.push(statements.map((statement) => statement.sql));
+			return statements.map((_, index) => ({
+				meta: { changes: index === 0 ? options.deleteChanges : 0 }
+			}));
 		}
 	} as unknown as D1Database;
 
-	return { db, deleteStatements, batched };
+	return { db, batches };
 }
 
 function mockBucket(options: { failOn?: string } = {}) {
@@ -74,15 +72,25 @@ function mockBucket(options: { failOn?: string } = {}) {
 
 describe('deleteUser', () => {
 	test('refuses to delete the account making the request', async () => {
-		const { db, deleteStatements } = mockDb({ deleteChanges: 1 });
+		const { db, batches } = mockDb({ deleteChanges: 1 });
 		const { bucket, deleted } = mockBucket();
 
 		await assert.rejects(
 			() => deleteUser(db, bucket, actor, actor.id),
 			/cannot delete your own account/
 		);
-		assert.deepEqual(deleteStatements, []);
+		assert.deepEqual(batches, []);
 		assert.deepEqual(deleted, []);
+	});
+
+	test('reports the last-admin refusal', async () => {
+		const { db } = mockDb({ deleteChanges: 0 });
+		const { bucket } = mockBucket();
+
+		await assert.rejects(
+			() => deleteUser(db, bucket, actor, targetRow.id),
+			/Keep at least one admin/
+		);
 	});
 
 	test('removes the R2 objects the deleted mail referenced', async () => {
@@ -95,34 +103,16 @@ describe('deleteUser', () => {
 	});
 
 	test('leaves R2 untouched when the delete is refused', async () => {
-		// changes = 0 means the last-admin guard in the statement rejected it.
 		const { db } = mockDb({ storageKeys: ['att/one'], deleteChanges: 0 });
 		const { bucket, deleted } = mockBucket();
 
-		await assert.rejects(
-			() => deleteUser(db, bucket, actor, targetRow.id),
-			/Keep at least one admin/
-		);
+		await assert.rejects(() => deleteUser(db, bucket, actor, targetRow.id));
 		assert.deepEqual(deleted, []);
 	});
 
-	test('enforces the last-admin rule inside the DELETE, not a preceding read', async () => {
-		// A count read followed by an unconditional DELETE lets two admins delete
-		// each other concurrently and leave the instance with none. The guard has
-		// to travel with the statement, so assert it is actually there.
-		const { db, deleteStatements } = mockDb({ deleteChanges: 1 });
-		const { bucket } = mockBucket();
-
-		await deleteUser(db, bucket, actor, targetRow.id);
-
-		assert.equal(deleteStatements.length, 1);
-		assert.match(deleteStatements[0], /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
-	});
-
 	test('still succeeds when an R2 delete fails, and purges the rest', async () => {
-		// The D1 delete has already committed by this point. Throwing here would
-		// report failure for a deletion that happened, and the retry would say
-		// the user no longer exists.
+		// The row is already gone by this point. Throwing would report failure for
+		// a deletion that happened, and the retry would say the user is missing.
 		const { db } = mockDb({ storageKeys: ['att/one', 'att/two'], deleteChanges: 1 });
 		const { bucket, deleted } = mockBucket({ failOn: 'att/one' });
 
@@ -130,11 +120,37 @@ describe('deleteUser', () => {
 		assert.deepEqual(deleted, ['att/two']);
 	});
 
-	test('clears child rows explicitly, for databases without cascade enforcement', async () => {
+	test('deletes the account and its children in a single batch', async () => {
+		// D1 rolls a batch back as a unit. Splitting these leaves the account gone
+		// with its mail, sessions and tokens behind if the second call fails.
+		const { db, batches } = mockDb({ deleteChanges: 1 });
+		const { bucket } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		assert.equal(batches.length, 1);
+		assert.ok(batches[0].some((sql) => sql.includes('DELETE FROM users')));
+		assert.ok(batches[0].some((sql) => sql.includes('DELETE FROM emails')));
+	});
+
+	test('enforces the last-admin rule inside the DELETE, not a preceding read', async () => {
+		// A count read followed by an unconditional DELETE lets two admins delete
+		// each other concurrently and leave the instance with none, so the guard
+		// has to travel with the statement.
+		const { db, batches } = mockDb({ deleteChanges: 1 });
+		const { bucket } = mockBucket();
+
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		assert.match(batches[0][0], /DELETE FROM users/);
+		assert.match(batches[0][0], /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
+	});
+
+	test('clears every child table, for databases without cascade enforcement', async () => {
 		// Older D1 databases were created without ON DELETE CASCADE enforced, so
 		// the user row going away is not enough — mail, addresses, sessions,
-		// tokens and push subscriptions would all be left behind.
-		const { db, batched } = mockDb({ deleteChanges: 1 });
+		// tokens and push subscriptions would all survive it.
+		const { db, batches } = mockDb({ deleteChanges: 1 });
 		const { bucket } = mockBucket();
 
 		await deleteUser(db, bucket, actor, targetRow.id);
@@ -148,30 +164,35 @@ describe('deleteUser', () => {
 			'push_subscriptions'
 		]) {
 			assert.ok(
-				batched.some((sql) => sql.includes(`DELETE FROM ${table}`)),
-				`expected the cleanup batch to delete from ${table}`
+				batches[0].some((sql) => sql.includes(`DELETE FROM ${table}`)),
+				`expected the batch to delete from ${table}`
 			);
 		}
 
 		assert.ok(
-			batched.some((sql) => sql.includes('UPDATE domains SET catchall_user_id = NULL')),
+			batches[0].some((sql) => sql.includes('UPDATE domains SET catchall_user_id = NULL')),
 			'expected the catch-all reference to be cleared'
 		);
 
-		// Attachment metadata is reachable only through emails, so it has to go first.
+		// Attachment metadata is reachable only through emails, so it must go first.
 		assert.ok(
-			batched.findIndex((sql) => sql.includes('DELETE FROM email_attachments')) <
-				batched.findIndex((sql) => sql.includes('DELETE FROM emails WHERE')),
+			batches[0].findIndex((sql) => sql.includes('DELETE FROM email_attachments')) <
+				batches[0].findIndex((sql) => sql.includes('DELETE FROM emails WHERE')),
 			'email_attachments must be cleared before the emails it hangs off'
 		);
 	});
 
-	test('leaves child rows alone when the delete is refused', async () => {
-		const { db, batched } = mockDb({ deleteChanges: 0 });
+	test('gates child cleanup on the account actually being gone', async () => {
+		// The child statements share a transaction with the guarded delete, so
+		// without this gate a refused delete would strip an account that survives.
+		const { db, batches } = mockDb({ deleteChanges: 1 });
 		const { bucket } = mockBucket();
 
-		await assert.rejects(() => deleteUser(db, bucket, actor, targetRow.id));
-		assert.deepEqual(batched, []);
+		await deleteUser(db, bucket, actor, targetRow.id);
+
+		for (const sql of batches[0].slice(1)) {
+			assert.match(sql, /NOT EXISTS \(SELECT 1 FROM users WHERE id = \?\)/);
+		}
 	});
 
 	test('works without a bucket configured', async () => {

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -55,10 +55,11 @@ function mockDb(options: { storageKeys?: string[]; deleteChanges: number }) {
 	return { db, deleteStatements };
 }
 
-function mockBucket() {
+function mockBucket(options: { failOn?: string } = {}) {
 	const deleted: string[] = [];
 	const bucket = {
 		async delete(key: string) {
+			if (options.failOn === key) throw new Error('R2 unavailable');
 			deleted.push(key);
 		}
 	} as unknown as R2Bucket;
@@ -110,6 +111,17 @@ describe('deleteUser', () => {
 
 		assert.equal(deleteStatements.length, 1);
 		assert.match(deleteStatements[0], /SELECT COUNT\(\*\) FROM users WHERE is_admin = 1/);
+	});
+
+	test('still succeeds when an R2 delete fails, and purges the rest', async () => {
+		// The D1 delete has already committed by this point. Throwing here would
+		// report failure for a deletion that happened, and the retry would say
+		// the user no longer exists.
+		const { db } = mockDb({ storageKeys: ['att/one', 'att/two'], deleteChanges: 1 });
+		const { bucket, deleted } = mockBucket({ failOn: 'att/one' });
+
+		await assert.doesNotReject(() => deleteUser(db, bucket, actor, targetRow.id));
+		assert.deepEqual(deleted, ['att/two']);
 	});
 
 	test('works without a bucket configured', async () => {

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -188,41 +188,50 @@ export async function deleteUser(
 			).results.map((row) => row.storage_key)
 		: [];
 
-	// The last-admin rule is enforced by the DELETE itself. Counting first and
-	// deleting after lets two admins delete each other concurrently — both
-	// reads see two admins, both deletes succeed, and nobody is left.
-	const result = await db
-		.prepare(
-			`DELETE FROM users
-			 WHERE id = ?
-			   AND (is_admin = 0 OR (SELECT COUNT(*) FROM users WHERE is_admin = 1) > 1)`
-		)
-		.bind(targetId)
-		.run();
-
-	if ((result.meta?.changes ?? 0) === 0) {
-		throw new Error('Keep at least one admin');
-	}
-
+	// One transaction: D1 rolls a batch back entirely if any statement fails, so
+	// the account can never be gone while its mail, sessions and tokens survive.
+	//
+	// The last-admin rule rides on the DELETE rather than a preceding read —
+	// counting first and deleting after lets two admins delete each other
+	// concurrently, both seeing two admins, leaving nobody. The child statements
+	// are then gated on the user actually having gone, so a refused delete
+	// leaves the account whole instead of stripping it inside the same batch.
+	//
 	// Older D1 databases were created without ON DELETE CASCADE enforcement, so
-	// clear the children explicitly — no-ops wherever the cascade already ran.
-	// email_attachments hangs off emails, so it has to go before those rows do.
-	await db.batch([
+	// the children are cleared explicitly; where the cascade ran they are no-ops.
+	// email_attachments is reachable only through emails, so it goes first.
+	const gone = 'NOT EXISTS (SELECT 1 FROM users WHERE id = ?)';
+	const [deletion] = await db.batch([
+		db
+			.prepare(
+				`DELETE FROM users
+				 WHERE id = ?
+				   AND (is_admin = 0 OR (SELECT COUNT(*) FROM users WHERE is_admin = 1) > 1)`
+			)
+			.bind(targetId),
 		db
 			.prepare(
 				`DELETE FROM email_attachments
-				 WHERE email_id IN (SELECT id FROM emails WHERE user_id = ?)`
+				 WHERE email_id IN (SELECT id FROM emails WHERE user_id = ?) AND ${gone}`
 			)
-			.bind(targetId),
-		db.prepare('DELETE FROM emails WHERE user_id = ?').bind(targetId),
-		db.prepare('DELETE FROM addresses WHERE user_id = ?').bind(targetId),
-		db.prepare('DELETE FROM sessions WHERE user_id = ?').bind(targetId),
-		db.prepare('DELETE FROM api_tokens WHERE user_id = ?').bind(targetId),
-		db.prepare('DELETE FROM push_subscriptions WHERE user_id = ?').bind(targetId),
+			.bind(targetId, targetId),
+		db.prepare(`DELETE FROM emails WHERE user_id = ? AND ${gone}`).bind(targetId, targetId),
+		db.prepare(`DELETE FROM addresses WHERE user_id = ? AND ${gone}`).bind(targetId, targetId),
+		db.prepare(`DELETE FROM sessions WHERE user_id = ? AND ${gone}`).bind(targetId, targetId),
+		db.prepare(`DELETE FROM api_tokens WHERE user_id = ? AND ${gone}`).bind(targetId, targetId),
 		db
-			.prepare('UPDATE domains SET catchall_user_id = NULL WHERE catchall_user_id = ?')
-			.bind(targetId)
+			.prepare(`DELETE FROM push_subscriptions WHERE user_id = ? AND ${gone}`)
+			.bind(targetId, targetId),
+		db
+			.prepare(
+				`UPDATE domains SET catchall_user_id = NULL WHERE catchall_user_id = ? AND ${gone}`
+			)
+			.bind(targetId, targetId)
 	]);
+
+	if ((deletion.meta?.changes ?? 0) === 0) {
+		throw new Error('Keep at least one admin');
+	}
 
 	// Purged only after the row is gone, so a refused delete never strands mail
 	// without the files it references. Best-effort from here: the account is

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -205,9 +205,17 @@ export async function deleteUser(
 	}
 
 	// Purged only after the row is gone, so a refused delete never strands mail
-	// without the files it references.
+	// without the files it references. Best-effort from here: the account is
+	// already deleted, so a storage hiccup must not report failure — the caller
+	// would retry and be told the user does not exist, with the strays no longer
+	// reachable from any metadata. Log them instead.
 	if (storageKeys.length > 0) {
-		await Promise.all(storageKeys.map((key) => bucket!.delete(key)));
+		const purged = await Promise.allSettled(storageKeys.map((key) => bucket!.delete(key)));
+		purged.forEach((outcome, index) => {
+			if (outcome.status === 'rejected') {
+				console.error('Failed to delete attachment object', storageKeys[index], outcome.reason);
+			}
+		});
 	}
 }
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -172,24 +172,13 @@ export async function deleteUser(
 		throw new Error('User not found');
 	}
 
-	// Collect the keys while the rows are still there: deleting the user
-	// cascades the attachment metadata away, and with it any way to find the
-	// objects it pointed at.
-	const storageKeys = bucket
-		? (
-				await db
-					.prepare(
-						`SELECT storage_key FROM email_attachments
-						 WHERE storage_key IS NOT NULL
-						   AND email_id IN (SELECT id FROM emails WHERE user_id = ?)`
-					)
-					.bind(targetId)
-					.all<{ storage_key: string }>()
-			).results.map((row) => row.storage_key)
-		: [];
-
 	// One transaction: D1 rolls a batch back entirely if any statement fails, so
 	// the account can never be gone while its mail, sessions and tokens survive.
+	//
+	// The key read is the batch's first statement rather than a preceding query.
+	// Reading outside the transaction leaves a window in which inbound delivery
+	// commits an attachment whose metadata this then deletes without ever having
+	// collected its object.
 	//
 	// The last-admin rule rides on the DELETE rather than a preceding read —
 	// counting first and deleting after lets two admins delete each other
@@ -201,7 +190,14 @@ export async function deleteUser(
 	// the children are cleared explicitly; where the cascade ran they are no-ops.
 	// email_attachments is reachable only through emails, so it goes first.
 	const gone = 'NOT EXISTS (SELECT 1 FROM users WHERE id = ?)';
-	const [deletion] = await db.batch([
+	const [keys, deletion] = await db.batch<{ storage_key: string }>([
+		db
+			.prepare(
+				`SELECT storage_key FROM email_attachments
+				 WHERE storage_key IS NOT NULL
+				   AND email_id IN (SELECT id FROM emails WHERE user_id = ?)`
+			)
+			.bind(targetId),
 		db
 			.prepare(
 				`DELETE FROM users
@@ -233,13 +229,15 @@ export async function deleteUser(
 		throw new Error('Keep at least one admin');
 	}
 
+	const storageKeys = (keys.results ?? []).map((row) => row.storage_key);
+
 	// Purged only after the row is gone, so a refused delete never strands mail
 	// without the files it references. Best-effort from here: the account is
 	// already deleted, so a storage hiccup must not report failure — the caller
 	// would retry and be told the user does not exist, with the strays no longer
 	// reachable from any metadata. Log them instead.
-	if (storageKeys.length > 0) {
-		const purged = await Promise.allSettled(storageKeys.map((key) => bucket!.delete(key)));
+	if (bucket && storageKeys.length > 0) {
+		const purged = await Promise.allSettled(storageKeys.map((key) => bucket.delete(key)));
 		purged.forEach((outcome, index) => {
 			if (outcome.status === 'rejected') {
 				console.error('Failed to delete attachment object', storageKeys[index], outcome.reason);

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 import { SESSION_COOKIE, SESSION_DAYS } from './constants';
 import { createSessionToken, hashPassword, hashToken, verifyPassword } from './crypto';
 import type { User } from '$lib/types';
@@ -152,7 +152,17 @@ export async function setUserPassword(
 	]);
 }
 
-export async function deleteUser(db: D1Database, actor: User, targetId: string): Promise<void> {
+/**
+ * Removes the account and everything the D1 cascade takes with it — sessions,
+ * addresses, mail — plus the R2 objects the mail's attachments point at, which
+ * the cascade cannot reach.
+ */
+export async function deleteUser(
+	db: D1Database,
+	bucket: R2Bucket | undefined,
+	actor: User,
+	targetId: string
+): Promise<void> {
 	if (actor.id === targetId) {
 		throw new Error('You cannot delete your own account');
 	}
@@ -162,14 +172,43 @@ export async function deleteUser(db: D1Database, actor: User, targetId: string):
 		throw new Error('User not found');
 	}
 
-	if (target.is_admin) {
-		const admins = (await listUsers(db)).filter((user) => user.is_admin);
-		if (admins.length <= 1) {
-			throw new Error('Keep at least one admin');
-		}
+	// Collect the keys while the rows are still there: deleting the user
+	// cascades the attachment metadata away, and with it any way to find the
+	// objects it pointed at.
+	const storageKeys = bucket
+		? (
+				await db
+					.prepare(
+						`SELECT storage_key FROM email_attachments
+						 WHERE storage_key IS NOT NULL
+						   AND email_id IN (SELECT id FROM emails WHERE user_id = ?)`
+					)
+					.bind(targetId)
+					.all<{ storage_key: string }>()
+			).results.map((row) => row.storage_key)
+		: [];
+
+	// The last-admin rule is enforced by the DELETE itself. Counting first and
+	// deleting after lets two admins delete each other concurrently — both
+	// reads see two admins, both deletes succeed, and nobody is left.
+	const result = await db
+		.prepare(
+			`DELETE FROM users
+			 WHERE id = ?
+			   AND (is_admin = 0 OR (SELECT COUNT(*) FROM users WHERE is_admin = 1) > 1)`
+		)
+		.bind(targetId)
+		.run();
+
+	if ((result.meta?.changes ?? 0) === 0) {
+		throw new Error('Keep at least one admin');
 	}
 
-	await db.prepare('DELETE FROM users WHERE id = ?').bind(targetId).run();
+	// Purged only after the row is gone, so a refused delete never strands mail
+	// without the files it references.
+	if (storageKeys.length > 0) {
+		await Promise.all(storageKeys.map((key) => bucket!.delete(key)));
+	}
 }
 
 export async function getUserFromSession(db: D1Database, token: string | undefined): Promise<User | null> {

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -204,6 +204,26 @@ export async function deleteUser(
 		throw new Error('Keep at least one admin');
 	}
 
+	// Older D1 databases were created without ON DELETE CASCADE enforcement, so
+	// clear the children explicitly — no-ops wherever the cascade already ran.
+	// email_attachments hangs off emails, so it has to go before those rows do.
+	await db.batch([
+		db
+			.prepare(
+				`DELETE FROM email_attachments
+				 WHERE email_id IN (SELECT id FROM emails WHERE user_id = ?)`
+			)
+			.bind(targetId),
+		db.prepare('DELETE FROM emails WHERE user_id = ?').bind(targetId),
+		db.prepare('DELETE FROM addresses WHERE user_id = ?').bind(targetId),
+		db.prepare('DELETE FROM sessions WHERE user_id = ?').bind(targetId),
+		db.prepare('DELETE FROM api_tokens WHERE user_id = ?').bind(targetId),
+		db.prepare('DELETE FROM push_subscriptions WHERE user_id = ?').bind(targetId),
+		db
+			.prepare('UPDATE domains SET catchall_user_id = NULL WHERE catchall_user_id = ?')
+			.bind(targetId)
+	]);
+
 	// Purged only after the row is gone, so a refused delete never strands mail
 	// without the files it references. Best-effort from here: the account is
 	// already deleted, so a storage hiccup must not report failure — the caller

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -2,6 +2,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import StackHeader from '$lib/components/StackHeader.svelte';
 	import AddressField from '$lib/components/AddressField.svelte';
+	import Check from '$lib/components/Check.svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -10,6 +11,7 @@
 	let newUserDomainId = $state('');
 	let name = $state('');
 	let password = $state('');
+	let makeAdmin = $state(false);
 
 	$effect(() => {
 		if (!newUserDomainId && data.domains[0]) {
@@ -18,6 +20,9 @@
 	});
 	let userError = $state('');
 	let creatingUser = $state(false);
+
+	let deleteError = $state('');
+	let deletingUser = $state<string | null>(null);
 
 	let connecting = $state<string | null>(null);
 	let domainError = $state('');
@@ -43,7 +48,13 @@
 			const res = await fetch('/api/admin/users', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ name, localPart, domainId: newUserDomainId, password })
+				body: JSON.stringify({
+					name,
+					localPart,
+					domainId: newUserDomainId,
+					password,
+					isAdmin: makeAdmin
+				})
 			});
 			const body = await res.json();
 			if (!res.ok) {
@@ -55,6 +66,37 @@
 			userError = 'Network error';
 		} finally {
 			creatingUser = false;
+		}
+	}
+
+	/**
+	 * The server refuses self-deletion and the last remaining admin, so those
+	 * errors surface here rather than being pre-empted in the UI.
+	 */
+	async function removeUser(userId: string, label: string) {
+		if (
+			!confirm(
+				`Delete ${label}? Their addresses and stored mail go too, and any domain they catch mail for falls back to unrouted.`
+			)
+		) {
+			return;
+		}
+
+		deleteError = '';
+		deletingUser = userId;
+
+		try {
+			const res = await fetch(`/api/admin/users/${userId}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const body = await res.json().catch(() => ({}));
+				deleteError = body.error ?? 'Failed to delete user';
+				return;
+			}
+			window.location.reload();
+		} catch {
+			deleteError = 'Network error';
+		} finally {
+			deletingUser = null;
 		}
 	}
 
@@ -250,6 +292,16 @@
 					class="admin-input"
 				/>
 
+				<div class="role-row">
+					<Check
+						label="Make this user an admin"
+						caption="Admin"
+						checked={makeAdmin}
+						onchange={(next) => (makeAdmin = next)}
+					/>
+					<span class="role-hint">Can manage users, domains, and unrouted mail.</span>
+				</div>
+
 				{#if userError}<p class="error">{userError}</p>{/if}
 
 				<button type="submit" disabled={creatingUser} class="btn-primary">
@@ -276,9 +328,22 @@
 						{#if user.is_admin}
 							<span class="admin-badge">Admin</span>
 						{/if}
+						{#if user.id !== data.user?.id}
+							<button
+								type="button"
+								class="user-delete"
+								title="Delete {user.name}"
+								aria-label="Delete {user.name}"
+								disabled={deletingUser === user.id}
+								onclick={() => removeUser(user.id, user.name)}
+							>
+								<Icon name="delete-bin-line" size={16} />
+							</button>
+						{/if}
 					</li>
 				{/each}
 			</ul>
+			{#if deleteError}<p class="error">{deleteError}</p>{/if}
 		</section>
 	</div>
 
@@ -542,6 +607,56 @@
 		font-weight: 500;
 		color: var(--color-text);
 		background: var(--color-surface-muted);
+	}
+
+	.role-row {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		flex-wrap: wrap;
+	}
+
+	.role-hint {
+		font-size: 0.75rem;
+		color: var(--color-muted);
+	}
+
+	.user-delete {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border: none;
+		border-radius: 0.5rem;
+		color: var(--color-muted);
+		background: transparent;
+		cursor: pointer;
+		transition: color 0.15s, background 0.15s;
+	}
+
+	.user-delete:hover:not(:disabled) {
+		color: var(--color-danger);
+		background: var(--color-surface-muted);
+	}
+
+	.user-delete:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 3px var(--color-focus-halo);
+	}
+
+	.user-delete:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+
+	@media (max-width: 900px) {
+		.user-delete {
+			width: var(--touch-target);
+			height: var(--touch-target);
+		}
 	}
 
 	.error {

--- a/src/routes/api/admin/users/+server.ts
+++ b/src/routes/api/admin/users/+server.ts
@@ -31,6 +31,7 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 		domainId?: string;
 		localPart?: string;
 		password?: string;
+		isAdmin?: boolean;
 	};
 
 	if (!body.name?.trim() || !body.localPart?.trim() || !body.domainId) {
@@ -52,7 +53,8 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 		const user = await createUser(db, {
 			email: `${localPart}@${domain.name}`,
 			name: body.name,
-			password: body.password
+			password: body.password,
+			isAdmin: body.isAdmin === true
 		});
 
 		const address = await createAddress(db, {

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -34,7 +34,7 @@ export const DELETE: RequestHandler = async ({ params, locals, platform }) => {
 	if (!db) return json({ error: 'Database unavailable' }, { status: 503 });
 
 	try {
-		await deleteUser(db, locals.user, params.id!);
+		await deleteUser(db, platform?.env.ATTACHMENTS, locals.user, params.id!);
 		return json({ ok: true });
 	} catch (error) {
 		return json(


### PR DESCRIPTION
## Why

The admin dashboard can create users but never grant admin, and the `DELETE` handler at `/api/admin/users/[id]` has no caller in the UI.

That makes `bootstrapAdmin` the only path to an admin account, and it is reachable only from first-run `/setup`, which is gated on `countUsers(db) === 0`. So an instance gets exactly one admin, ever — promoting a second one means editing D1 by hand:

```
wrangler d1 execute quickmail --remote --command \
  "UPDATE users SET is_admin = 1 WHERE email = '...'"
```

`deleteUser` already guards `Keep at least one admin`, which reads like multiple admins were always intended — there just wasn't a supported way to create them.

## What changed

- `POST /api/admin/users` accepts `isAdmin` and forwards it to `createUser`, which already took the parameter.
- The create-user form gains an **Admin** toggle, reusing the existing `Check` component from the API-keys UI rather than introducing a new control.
- Each user row gains a delete button, hidden for the signed-in admin.

Server rules are not duplicated on the client. `deleteUser` already refuses self-deletion and removal of the last admin, so those errors surface inline under the list instead of becoming a second source of truth.

## Notes

- No schema change — `users.is_admin` and both endpoints already existed.
- Deleting a user cascades to their sessions, addresses, and stored mail, and a domain they were catch-all for gets `catchall_user_id = NULL`, after which unmatched mail lands in the unrouted view. The confirm dialog says this.
- Admin stays an all-or-nothing role; this doesn't introduce granular permissions.

## Testing

Full CI sequence run on a clean checkout of this commit:

- `bun run check:clean` — clean, 188 tracked files scanned
- `bun run check` — **0 errors** (2 warnings, both pre-existing in `MobileChrome.svelte` and `settings/+page.svelte`, neither touched here)
- `bun run build` — passes
- `bun run test` — 49 pass, 0 fail

Also deployed to a live instance running the Cloudflare Email Service provider, and confirmed both changes are present in the built worker bundle. Interactive click-through of the two new controls hasn't been done yet — worth a look from a reviewer who has an instance handy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can assign admin status when creating new users.
  * Administrators can delete users other than themselves after confirming the action.
  * Added loading indicators and clear error messages for user deletion.

* **Bug Fixes**
  * User deletion now protects against removing the final administrator.
  * Associated uploaded attachments are cleaned up when a user is deleted.

* **Style**
  * Improved styling for admin-role controls and the delete action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->