### PR TITLE
Attribute inbound mail to the From: header, not the bounce envelope

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"cf-typegen": "wrangler types",
 		"quickmail": "bun cli/main.ts",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/html.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts src/lib/server/cloudflare-inbound.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/lib/server/cloudflare-inbound.test.ts
+++ b/src/lib/server/cloudflare-inbound.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { inboundSender } from './cloudflare-inbound';
+
+describe('inboundSender', () => {
+	test('prefers the From: header over the bounce envelope sender', () => {
+		// Cloudflare Email Sending puts bounces@cf-bounce.<domain> in MAIL FROM, so
+		// mail between two addresses on the same instance arrives with an envelope
+		// sender that is not the author. Taking it would mis-attribute the message
+		// and point replies at the bounce mailbox.
+		assert.equal(
+			inboundSender('alice@example.com', 'bounces@cf-bounce.example.com'),
+			'alice@example.com'
+		);
+	});
+
+	test('falls back to the envelope sender when there is no From: header', () => {
+		assert.equal(inboundSender(undefined, 'someone@example.com'), 'someone@example.com');
+		assert.equal(inboundSender('', 'someone@example.com'), 'someone@example.com');
+	});
+
+	test('falls back when the From: header yields no address', () => {
+		// Blank and malformed headers are still truthy strings, so the choice has
+		// to turn on whether an address came out of them.
+		assert.equal(inboundSender('   ', 'someone@example.com'), 'someone@example.com');
+		assert.equal(inboundSender('<>', 'someone@example.com'), 'someone@example.com');
+		assert.equal(
+			inboundSender('undisclosed-recipients', 'someone@example.com'),
+			'someone@example.com'
+		);
+	});
+
+	test('unwraps a display name', () => {
+		assert.equal(inboundSender('Grace Hopper <grace@example.com>', ''), 'grace@example.com');
+	});
+
+	test('normalises case', () => {
+		assert.equal(inboundSender('Grace@Example.COM', ''), 'grace@example.com');
+	});
+
+	test('returns an empty string when neither is present', () => {
+		assert.equal(inboundSender(undefined, undefined), '');
+	});
+});

--- a/src/lib/server/cloudflare-inbound.ts
+++ b/src/lib/server/cloudflare-inbound.ts
@@ -39,7 +39,7 @@ export async function handleCloudflareInbound(
 		bcc: mailboxAddresses(parsed.bcc)
 	});
 
-	const from = parseEmailAddress(message.from || mailboxAddresses(parsed.from)[0] || '');
+	const from = inboundSender(mailboxAddresses(parsed.from)[0], message.from);
 	const subject = parsed.subject?.trim() || message.headers.get('subject')?.trim() || '(no subject)';
 	const messageId =
 		normalizeMessageId(parsed.messageId ?? message.headers.get('message-id')) ?? null;
@@ -116,6 +116,30 @@ async function storeInboundAttachments(
 			console.error('Failed to store inbound Cloudflare attachment', attachment.filename, error);
 		}
 	}
+}
+
+/**
+ * Who the mail is *from*, for display, replies and search.
+ *
+ * `message.from` is the envelope sender — SMTP `MAIL FROM` — which providers
+ * routinely point at a bounce mailbox rather than the author. Cloudflare Email
+ * Sending uses `bounces@cf-bounce.<domain>`, and VERP senders behave the same
+ * way, so preferring the envelope attributes mail to the bounce address and
+ * sends replies there. The `From:` header carries the author, so it wins; the
+ * envelope is only a fallback for mail that arrives without a usable header.
+ */
+export function inboundSender(
+	headerFrom: string | undefined,
+	envelopeFrom: string | undefined
+): string {
+	// Choose on whether the header actually yielded an address, not on whether it
+	// was present: a blank or malformed `From:` is still a truthy string, and
+	// picking it on that alone would skip the fallback entirely.
+	const header = parseEmailAddress(headerFrom ?? '');
+	if (header.includes('@')) return header;
+
+	const envelope = parseEmailAddress(envelopeFrom ?? '');
+	return envelope || header;
 }
 
 function mailboxAddresses(value: Address | Address[] | undefined): string[] {


### PR DESCRIPTION
## The bug

Inbound mail on the Cloudflare path is attributed to the envelope sender:

```ts
const from = parseEmailAddress(message.from || mailboxAddresses(parsed.from)[0] || '');
```

`message.from` is the envelope sender — SMTP `MAIL FROM` — and the parsed `From:` header is only a fallback. Senders routinely put a bounce mailbox in the envelope, so the author is lost whenever the two differ.

**Cloudflare Email Sending always differs.** It sends with `bounces@cf-bounce.<domain>` as `MAIL FROM`, which is what the `cf-bounce` MX and DKIM records onboarding creates are for. So on a Cloudflare-provider deployment, mail between two addresses on the same instance arrives attributed to the bounce address. VERP senders — SES, SendGrid, Mailchimp — hit the same path.

The two halves of one message, as stored:

```
outbound  alice@example.com              → bob@example.com   "test message"
inbound   bounces@cf-bounce.example.com  → bob@example.com   "test message"
```

## Why it isn't only cosmetic

`from_addr` is what a reply is addressed to:

```ts
// src/routes/api/mail/[id]/+server.ts
const to = original.direction === 'inbound' ? original.from_addr : original.to_addr;
```

So replying to an affected message sends to the bounce mailbox instead of the sender. It also feeds thread participants (`mail-store.ts`) and sender search.

## The fix

The header wins; the envelope stays as a fallback for mail arriving without a usable `From:`. This is what the Resend path already does — it reads `received.from`, the header.

Pulled out as `inboundSender()` so the precedence is stated once, documented, and testable.

A follow-up commit makes the fallback turn on whether the header actually yielded an address rather than on truthiness: `parseEmailAddress` returns its input when it finds no address, so a blank header, a bare `<>`, or `undisclosed-recipients` were all truthy and skipped the fallback.

## Testing

- 6 unit tests on `inboundSender`, including the Cloudflare bounce-envelope case and the malformed-header fallbacks. Mutation-checked both ways: restoring envelope-first precedence fails the precedence test, and reverting to the truthiness pick fails the fallback test.
- `bun run test` — 55 pass, 0 fail
- `bun run check` — 0 errors
- **Verified live** on a Cloudflare Email Service deployment. Before the fix, a message between two addresses on the same domain stored `bounces@cf-bounce.<domain>`; after it, the same send stored the actual sending address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inbound email sender detection by prioritizing a valid `From:` address.
  - Added fallback to the envelope sender when the `From:` header is missing, empty, or malformed.
  - Improved sender formatting, including display-name handling and consistent address casing.
  - Returns a blank sender value when no valid sender information is available.

- **Tests**
  - Expanded coverage for sender parsing and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->