### PR TITLE
Give phones a way to sign out

### DIFF
--- a/src/lib/components/MobileChrome.svelte
+++ b/src/lib/components/MobileChrome.svelte
@@ -299,6 +299,13 @@
 			bottom: 0;
 			left: 0;
 			z-index: 50;
+			/* Landscape phones are short enough that the sheet can outgrow the
+			   viewport once a domain switcher and Log out are both present. It is
+			   anchored to the bottom, so without this the top is clipped off-screen
+			   with no way to reach it. */
+			max-height: calc(100dvh - 1rem);
+			overflow-y: auto;
+			overscroll-behavior: contain;
 			padding: 0.5rem 1rem calc(1rem + env(safe-area-inset-bottom));
 			background: var(--color-surface);
 			border-radius: 1.25rem 1.25rem 0 0;

--- a/src/lib/components/MobileChrome.svelte
+++ b/src/lib/components/MobileChrome.svelte
@@ -9,12 +9,14 @@
 		counts,
 		domains,
 		activeDomainId,
-		isAdmin
+		isAdmin,
+		onLogout
 	}: {
 		counts: MailboxCounts;
 		domains: Domain[];
 		activeDomainId: string | null;
 		isAdmin: boolean;
+		onLogout: () => void;
 	} = $props();
 
 	let moreOpen = $state(false);
@@ -158,6 +160,18 @@
 				<DomainSwitcher {domains} {activeDomainId} block />
 			</div>
 		{/if}
+
+		<!--
+			The topbar's account menu is the only other way out, and it is hidden on
+			phones for stacked and utility pages — so on Settings and Admin, where
+			people go looking for it, there was no way to sign out at all.
+		-->
+		<div class="sheet-section">
+			<button type="button" class="sheet-link sheet-logout" onclick={onLogout}>
+				<Icon name="logout-box-r-line" size={20} />
+				<span>Log out</span>
+			</button>
+		</div>
 	</div>
 {/if}
 
@@ -333,6 +347,15 @@
 			margin-top: 0.875rem;
 			padding-top: 0.875rem;
 			box-shadow: inset 0 1px 0 var(--color-line);
+		}
+
+		.sheet-logout {
+			width: 100%;
+			border: none;
+			background: transparent;
+			font: inherit;
+			text-align: left;
+			cursor: pointer;
 		}
 
 		.sheet-title {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -139,6 +139,7 @@
 				domains={data.domains}
 				activeDomainId={data.activeDomainId}
 				isAdmin={data.user!.is_admin}
+				onLogout={logout}
 			/>
 		{/if}
 	</div>


### PR DESCRIPTION
## The bug

On a phone there is no way to sign out of Settings or Admin, and no obvious way anywhere else.

`Log out` exists in exactly one place in the app — the account menu in `Topbar.svelte`. That topbar is hidden on phones for two whole classes of page:

```css
/* Topbar.svelte */
@media (max-width: 900px) {
  :global(.app-shell[data-stacked='true'] .topbar),
  :global(.app-shell[data-utility='true'] .topbar) { display: none; }
}
```

`isUtilityPath` is `/settings` and `/admin`. Those keep the bottom tab bar and drop the topbar — but the More sheet that stands in for it lists Drafts, Trash, Settings, Admin and Domains, and no Log out. So on the two pages a person is most likely to go looking, signing out is not possible at all.

On mailbox pages the topbar is present, but `.account-text` is `min-width: 901px`, so the trigger renders as a bare avatar circle with no accompanying name or address. It is reachable, but there is nothing indicating it is the account menu.

## The fix

Adds `Log out` to the More sheet, which renders on every non-stacked page — so it now covers Settings and Admin as well as the mailboxes. `MobileChrome` takes an `onLogout` prop and the layout passes the handler it already has for the topbar, so both entry points run the same code path.

`/compose` and `/mail/*` are left alone deliberately: both the topbar and the tab bar are hidden there by design, and they are transient views you back out of.

## Testing

- `bun run check:clean` — clean, 188 tracked files
- `bun run check` — 0 errors (2 warnings, both pre-existing and in files this doesn't touch)
- `bun run test` — 49 pass, 0 fail
- `bun run build` — passes
- Deployed to a live instance and confirmed `Log out` ships in the built client bundle

There is no component test here — the repo has no harness for rendering Svelte components, and adding one for a single sheet entry felt disproportionate. Happy to add one if you would like the infrastructure.

Follows on from #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Log out” button to the mobile more menu.
  * Logging out now disables push notifications, clears the active session, and redirects to the login screen.

* **Bug Fixes**
  * Improved the mobile more menu on short landscape screens by enabling internal scrolling and keeping its top content accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->