### PR TITLE
Keep forwarded mail in a separate conversation

### DIFF
--- a/src/lib/server/mail-store.ts
+++ b/src/lib/server/mail-store.ts
@@ -48,6 +48,8 @@ export async function insertEmail(
 		providerId?: string | null;
 		status?: MailStatus | null;
 		isRead?: boolean;
+		/** Disable fallback grouping when this message must start a conversation. */
+		subjectMatch?: boolean;
 	}
 ): Promise<string> {
 	const id = crypto.randomUUID();
@@ -66,7 +68,7 @@ export async function insertEmail(
 		references: input.references,
 		replyToEmailId: input.replyToEmailId,
 		domainId: input.domainId,
-		subjectMatch: input.status !== 'draft'
+		subjectMatch: input.subjectMatch ?? input.status !== 'draft'
 	});
 
 	await db

--- a/src/lib/server/mail-store.ts
+++ b/src/lib/server/mail-store.ts
@@ -60,6 +60,7 @@ export async function insertEmail(
 	// view never has to guess.
 	const threadId = await resolveThreadId(db, input.userId, {
 		emailId: id,
+		direction: input.direction,
 		subject: input.subject,
 		from: input.from,
 		to: input.to,

--- a/src/lib/server/outbox.ts
+++ b/src/lib/server/outbox.ts
@@ -30,6 +30,8 @@ export type ComposeInput = {
 	references?: string | null;
 	replyToEmailId?: string | null;
 	attachments?: OutboundAttachmentInput[];
+	/** Disable subject fallback for messages that intentionally start a thread. */
+	subjectMatch?: boolean;
 };
 
 /**
@@ -162,7 +164,8 @@ export async function sendAndStore(
 		addressId: from.id,
 		providerId,
 		status: initialOutboundStatus(provider.kind),
-		isRead: true
+		isRead: true,
+		subjectMatch: input.subjectMatch
 	});
 
 	if (attachments.length > 0) {

--- a/src/lib/server/threads.test.ts
+++ b/src/lib/server/threads.test.ts
@@ -29,6 +29,7 @@ describe('domain-scoped threading', () => {
 			'user-1',
 			{
 				emailId,
+				direction: 'inbound',
 				subject: 'Inbox test',
 				from: 'sender@external.test',
 				to: 'support@example.org',
@@ -47,6 +48,7 @@ describe('domain-scoped threading', () => {
 			'user-1',
 			{
 				emailId: 'new-reply',
+				direction: 'inbound',
 				subject: 'Re: Inbox test',
 				from: 'sender@external.test',
 				to: 'support@example.org',
@@ -81,6 +83,7 @@ describe('subject fallback', () => {
 
 		const threadId = await resolveThreadId(db, 'user-1', {
 			emailId: 'forward-to-bob',
+			direction: 'outbound',
 			subject: 'Fwd: Quarterly figures',
 			from: 'me@example.com',
 			to: 'bob@example.com',
@@ -90,5 +93,68 @@ describe('subject fallback', () => {
 
 		assert.equal(threadId, 'forward-to-bob');
 		assert.equal(subjectLookupRan, false);
+	});
+
+	test('matches a reply to a forward through the external sender', async () => {
+		const db = {
+			prepare(sql: string) {
+				return {
+					bind(...values: unknown[]) {
+						return {
+							async first() {
+								if (!sql.includes('AND thread_key = ?')) return null;
+								assert.equal(values.at(-1), 'bob@example.com');
+								assert.equal(values.includes('me@example.com'), false);
+								return {
+									id: 'forward-to-bob',
+									thread_id: 'forward-to-bob'
+								};
+							}
+						};
+					}
+				};
+			}
+		} as unknown as D1Database;
+
+		const threadId = await resolveThreadId(db, 'user-1', {
+			emailId: 'reply-from-bob',
+			direction: 'inbound',
+			subject: 'Re: Fwd: Quarterly figures',
+			from: 'bob@example.com',
+			to: 'me@example.com',
+			domainId: 'example.com'
+		});
+
+		assert.equal(threadId, 'forward-to-bob');
+	});
+
+	test('does not match a reply to a forward through the user mailbox', async () => {
+		const db = {
+			prepare(sql: string) {
+				return {
+					bind(...values: unknown[]) {
+						return {
+							async first() {
+								if (!sql.includes('AND thread_key = ?')) return null;
+								assert.equal(values.at(-1), 'bob@example.com');
+								assert.equal(values.includes('me@example.com'), false);
+								return null;
+							}
+						};
+					}
+				};
+			}
+		} as unknown as D1Database;
+
+		const threadId = await resolveThreadId(db, 'user-1', {
+			emailId: 'reply-from-bob',
+			direction: 'inbound',
+			subject: 'Re: Fwd: Quarterly figures',
+			from: 'bob@example.com',
+			to: 'me@example.com',
+			domainId: 'example.com'
+		});
+
+		assert.equal(threadId, 'reply-from-bob');
 	});
 });

--- a/src/lib/server/threads.test.ts
+++ b/src/lib/server/threads.test.ts
@@ -57,3 +57,38 @@ describe('domain-scoped threading', () => {
 		assert.equal(threadId, 'earlier-thread');
 	});
 });
+
+describe('subject fallback', () => {
+	test('does not merge a forward through the sender mailbox when disabled', async () => {
+		let subjectLookupRan = false;
+		const db = {
+			prepare(sql: string) {
+				subjectLookupRan = subjectLookupRan || sql.includes('AND thread_key = ?');
+				return {
+					bind() {
+						return {
+							async first() {
+								return {
+									id: 'alice-message',
+									thread_id: 'alice-thread'
+								};
+							}
+						};
+					}
+				};
+			}
+		} as unknown as D1Database;
+
+		const threadId = await resolveThreadId(db, 'user-1', {
+			emailId: 'forward-to-bob',
+			subject: 'Fwd: Quarterly figures',
+			from: 'me@example.com',
+			to: 'bob@example.com',
+			domainId: 'example.com',
+			subjectMatch: false
+		});
+
+		assert.equal(threadId, 'forward-to-bob');
+		assert.equal(subjectLookupRan, false);
+	});
+});

--- a/src/lib/server/threads.ts
+++ b/src/lib/server/threads.ts
@@ -91,6 +91,7 @@ function addressesIn(value: string | null | undefined): string[] {
 export type ThreadLookup = {
 	/** Id already minted for the message being inserted; used as a new thread id. */
 	emailId: string;
+	direction: 'inbound' | 'outbound';
 	subject: string;
 	from: string;
 	to: string;
@@ -148,12 +149,14 @@ export async function resolveThreadId(
 
 	if (input.subjectMatch !== false) {
 		const threadKey = normalizeSubject(input.subject);
+		// Only the correspondent side identifies a conversation. Including both
+		// sides lets every message overlap through the user's own mailbox.
+		const correspondentAddresses =
+			input.direction === 'inbound'
+				? addressesIn(input.from)
+				: [...addressesIn(input.to), ...addressesIn(input.cc)];
 		const participants = [
-			...new Set([
-				...addressesIn(input.from),
-				...addressesIn(input.to),
-				...addressesIn(input.cc)
-			])
+			...new Set(correspondentAddresses)
 		].slice(0, MAX_PARTICIPANTS);
 
 		if (threadKey && threadKey !== '(no subject)' && participants.length > 0) {

--- a/src/routes/api/mail/[id]/forward/+server.ts
+++ b/src/routes/api/mail/[id]/forward/+server.ts
@@ -63,6 +63,7 @@ export const POST: RequestHandler = async ({ params, request, locals, platform }
 			subject,
 			text,
 			html,
+			subjectMatch: false,
 			attachments:
 				body.includeAttachments === false
 					? []


### PR DESCRIPTION
## Summary
- let outbound callers explicitly disable subject-based thread matching
- disable that fallback for forwards so the sender's own mailbox cannot merge them into the source conversation
- add a regression test covering an Alice thread forwarded to Bob

Closes #42

## Test plan
- [x] `bun test src/lib/server/threads.test.ts src/lib/server/outbox.test.ts src/lib/server/forward.test.ts` (24 passed)
- [x] changed-file diagnostics (no errors)
- [ ] `bun test` (118 passed, 1 unrelated existing failure: `compose is not a centred reading column on desktop`)
- [ ] `bun run check` (blocked by existing generated `.svelte-kit/output` diagnostics: 1,722 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forwarded emails now reliably start a new conversation instead of being grouped with an existing thread sharing the same subject.
  * Improved conversation assignment for replies to forwarded messages by matching the correct external participants.
  * Normal subject-based grouping remains available for other incoming and outgoing emails.

* **Tests**
  * Added coverage for forwarded-message threading and participant-aware conversation matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->