### PR TITLE
Show new mail in the inbox without a manual refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"quickinbox": "bun cli/main.ts",
 		"quickmail": "bun cli/main.ts",
 		"translate": "gt translate",
-		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/email-html.test.ts src/lib/utils/html.test.ts src/lib/device-activity.test.ts src/lib/i18n/translate.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/attachments.test.ts src/lib/server/auth.test.ts src/lib/server/cloudflare-inbound.test.ts src/lib/server/email-address.test.ts src/lib/server/email-provider.test.ts src/lib/server/forward.test.ts src/lib/server/mail-store.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts src/lib/server/threads.test.ts cli/client.test.ts"
+		"test": "bun test src/lib/email-signature.test.ts src/lib/mobile.test.ts src/lib/push-client.test.ts src/lib/utils/email-html.test.ts src/lib/utils/html.test.ts src/lib/device-activity.test.ts src/lib/i18n/translate.test.ts src/lib/mail/sync.test.ts src/lib/server/api-access.test.ts src/lib/server/api-tokens.test.ts src/lib/server/attachments.test.ts src/lib/server/auth.test.ts src/lib/server/cloudflare-inbound.test.ts src/lib/server/email-address.test.ts src/lib/server/email-provider.test.ts src/lib/server/forward.test.ts src/lib/server/mail-store.test.ts src/lib/server/outbox.test.ts src/lib/server/push-notifications.test.ts src/lib/server/threads.test.ts cli/client.test.ts"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20260601.1",

--- a/src/lib/components/MailboxLiveSync.svelte
+++ b/src/lib/components/MailboxLiveSync.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { startMailboxLiveSync } from '$lib/mail/live';
+
+	$effect(() => startMailboxLiveSync(invalidateAll));
+</script>

--- a/src/lib/components/MailboxView.svelte
+++ b/src/lib/components/MailboxView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page as currentPage } from '$app/stores';
 	import Icon from './Icon.svelte';
@@ -63,10 +64,10 @@
 	let pressY = 0;
 
 	$effect(() => {
-		items = mailbox.threads;
-		selected = [];
-		selecting = false;
-		hadSelection = false;
+		const next = mailbox.threads;
+		items = next;
+		const ids = new Set(next.map((thread) => thread.thread_id));
+		selected = untrack(() => selected).filter((id) => ids.has(id));
 	});
 
 	$effect(() => {

--- a/src/lib/mail/live.ts
+++ b/src/lib/mail/live.ts
@@ -1,0 +1,172 @@
+import {
+	isMailChangedMessage,
+	MAIL_CHANGED_MESSAGE,
+	MAILBOX_SYNC_RETRY_MS,
+	mailboxSyncUrl,
+	readMailboxCursor,
+	shouldRefreshMailbox,
+	waitForAbortable
+} from './sync';
+
+type CursorFetch =
+	| { kind: 'ok'; cursor: string }
+	| { kind: 'retry' }
+	| { kind: 'stop' };
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException
+		? error.name === 'AbortError'
+		: error instanceof Error && error.name === 'AbortError';
+}
+
+async function fetchMailboxCursor(
+	cursor: string | null,
+	signal: AbortSignal
+): Promise<CursorFetch> {
+	const response = await fetch(mailboxSyncUrl(cursor), {
+		signal,
+		credentials: 'same-origin',
+		cache: 'no-store',
+		headers: { Accept: 'application/json' }
+	});
+
+	if (response.status === 401 || response.status === 403) return { kind: 'stop' };
+	if (!response.ok) return { kind: 'retry' };
+
+	const next = readMailboxCursor(await response.json());
+	return next ? { kind: 'ok', cursor: next } : { kind: 'retry' };
+}
+
+function waitUntilVisible(signal: AbortSignal): Promise<void> {
+	return new Promise((resolve, reject) => {
+		if (signal.aborted) {
+			reject(new DOMException('Aborted', 'AbortError'));
+			return;
+		}
+		if (document.visibilityState === 'visible') {
+			resolve();
+			return;
+		}
+
+		const onAbort = () => {
+			cleanup();
+			reject(new DOMException('Aborted', 'AbortError'));
+		};
+		const onVisibility = () => {
+			if (document.visibilityState !== 'visible') return;
+			cleanup();
+			resolve();
+		};
+		const cleanup = () => {
+			signal.removeEventListener('abort', onAbort);
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
+
+		signal.addEventListener('abort', onAbort);
+		document.addEventListener('visibilitychange', onVisibility);
+	});
+}
+
+/**
+ * Keep the open mailbox in sync with inbound delivery. Long-polls a cursor,
+ * pauses in background tabs, and wakes immediately on a push message.
+ */
+export function startMailboxLiveSync(invalidate: () => Promise<void>): () => void {
+	if (typeof document === 'undefined') return () => {};
+
+	const lifecycle = new AbortController();
+	let poll: AbortController | null = null;
+
+	const stopPoll = () => {
+		poll?.abort();
+		poll = null;
+	};
+
+	const run = async () => {
+		let cursor: string | null = null;
+
+		while (!lifecycle.signal.aborted) {
+			if (document.visibilityState !== 'visible') {
+				try {
+					await waitUntilVisible(lifecycle.signal);
+				} catch (error) {
+					if (isAbortError(error)) return;
+					throw error;
+				}
+				continue;
+			}
+
+			poll = new AbortController();
+			const onLifecycleAbort = () => poll?.abort();
+			lifecycle.signal.addEventListener('abort', onLifecycleAbort);
+
+			try {
+				const result = await fetchMailboxCursor(cursor, poll.signal);
+				switch (result.kind) {
+					case 'ok':
+						if (shouldRefreshMailbox(cursor, result.cursor)) {
+							cursor = result.cursor;
+							await invalidate();
+							window.dispatchEvent(new Event(MAIL_CHANGED_MESSAGE));
+						} else {
+							cursor = result.cursor;
+						}
+						break;
+					case 'retry':
+						await waitForAbortable(MAILBOX_SYNC_RETRY_MS, poll.signal);
+						break;
+					case 'stop':
+						await new Promise<void>((resolve) => {
+							if (lifecycle.signal.aborted) {
+								resolve();
+								return;
+							}
+							lifecycle.signal.addEventListener('abort', () => resolve(), { once: true });
+						});
+						return;
+					default: {
+						const _never: never = result;
+						return _never;
+					}
+				}
+			} catch (error) {
+				if (lifecycle.signal.aborted) return;
+				if (!isAbortError(error)) {
+					await waitForAbortable(MAILBOX_SYNC_RETRY_MS, lifecycle.signal);
+				}
+			} finally {
+				lifecycle.signal.removeEventListener('abort', onLifecycleAbort);
+				poll = null;
+			}
+		}
+	};
+
+	const wake = () => {
+		stopPoll();
+	};
+
+	const onPageShow = (event: PageTransitionEvent) => {
+		if (event.persisted) wake();
+	};
+
+	document.addEventListener('visibilitychange', wake);
+	window.addEventListener('online', wake);
+	window.addEventListener('pageshow', onPageShow);
+
+	const onMessage = (event: MessageEvent) => {
+		if (!isMailChangedMessage(event.data)) return;
+		stopPoll();
+	};
+	navigator.serviceWorker?.addEventListener('message', onMessage);
+
+	void run();
+
+	return () => {
+		lifecycle.abort();
+		stopPoll();
+		document.removeEventListener('visibilitychange', wake);
+		window.removeEventListener('online', wake);
+		window.removeEventListener('pageshow', onPageShow);
+		navigator.serviceWorker?.removeEventListener('message', onMessage);
+	};
+}

--- a/src/lib/mail/sync.test.ts
+++ b/src/lib/mail/sync.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	isMailChangedMessage,
+	MAIL_CHANGED_MESSAGE,
+	MAILBOX_SYNC_PATH,
+	mailboxSyncUrl,
+	readMailboxCursor,
+	shouldRefreshMailbox,
+	waitForAbortable
+} from './sync';
+
+test('mailbox sync URLs carry the cursor only after the first snapshot', () => {
+	assert.equal(mailboxSyncUrl(null), MAILBOX_SYNC_PATH);
+	assert.equal(mailboxSyncUrl('9:41'), `${MAILBOX_SYNC_PATH}?cursor=9%3A41`);
+});
+
+test('the first cursor snapshot does not refresh, later changes do', () => {
+	assert.equal(shouldRefreshMailbox(null, '0:0'), false);
+	assert.equal(shouldRefreshMailbox('1:10', '1:10'), false);
+	assert.equal(shouldRefreshMailbox('1:10', '2:11'), true);
+});
+
+test('cursor payloads must be non-empty strings', () => {
+	assert.equal(readMailboxCursor({ cursor: '2:11' }), '2:11');
+	assert.equal(readMailboxCursor({ cursor: '' }), null);
+	assert.equal(readMailboxCursor({ cursor: 2 }), null);
+	assert.equal(readMailboxCursor(null), null);
+});
+
+test('open tabs wake on the push worker mail-changed message', () => {
+	assert.equal(isMailChangedMessage({ type: MAIL_CHANGED_MESSAGE }), true);
+	assert.equal(isMailChangedMessage({ type: 'push' }), false);
+	assert.equal(isMailChangedMessage('mail:changed'), false);
+});
+
+test('abortable waits resolve early when the signal fires', async () => {
+	const controller = new AbortController();
+	const started = Date.now();
+	queueMicrotask(() => controller.abort());
+	assert.equal(await waitForAbortable(5_000, controller.signal), false);
+	assert.ok(Date.now() - started < 1_000);
+	assert.equal(await waitForAbortable(1, new AbortController().signal), true);
+});

--- a/src/lib/mail/sync.ts
+++ b/src/lib/mail/sync.ts
@@ -1,0 +1,46 @@
+export const MAIL_CHANGED_MESSAGE = 'mail:changed';
+export const MAILBOX_SYNC_PATH = '/api/mail/sync';
+/** Stay under the Workers HTTP wall-clock limit so the hold can finish cleanly. */
+export const MAILBOX_SYNC_HOLD_MS = 20_000;
+export const MAILBOX_SYNC_TICK_MS = 1_000;
+export const MAILBOX_SYNC_RETRY_MS = 2_000;
+
+export function mailboxSyncUrl(cursor: string | null): string {
+	if (!cursor) return MAILBOX_SYNC_PATH;
+	return `${MAILBOX_SYNC_PATH}?cursor=${encodeURIComponent(cursor)}`;
+}
+
+export function readMailboxCursor(body: unknown): string | null {
+	if (typeof body !== 'object' || body === null) return null;
+	const cursor = (body as { cursor?: unknown }).cursor;
+	return typeof cursor === 'string' && cursor.length > 0 ? cursor : null;
+}
+
+export function shouldRefreshMailbox(previous: string | null, next: string): boolean {
+	return previous !== null && previous !== next;
+}
+
+export function isMailChangedMessage(data: unknown): boolean {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		(data as { type?: unknown }).type === MAIL_CHANGED_MESSAGE
+	);
+}
+
+/** Resolves false when the wait was aborted, so callers can stop without throwing. */
+export async function waitForAbortable(ms: number, signal: AbortSignal): Promise<boolean> {
+	if (signal.aborted) return false;
+	await new Promise<void>((resolve) => {
+		const timer = setTimeout(() => {
+			signal.removeEventListener('abort', onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		signal.addEventListener('abort', onAbort, { once: true });
+	});
+	return !signal.aborted;
+}

--- a/src/lib/mobile.test.ts
+++ b/src/lib/mobile.test.ts
@@ -129,7 +129,20 @@ test('service worker is a classic worker, not a Vite module', () => {
 	const source = readFileSync(join(root, 'src/service-worker.ts'), 'utf8');
 	assert.match(source, /addEventListener\('install'/);
 	assert.match(source, /addEventListener\('push'/);
+	assert.match(source, /postMessage/);
+	assert.match(source, /mail:changed/);
 	assert.doesNotMatch(source, /import\s+['"]\/@fs/);
+});
+
+test('signed-in shell refreshes the mailbox without a manual reload', () => {
+	const layout = readFileSync(join(root, 'src/routes/+layout.svelte'), 'utf8');
+	assert.match(layout, /MailboxLiveSync/);
+	const live = readFileSync(join(root, 'src/lib/mail/live.ts'), 'utf8');
+	assert.match(live, /mailboxSyncUrl/);
+	assert.match(live, /startMailboxLiveSync/);
+	assert.match(live, /MAIL_CHANGED_MESSAGE/);
+	const sync = readFileSync(join(root, 'src/lib/mail/sync.ts'), 'utf8');
+	assert.match(sync, /\/api\/mail\/sync/);
 });
 
 test('PWA manifest is standalone and points at real icons', () => {

--- a/src/lib/server/api-access.test.ts
+++ b/src/lib/server/api-access.test.ts
@@ -62,6 +62,24 @@ describe('API key access', () => {
 	test('a read key can list and open threads', () => {
 		assert.deepEqual(
 			authorizeApiRequest({
+				pathname: '/api/mail/sync',
+				method: 'GET',
+				authMethod: 'api_token',
+				scopes: ['mail:read']
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
+				pathname: '/api/mail/sync',
+				method: 'GET',
+				authMethod: 'mobile_session',
+				scopes: []
+			}),
+			{ ok: true }
+		);
+		assert.deepEqual(
+			authorizeApiRequest({
 				pathname: '/api/mail',
 				method: 'GET',
 				authMethod: 'api_token',

--- a/src/lib/server/api-access.ts
+++ b/src/lib/server/api-access.ts
@@ -27,6 +27,11 @@ const BEARER_ROUTES: RouteRule[] = [
 		scopes: ['mail:read']
 	},
 	{
+		method: 'GET',
+		match: (pathname) => pathname === '/api/mail/sync',
+		scopes: ['mail:read']
+	},
+	{
 		method: 'POST',
 		match: (pathname) => pathname === '/api/mail',
 		scopes: ['mail:send']
@@ -132,6 +137,7 @@ const MOBILE_SESSION_ROUTES: Array<Pick<RouteRule, 'method' | 'match'>> = [
 	{ method: 'GET', match: (pathname) => pathname === '/api/auth/me' },
 	{ method: 'DELETE', match: (pathname) => pathname === '/api/auth/session' },
 	{ method: 'GET', match: (pathname) => pathname === '/api/mail' },
+	{ method: 'GET', match: (pathname) => pathname === '/api/mail/sync' },
 	{ method: 'POST', match: (pathname) => pathname === '/api/mail' },
 	{ method: 'POST', match: (pathname) => pathname === '/api/mail/actions' },
 	{

--- a/src/lib/server/mail-store.test.ts
+++ b/src/lib/server/mail-store.test.ts
@@ -3,7 +3,11 @@ import { describe, test } from 'node:test';
 import type { D1Database } from '@cloudflare/workers-types';
 import type { EmailRow } from '$lib/types';
 import { buildThreadParticipants } from './thread-participants';
-import { listForwardThreadMessages } from './mail-store';
+import {
+	encodeMailboxCursor,
+	getMailboxCursor,
+	listForwardThreadMessages
+} from './mail-store';
 
 describe('thread participants', () => {
 	test('supplies a real inbound display name', () => {
@@ -130,4 +134,32 @@ test('forward-thread lookup rejects cross-user messages and returns the owned th
 		['older', 'newer']
 	);
 	assert.deepEqual(await listForwardThreadMessages(db, 'user-3', 'thread-1'), []);
+});
+
+test('mailbox cursor is a count plus latest rowid and can scope to a domain', async () => {
+	const binds: unknown[][] = [];
+	const db = {
+		prepare(sql: string) {
+			assert.match(sql, /COUNT\(\*\)/);
+			assert.match(sql, /MAX\(rowid\)/);
+			return {
+				bind(...values: unknown[]) {
+					binds.push(values);
+					return {
+						async first() {
+							return {
+								message_count: values.length === 2 ? 4 : 9,
+								latest_rowid: 41
+							};
+						}
+					};
+				}
+			};
+		}
+	} as unknown as D1Database;
+
+	assert.equal(encodeMailboxCursor(0, 0), '0:0');
+	assert.equal(await getMailboxCursor(db, 'user-1'), '9:41');
+	assert.equal(await getMailboxCursor(db, 'user-1', 'domain-9'), '4:41');
+	assert.deepEqual(binds, [['user-1'], ['user-1', 'domain-9']]);
 });

--- a/src/lib/server/mail-store.ts
+++ b/src/lib/server/mail-store.ts
@@ -432,6 +432,38 @@ export async function listEmails(
 }
 
 /**
+ * Cheap "has anything been inserted or deleted?" fingerprint. Flag changes
+ * (read, star, archive) do not move this, so a live poll can refresh on new
+ * mail without fighting the user's current selection.
+ */
+export function encodeMailboxCursor(messageCount: number, latestRowid: number): string {
+	return `${messageCount}:${latestRowid}`;
+}
+
+export async function getMailboxCursor(
+	db: D1Database,
+	userId: string,
+	domainId?: string | null
+): Promise<string> {
+	const bindings: unknown[] = [userId];
+	let scope = 'user_id = ?';
+	if (domainId) {
+		scope += ' AND domain_id = ?';
+		bindings.push(domainId);
+	}
+
+	const row = await db
+		.prepare(
+			`SELECT COUNT(*) AS message_count, COALESCE(MAX(rowid), 0) AS latest_rowid
+			 FROM emails WHERE ${scope}`
+		)
+		.bind(...bindings)
+		.first<{ message_count: number | string | null; latest_rowid: number | string | null }>();
+
+	return encodeMailboxCursor(Number(row?.message_count ?? 0), Number(row?.latest_rowid ?? 0));
+}
+
+/**
  * Row counts behind every sidebar entry, in one round trip. Counted in
  * conversations so the badges agree with what the lists actually show.
  */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 	import { persistUiTheme } from '$lib/ui-theme/apply';
 	import { persistLocale } from '$lib/i18n';
 	import { getTheme } from '$lib/ui-theme/registry';
+	import MailboxLiveSync from '$lib/components/MailboxLiveSync.svelte';
 	import type { ThemeShellData } from '$lib/ui-theme/types';
 	import type { LayoutData } from './$types';
 
@@ -86,6 +87,7 @@
 </svelte:head>
 
 {#if showShell && shellData}
+	<MailboxLiveSync />
 	<ThemeShell data={shellData}>
 		{@render children()}
 	</ThemeShell>

--- a/src/routes/api/mail/sync/+server.ts
+++ b/src/routes/api/mail/sync/+server.ts
@@ -1,0 +1,34 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { getMailboxCursor } from '$lib/server/mail-store';
+import { MAILBOX_SYNC_HOLD_MS, MAILBOX_SYNC_TICK_MS, waitForAbortable } from '$lib/mail/sync';
+
+/**
+ * Long-poll for mailbox inserts/deletes. The inbound webhook and this request
+ * run on different Worker isolates, so we watch D1 instead of pushing from
+ * the receive path.
+ */
+export const GET: RequestHandler = async ({ locals, platform, url, request }) => {
+	const db = platform?.env.DB;
+	if (!db || !locals.user) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const held = url.searchParams.get('cursor');
+	let cursor = await getMailboxCursor(db, locals.user.id, locals.activeDomainId);
+	const deadline = Date.now() + MAILBOX_SYNC_HOLD_MS;
+
+	while (held && cursor === held && Date.now() < deadline) {
+		const stillOpen = await waitForAbortable(MAILBOX_SYNC_TICK_MS, request.signal);
+		if (!stillOpen) break;
+		cursor = await getMailboxCursor(db, locals.user.id, locals.activeDomainId);
+	}
+
+	return json(
+		{ cursor },
+		{
+			headers: {
+				'Cache-Control': 'no-store'
+			}
+		}
+	);
+};

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -25,6 +25,13 @@ function stringValue(value: unknown, fallback: string): string {
 	return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
+async function notifyOpenClients(): Promise<void> {
+	const windows = await worker.clients.matchAll({ type: 'window', includeUncontrolled: true });
+	for (const client of windows) {
+		client.postMessage({ type: 'mail:changed' });
+	}
+}
+
 function readPushPayload(event: PushEvent): PushPayload {
 	if (!event.data) return {};
 	try {
@@ -61,6 +68,7 @@ worker.addEventListener('push', (event: PushEvent) => {
 	event.waitUntil(
 		(async () => {
 			if (!(await currentAccountOwnsSubscription())) return;
+			await notifyOpenClients();
 			await worker.registration.showNotification(stringValue(payload.title, 'New message'), {
 				body: stringValue(payload.body, 'You received a new email.'),
 				icon: '/icons/icon-192.png',

--- a/src/themes/zero/mail/Mailbox.svelte
+++ b/src/themes/zero/mail/Mailbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { formatRelativeDate } from '$lib/utils/date';
@@ -27,7 +28,10 @@
 	let viewsOpen = $state(false);
 
 	$effect(() => {
-		items = mailbox.threads;
+		const next = mailbox.threads;
+		items = next;
+		const ids = new Set(next.map((thread) => thread.thread_id));
+		selected = untrack(() => selected).filter((id) => ids.has(id));
 	});
 
 	$effect(() => {

--- a/src/themes/zero/mail/ThreadPane.svelte
+++ b/src/themes/zero/mail/ThreadPane.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { page } from '$app/stores';
 	import { invalidateAll } from '$app/navigation';
 	import EmailBody from '$lib/components/EmailBody.svelte';
@@ -8,6 +9,7 @@
 	import { formatMailDate, formatMailTime, shouldShowSeparateTime } from '$lib/utils/date';
 	import { attachmentHref } from '$lib/utils/attachments';
 	import { runMailAction } from '$lib/mail/client';
+	import { MAIL_CHANGED_MESSAGE } from '$lib/mail/sync';
 	import { initials, parseAddressList, type AddressPart } from '$lib/mail/folders';
 	import { t } from '$lib/i18n';
 	import type { MailAddress, MailboxView, OutboundAttachmentInput, ThreadMessage } from '$lib/types';
@@ -82,28 +84,47 @@
 		replyOpen = false;
 		detailsFor = null;
 		menuFor = null;
-		void fetch(`/api/mail/${current}`)
-			.then(async (response) => {
-				const body = (await response.json()) as ThreadPayload & { error?: string };
-				if (cancelled) return;
-				if (!response.ok) {
-					error = body.error ?? t('thread.couldNotLoad');
-					thread = null;
-					return;
-				}
-				thread = body;
-				const last = body.messages[body.messages.length - 1];
-				opened = new Set(last ? [last.id] : []);
-				onRead?.(body.threadId);
-			})
-			.catch(() => {
-				if (!cancelled) error = t('common.networkError');
-			})
-			.finally(() => {
-				if (!cancelled) loading = false;
-			});
+
+		const load = (resetUi: boolean) => {
+			if (resetUi) loading = true;
+			return fetch(`/api/mail/${current}`)
+				.then(async (response) => {
+					const body = (await response.json()) as ThreadPayload & { error?: string };
+					if (cancelled) return;
+					if (!response.ok) {
+						if (resetUi) {
+							error = body.error ?? t('thread.couldNotLoad');
+							thread = null;
+						}
+						return;
+					}
+					thread = body;
+					const last = body.messages[body.messages.length - 1];
+					if (resetUi) {
+						opened = new Set(last ? [last.id] : []);
+					} else if (last) {
+						opened = new Set([...untrack(() => opened), last.id]);
+					}
+					onRead?.(body.threadId);
+				})
+				.catch(() => {
+					if (!cancelled && resetUi) error = t('common.networkError');
+				})
+				.finally(() => {
+					if (!cancelled) loading = false;
+				});
+		};
+
+		void load(true);
+
+		const onMailChanged = () => {
+			void load(false);
+		};
+		window.addEventListener(MAIL_CHANGED_MESSAGE, onMailChanged);
+
 		return () => {
 			cancelled = true;
+			window.removeEventListener(MAIL_CHANGED_MESSAGE, onMailChanged);
 		};
 	});
 


### PR DESCRIPTION
## Summary
- Keep an open mailbox in sync with inbound delivery so new messages appear without clicking refresh.
- Long-poll a cheap mailbox cursor, pause in background tabs, and wake immediately from web push when a tab is already open.
- Refresh an open conversation when a reply arrives without clearing a reply in progress.

## Test plan
- [ ] Sign in, leave the inbox open, send yourself a message, and confirm it appears without clicking refresh.
- [ ] Open a conversation, send a reply to that thread, and confirm the new message shows up without losing composer state.
- [ ] Background the tab, then return, and confirm it catches up.
- [ ] Confirm the refresh control still works as a fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mailboxes now update automatically when new messages arrive or existing messages change.
  - Updates pause when the tab is hidden and resume when it becomes active or reconnects.
  - Open threads refresh in the background without resetting the current view or opened messages.
  - Push notifications can refresh active mailbox and thread views immediately.

- **Bug Fixes**
  - Selected threads remain selected when mailbox contents refresh, unless they are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->