### PR TITLE
Keep desktop compose full-width instead of a phone column

### DIFF
--- a/src/lib/components/RichTextEditor.svelte
+++ b/src/lib/components/RichTextEditor.svelte
@@ -13,7 +13,7 @@
 		placeholder?: string;
 		minHeight?: number;
 		embedded?: boolean;
-		/** Grow to fill the composer and drop the desktop card chrome. */
+		/** On phones, grow to fill the composer and drop the card chrome. */
 		fill?: boolean;
 		toolbarEnd?: import('svelte').Snippet;
 	} = $props();
@@ -81,7 +81,7 @@
 		role="textbox"
 		aria-multiline="true"
 		class="editor prose prose-sm max-w-none px-4 py-3 outline-none"
-		style:min-height={fill ? undefined : `${minHeight}px`}
+		style:--editor-min-height="{minHeight}px"
 		data-placeholder={placeholder}
 		oninput={handleInput}
 		onpaste={handlePaste}
@@ -112,19 +112,6 @@
 		padding-right: 0;
 	}
 
-	.editor-shell-fill {
-		display: flex;
-		flex-direction: column;
-		flex: 1;
-		min-height: 0;
-	}
-
-	.editor-shell-fill .editor {
-		flex: 1;
-		min-height: 0;
-		overflow-y: auto;
-	}
-
 	.toolbar {
 		display: flex;
 		align-items: center;
@@ -137,6 +124,7 @@
 	}
 
 	.editor {
+		min-height: var(--editor-min-height, 240px);
 		color: var(--color-text);
 	}
 
@@ -151,6 +139,10 @@
 		}
 
 		.editor-shell-fill {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+			min-height: 0;
 			border-radius: 0;
 			box-shadow: none;
 			background: transparent;
@@ -171,7 +163,9 @@
 		}
 
 		.editor-shell-fill .editor {
+			flex: 1;
 			min-height: 8rem;
+			overflow-y: auto;
 			padding: 0.75rem 1rem 1rem;
 		}
 	}

--- a/src/lib/components/SwipeBack.svelte
+++ b/src/lib/components/SwipeBack.svelte
@@ -153,14 +153,10 @@
 	}
 
 	@media (min-width: 901px) {
+		/* Phone stacked-screen chrome only. A real box here becomes a centred
+		   surface column on desktop and squeezes compose/thread into a phone. */
 		.swipe-back {
-			touch-action: auto;
-		}
-
-		.swipe-back.dragging,
-		.swipe-back:not(.dragging) {
-			transform: none;
-			transition: none;
+			display: contents;
 		}
 	}
 

--- a/src/lib/mobile.test.ts
+++ b/src/lib/mobile.test.ts
@@ -106,6 +106,25 @@ test('phone gestures follow the 900px shell, not desktop pointer type', () => {
 	}
 });
 
+test('stacked swipe wrapper does not become a phone column on desktop', () => {
+	const source = readFileSync(join(root, 'src/lib/components/SwipeBack.svelte'), 'utf8');
+	assert.match(source, /@media \(min-width:\s*901px\)[\s\S]*display:\s*contents/);
+});
+
+test('compose is not a centred reading column on desktop', () => {
+	const source = readFileSync(join(root, 'src/routes/+layout.svelte'), 'utf8');
+	assert.match(source, /const NARROW = \['\/mail', '\/settings'\]/);
+	assert.doesNotMatch(source, /NARROW = \[[^\]]*\/compose/);
+});
+
+test('composer fill layout is phone-only', () => {
+	const source = readFileSync(join(root, 'src/lib/components/RichTextEditor.svelte'), 'utf8');
+	const style = source.split('<style>')[1] ?? '';
+	const desktop = style.split('@media (max-width: 900px)')[0] ?? '';
+	assert.doesNotMatch(desktop, /\.editor-shell-fill\s*\{/);
+	assert.match(style, /@media \(max-width: 900px\)[\s\S]*\.editor-shell-fill/);
+});
+
 test('service worker is a classic worker, not a Vite module', () => {
 	const source = readFileSync(join(root, 'src/service-worker.ts'), 'utf8');
 	assert.match(source, /addEventListener\('install'/);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,8 +26,9 @@
 	// Onboarding runs before the user has an address, so the shell would be empty.
 	const showShell = $derived(Boolean(data.user) && $page.url.pathname !== '/onboarding');
 
-	// Pages that read better centred than full-bleed.
-	const NARROW = ['/compose', '/mail', '/settings'];
+	// Thread and settings read better as a centred column. Compose needs the
+	// full desktop pane — a 48rem cap makes it look like a phone form.
+	const NARROW = ['/mail', '/settings'];
 	const narrow = $derived(NARROW.some((path) => $page.url.pathname.startsWith(path)));
 	const stacked = $derived(isStackedPath($page.url.pathname));
 	const mailbox = $derived(isMailboxPath($page.url.pathname));

--- a/src/routes/compose/+page.svelte
+++ b/src/routes/compose/+page.svelte
@@ -267,7 +267,7 @@
 	{/if}
 
 	<div class="compose-editor">
-		<RichTextEditor bind:html fill minHeight={160}>
+		<RichTextEditor bind:html fill minHeight={320}>
 			{#snippet toolbarEnd()}
 				<AttachmentPicker bind:attachments mode="button" />
 				<button
@@ -303,6 +303,10 @@
 </form>
 
 <style>
+	.compose-page {
+		width: 100%;
+	}
+
 	.compose-header {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
## Summary
- Stop treating compose as a centred 48rem reading column on desktop so the form uses the full content pane.
- Make the mobile swipe wrapper a layout no-op above 900px, and keep the editor fill/chrome for phones only.

## Test plan
- [ ] On a wide desktop viewport, open **New message** and confirm the compose form spans the main pane (no large gutters).
- [ ] Confirm the desktop header (Cc/Bcc, Save draft, Send) and Attach footer are still used.
- [ ] Resize under 900px and confirm compose is still full-bleed with the mobile close/send bar.
- [ ] Open a thread and Settings on desktop and confirm those stay as a centred reading column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved responsive layouts so desktop views no longer use phone-specific swipe and column behavior.
  - Limited rich-text editor fill mode to phone-sized screens.
  - Updated the compose page to use the full available width.

- **Improvements**
  - Increased the compose editor’s minimum height for a more comfortable writing experience.
  - Improved scrolling and space usage when the editor fills the phone viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->